### PR TITLE
Support Mlflow, allow forward to have different batch size, compute more metrics

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -90,7 +90,7 @@ critic:
         min_num_params: 0
   ppo_mini_batch_size: ${actor_rollout_ref.actor.ppo_mini_batch_size}
   ppo_micro_batch_size: 64
-  log_prob_micro_batch_size: ${critic.ppo_micro_batch_size}
+  forward_micro_batch_size: ${critic.ppo_micro_batch_size}
   ppo_epochs: ${actor_rollout_ref.actor.ppo_epochs}
   shuffle: ${actor_rollout_ref.actor.shuffle}
   grad_clip: 1.0

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -15,7 +15,7 @@ actor_rollout_ref:
   model:
     path: ~/models/deepseek-llm-7b-chat
     external_lib: null
-    override_config: {}
+    override_config: { }
     enable_gradient_checkpointing: False
   actor:
     strategy: fsdp  # This is for backward-compatibility
@@ -78,7 +78,7 @@ critic:
   model:
     path: ~/models/deepseek-llm-7b-chat
     tokenizer_path: ${actor_rollout_ref.model.path}
-    override_config: {}
+    override_config: { }
     external_lib: ${actor_rollout_ref.model.external_lib}
     enable_gradient_checkpointing: False
     fsdp_config:
@@ -90,6 +90,7 @@ critic:
         min_num_params: 0
   ppo_mini_batch_size: ${actor_rollout_ref.actor.ppo_mini_batch_size}
   ppo_micro_batch_size: 64
+  log_prob_micro_batch_size: ${critic.ppo_micro_batch_size}
   ppo_epochs: ${actor_rollout_ref.actor.ppo_epochs}
   shuffle: ${actor_rollout_ref.actor.shuffle}
   grad_clip: 1.0
@@ -121,7 +122,7 @@ trainer:
   total_epochs: 30
   project_name: verl_examples
   experiment_name: gsm8k
-  logger: ['console', 'wandb']
+  logger: [ 'console', 'wandb' ]
   nnodes: 1
   n_gpus_per_node: 8
   save_freq: -1

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -225,6 +225,13 @@ def compute_timing_metrics(batch, timing_raw):
     }
 
 
