### PR TITLE
(fix): fix values response mask in dp critic.

### DIFF
--- a/verl/trainer/ppo/critic/dp_critic.py
+++ b/verl/trainer/ppo/critic/dp_critic.py
@@ -84,6 +84,10 @@ class DataParallelPPOCritic(BasePPOCritic):
                 values = self._forward_micro_batch(micro_batch)
             values_lst.append(values)
         values = torch.concat(values_lst, dim=0)
+        responses = data.batch['responses']
+        attention_mask = data.batch['attention_mask']
+        response_length = responses.size(1)
+        values = values * attention_mask[:, -response_length - 1:-1]
         return values
 
     def update_critic(self, data: DataProto):


### PR DESCRIPTION
The values need to be multiplied by the response mask; otherwise, the calculation of adv later will be incorrect. This is similar to the approach used in megatron_critic:
https://github.com/PanAndy/verl/blob/681dc00b78b90cda4288535ca9a6c1ec7a4b7c98/verl/trainer/ppo/critic/megatron_critic.py#L92