### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This makes the project PEP 517 compliant (see https://packaging.python.org/en/latest/guides/modernize-setup-py-project/) which is generally seen as good practice (e.g. it adds build isolation for pip install and makes it more compatible with other package managers).