+@contextmanager
+def _timer(name: str, timing_raw: Dict[str, float]):
+    with Timer(name=name, logger=None) as timer:
+        yield
+    timing_raw[name] = timer.last
+
+
 class RayPPOTrainer(object):
     """
     Note that this trainer runs on the driver process on a single CPU/GPU node.
@@ -567,10 +574,3 @@ class RayPPOTrainer(object):
             val_metrics = self._validate()
             pprint(f'Final validation metrics: {val_metrics}')
             logger.log(data=val_metrics, step=global_steps)
-
-
-@contextmanager
-def _timer(name: str, timing_raw: Dict[str, float]):
-    with Timer(name=name, logger=None) as timer:
-        yield
-    timing_raw[name] = timer.last

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -217,8 +217,8 @@ def compute_timing_metrics(batch, timing_raw):
 
     return {
         **{f'timing/{name}': value for name, value in timing_raw.items()},
-        **{f'timing_per_token/{name}': timing_raw[name] / num_tokens
-           for name, num_tokens in num_tokens_of_section.items()},
+        **{f'timing_per_token/{name}': timing_raw[name] / num_tokens_of_section[name]
+           for name in set(num_tokens_of_section.keys()) & set(timing_raw.keys())},
     }
 
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -205,10 +205,20 @@ def compute_timing_metrics(batch, timing_raw):
     response_info = _compute_response_info(batch)
     num_prompt_tokens = torch.sum(response_info['prompt_length']).item()
     num_response_tokens = torch.sum(response_info['response_length']).item()
+    num_overall_tokens = num_prompt_tokens + num_response_tokens
+
+    num_tokens_of_section = {
+        'gen': num_response_tokens,
+        'ref': num_overall_tokens,
+        'values': num_overall_tokens,
+        'critic': num_overall_tokens,
+        'actor': num_overall_tokens,
+    }
 
     return {
         **{f'timing/{name}': value for name, value in timing_raw.items()},
-        f'timing_per_token/{name}': TODO,
+        **{f'timing_per_token/{name}': timing_raw[name] / num_tokens
+           for name, num_tokens in num_tokens_of_section.items()},
     }
 
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -209,10 +209,7 @@ def compute_timing_metrics(batch, timing_raw):
 
     num_tokens_of_section = {
         'gen': num_response_tokens,
-        'ref': num_overall_tokens,
-        'values': num_overall_tokens,
-        'critic': num_overall_tokens,
-        'actor': num_overall_tokens,
+        **{name: num_overall_tokens for name in ['ref', 'values', 'adv', 'update_critic', 'update_actor']},
     }
 
     return {

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -570,4 +570,4 @@ class RayPPOTrainer(object):
 def _timer(name: str, timing_raw: Dict[str, float]):
     with Timer(name=name, logger=None) as timer:
         yield
-    timing_raw[f'timing/{name}'] = timer.last
+    timing_raw[name] = timer.last

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -209,13 +209,19 @@ def compute_timing_metrics(batch, timing_raw):
 
     num_tokens_of_section = {
         'gen': num_response_tokens,
-        **{name: num_overall_tokens for name in ['ref', 'values', 'adv', 'update_critic', 'update_actor']},
+        **{
+            name: num_overall_tokens for name in ['ref', 'values', 'adv', 'update_critic', 'update_actor']
+        },
     }
 
     return {
-        **{f'timing/{name}': value for name, value in timing_raw.items()},
-        **{f'timing_per_token/{name}': timing_raw[name] / num_tokens_of_section[name]
-           for name in set(num_tokens_of_section.keys()) & set(timing_raw.keys())},
+        **{
+            f'timing/{name}': value for name, value in timing_raw.items()
+        },
+        **{
+            f'timing_per_token/{name}': timing_raw[name] / num_tokens_of_section[name] for name in set(num_tokens_of_section.keys(
+            )) & set(timing_raw.keys())
+        },
     }
 
 

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -14,8 +14,11 @@
 """
 A unified tracking interface that supports logging data to different backend
 """
-
-from typing import List, Union
+import dataclasses
+from enum import Enum
+from functools import partial
+from pathlib import Path
+from typing import List, Union, Dict, Any
 
 
 class Tracking(object):
@@ -41,7 +44,7 @@ class Tracking(object):
         if 'mlflow' in default_backend:
             import mlflow
             mlflow.start_run()
-            mlflow.log_params(_convert_config_to_mlflow(config))
+            mlflow.log_params(_compute_mlflow_params_from_objects(config))
             self.logger['mlflow'] = _MlflowLoggingAdapter()
 
         if 'console' in default_backend:
@@ -59,3 +62,37 @@ class _MlflowLoggingAdapter:
     def log(self, data, step):
         import mlflow
         mlflow.log_metrics(metrics=data, step=step)
+
+
+def _compute_mlflow_params_from_objects(params) -> Dict[str, Any]:
+    if params is None:
+        return {}
+
+    return _flatten_dict(_transform_params_to_json_serializable(params, convert_list_to_dict=True), sep='/')
+
+
+def _transform_params_to_json_serializable(x, convert_list_to_dict: bool):
+    _transform = partial(_transform_params_to_json_serializable, convert_list_to_dict=convert_list_to_dict)
+
+    if dataclasses.is_dataclass(x):
+        return _transform(dataclasses.asdict(x))
+    if isinstance(x, dict):
+        return {k: _transform(v) for k, v in x.items()}
+    if isinstance(x, list):
+        if convert_list_to_dict:
+            return {'list_len': len(x)} | {f'{i}': _transform(v) for i, v in enumerate(x)}
+        else:
+            return [_transform(v) for v in x]
+    if isinstance(x, Path):
+        return str(x)
+    if isinstance(x, Enum):
+        return x.value
+
+    return x
+
+
+def _flatten_dict(raw: Dict[str, Any], *, sep: str) -> Dict[str, Any]:
+    import pandas as pd
+    ans = pd.json_normalize(raw, sep=sep).to_dict(orient='records')[0]
+    assert isinstance(ans, dict)
+    return ans

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -59,6 +59,7 @@ class Tracking(object):
 
 
 class _MlflowLoggingAdapter:
+
     def log(self, data, step):
         import mlflow
         mlflow.log_metrics(metrics=data, step=step)

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -43,7 +43,7 @@ class Tracking(object):
 
         if 'mlflow' in default_backend:
             import mlflow
-            mlflow.start_run()
+            mlflow.start_run(run_name=experiment_name)
             mlflow.log_params(_compute_mlflow_params_from_objects(config))
             self.logger['mlflow'] = _MlflowLoggingAdapter()
 

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -40,8 +40,9 @@ class Tracking(object):
 
         if 'mlflow' in default_backend:
             import mlflow
-            TODO
-            self.logger['mlflow'] = mlflow
+            mlflow.start_run()
+            mlflow.log_params(_convert_config_to_mlflow(config))
+            self.logger['mlflow'] = _MlflowLoggingAdapter()
 
         if 'console' in default_backend:
             from verl.utils.logger.aggregate_logger import LocalLogger
@@ -52,3 +53,9 @@ class Tracking(object):
         for default_backend, logger_instance in self.logger.items():
             if backend is None or default_backend in backend:
                 logger_instance.log(data=data, step=step)
+
+
+class _MlflowLoggingAdapter:
+    def log(self, data, step):
+        import mlflow
+        mlflow.log_metrics(metrics=data, step=step)

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -19,7 +19,7 @@ from typing import List, Union
 
 
 class Tracking(object):
-    supported_backend = ['wandb', 'console']
+    supported_backend = ['wandb', 'mlflow', 'console']
 
     def __init__(self, project_name, experiment_name, default_backend: Union[str, List[str]] = 'console', config=None):
         if isinstance(default_backend, str):
@@ -37,6 +37,11 @@ class Tracking(object):
             import wandb
             wandb.init(project=project_name, name=experiment_name, config=config)
             self.logger['wandb'] = wandb
+
+        if 'mlflow' in default_backend:
+            import mlflow
+            TODO
+            self.logger['mlflow'] = mlflow
 
         if 'console' in default_backend:
             from verl.utils.logger.aggregate_logger import LocalLogger

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -15,26 +15,26 @@
 The main entry point to run the PPO algorithm
 """
 
-import os
 import logging
+import os
 import warnings
-import ray
+
 import torch
 import torch.distributed
-from omegaconf import DictConfig, open_dict
-
+import verl.utils.hdfs_io as hdfs_io
+import verl.utils.torch_functional as verl_F
+from omegaconf import DictConfig
+from verl import DataProto
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import register, Dispatch
-import verl.utils.torch_functional as verl_F
-from verl import DataProto
-from verl.utils.model import compute_position_id_with_mask
-from verl.utils.fs import copy_local_path_from_hdfs
-from verl.utils.fsdp_utils import get_fsdp_wrap_policy, load_fsdp_grad, offload_fsdp_grad, init_fn, get_init_weight_context_manager
-from verl.utils.fsdp_utils import offload_fsdp_optimizer, offload_fsdp_param_and_grad, load_fsdp_optimizer, load_fsdp_param_and_grad
-from verl.utils.import_utils import import_external_libs
-from verl.utils.debug import log_gpu_memory_usage
-import verl.utils.hdfs_io as hdfs_io
 from verl.utils import hf_tokenizer
+from verl.utils.debug import log_gpu_memory_usage
+from verl.utils.fs import copy_local_path_from_hdfs
+from verl.utils.fsdp_utils import get_fsdp_wrap_policy, offload_fsdp_grad, init_fn, get_init_weight_context_manager
+from verl.utils.fsdp_utils import offload_fsdp_optimizer, offload_fsdp_param_and_grad, load_fsdp_optimizer, \
+    load_fsdp_param_and_grad
+from verl.utils.import_utils import import_external_libs
+from verl.utils.model import compute_position_id_with_mask
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv('VERL_PPO_LOGGING_LEVEL', 'WARN'))
@@ -95,9 +95,8 @@ class ActorRolloutRefWorker(Worker):
                                trust_remote_code=False):
         from verl.utils.model import print_model_size, update_model_config
         from verl.utils.torch_dtypes import PrecisionType
-        from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy, MixedPrecision, \
-            CPUOffload
+        from transformers import AutoModelForCausalLM, AutoConfig
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy, MixedPrecision
         from torch import optim
 
         log_gpu_memory_usage('Before init from HF AutoModel', logger=logger)
@@ -322,7 +321,7 @@ class ActorRolloutRefWorker(Worker):
 
         self.actor_lr_scheduler.step()
         lr = self.actor_lr_scheduler.get_last_lr()[0]
-        metrics['actor/lr(1e-4)'] = lr * 1e4
+        metrics['actor/lr'] = lr
 
         log_gpu_memory_usage('After update policy', logger=logger)
 
@@ -453,15 +452,13 @@ class CriticWorker(Worker):
         # the following line is necessary
         from verl.utils.model import LambdaLayer, print_model_size, squeeze
         from verl.utils.torch_dtypes import PrecisionType
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy, MixedPrecision, \
-            CPUOffload
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy, MixedPrecision
         from torch import optim
 
         local_path = copy_local_path_from_hdfs(config.model.path)
         # note that the tokenizer between actor and critic may be different. So override tokenizer info with actor info
         # using random initialized model from any architecture. May not be the same as Actor.
         # TODO: support loading critic weights from RM. Support using AutoModelForTokenClassification
-        from transformers import AutoTokenizer
 
         tokenizer_path = copy_local_path_from_hdfs(config.model.tokenizer_path)
         self.tokenizer = hf_tokenizer(tokenizer_path, trust_remote_code=config.model.get('trust_remote_code', False))
@@ -600,7 +597,7 @@ class CriticWorker(Worker):
 
         self.critic_lr_scheduler.step()
         lr = self.critic_lr_scheduler.get_last_lr()[0]
-        metrics['critic/lr(1e-4)'] = lr * 1e4
+        metrics['critic/lr'] = lr
 
         output = DataProto(batch=None, meta_info={'metrics': metrics})
         if self._is_offload_param:
@@ -656,7 +653,7 @@ class RewardModelWorker(Worker):
 
     def _build_model(self, config):
         # the following line is necessary
-        from transformers import AutoModelForSequenceClassification, AutoTokenizer, AutoConfig
+        from transformers import AutoModelForSequenceClassification, AutoConfig
         from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy, CPUOffload
 
         # download the checkpoint from hdfs

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -447,6 +447,7 @@ class CriticWorker(Worker):
         # normalize config
         self.config.ppo_mini_batch_size //= torch.distributed.get_world_size()
         self.config.ppo_micro_batch_size //= torch.distributed.get_world_size()
+        self.config.forward_micro_batch_size //= torch.distributed.get_world_size()
 
     def _build_critic_model_optimizer(self, config):
         # the following line is necessary
@@ -574,7 +575,7 @@ class CriticWorker(Worker):
             load_fsdp_param_and_grad(module=self.critic_module,
                                      device_id=torch.cuda.current_device(),
                                      load_grad=self._is_offload_grad)
-        micro_batch_size = self.config.ppo_micro_batch_size
+        micro_batch_size = self.config.forward_micro_batch_size
         data.meta_info['micro_batch_size'] = micro_batch_size
         values = self.critic.compute_values(data=data)
         output = DataProto.from_dict(tensors={'values': values})


### PR DESCRIPTION
Hi, this is a tiny PR to

* support mlflow in addition to existing wandb and console
* allow critic forward to have different batch size than critic update (if I understand correctly, usually forward can have larger one)
* expose more metrics, mainly the "timing per token"

Example outputs of mlflow:

![image](https://github.com/user-attachments/assets/dd2d9c77-58b4-4364-9903-9203b7300cf0)


Example outputs of the new metrics:

![image](https://github.com/user-attachments/assets/ebf49791-cc4e-49e6-9d3a-c08ea4010395)
