### PR TITLE
Support megatron 0.6 in veRL

### DIFF
--- a/verl/models/llama/megatron/checkpoint_utils/llama_loader.py
+++ b/verl/models/llama/megatron/checkpoint_utils/llama_loader.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+from packaging.version import Version
 import torch
 import time
 from typing import Dict, Any, Callable, Optional
 import torch.distributed as dist
 
+megatron_version = Version(importlib.metadata.version('megatron-core'))
 
 def _megatron_calc_layer_map(config):
     """Calculate the mapping of global layer_idx to local layer_idx
@@ -53,7 +56,11 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
     """
     import megatron
     from megatron.core import mpu
-    from megatron.utils import print_rank_0, unwrap_model
+    megatron_version = Version(importlib.metadata.version('megatron-core'))
+    if megatron_version < Version('0.6.0'):
+        from megatron.utils import print_rank_0, unwrap_model
+    else:
+        from megatron.training.utils import print_rank_0, unwrap_model
     from megatron.core.transformer.module import Float16Module
     from megatron.core import DistributedDataParallel as LocalDDP
     from torch.nn.parallel import DistributedDataParallel as torchDDP

--- a/verl/models/llama/megatron/checkpoint_utils/llama_saver.py
+++ b/verl/models/llama/megatron/checkpoint_utils/llama_saver.py
@@ -12,18 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import megatron
-from megatron.core import mpu
-from megatron.utils import print_rank_0, unwrap_model
-from megatron.model import Float16Module
-from megatron.model import DistributedDataParallel as LocalDDP
+import importlib
+from packaging.version import Version
 from torch.nn.parallel import DistributedDataParallel as torchDDP
 import torch
 import time
 from typing import Optional
 import torch.distributed as dist
-from megatron import get_args
 
+import megatron
+from megatron import get_args
+from megatron.core import mpu
+from megatron.model import Float16Module
+from megatron.model import DistributedDataParallel as LocalDDP
+
+megatron_version = Version(importlib.metadata.version('megatron-core'))
+if megatron_version < Version('0.6.0'):
+    from megatron.utils import print_rank_0, unwrap_model
+else:
+    from megatron.training.utils import print_rank_0, unwrap_model
 
 def _megatron_calc_global_rank(tp_rank: int = 0, dp_rank: int = 0, pp_rank: int = 0):
     """given TP,DP,PP rank to get the global rank."""

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Pretrain utilities."""
+import importlib
+from packaging.version import Version
 from typing import Any, Dict
 import time
 from omegaconf import DictConfig
@@ -216,7 +218,11 @@ class FakeTimers:
     """Disable All Megatron Timing with FakeTimers"""
 
     def __init__(self):
-        from megatron.timers import DummyTimer
+        megatron_version = Version(importlib.metadata.version('megatron-core'))
+        if megatron_version < Version('0.6.0'):
+            from megatron.timers import DummyTimer
+        else:
+            from megatron.core.timers import DummyTimer
         self.dummy_timer = DummyTimer()
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:

--- a/verl/utils/memory_buffer.py
+++ b/verl/utils/memory_buffer.py
@@ -15,7 +15,7 @@
 This file contains utilities to manipulate torch memory buffers
 """
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import torch
 from torch import nn
@@ -27,11 +27,14 @@ class MemoryBuffer:
     memory. It must have a unique type to support this behavior.
     """
 
-    def __init__(self, numel: int, numel_padded: int, dtype: torch.dtype):
+    def __init__(self, numel: int, numel_padded: int, dtype: torch.dtype, source: Optional[torch.Tensor] = None):
         self.numel = numel
         self.numel_padded = numel_padded
         self.dtype = dtype
-        self.data = torch.zeros(self.numel_padded, dtype=self.dtype, device='cuda', requires_grad=False)
+        if source is not None:
+            self.data = source
+        else:
+            self.data = torch.zeros(self.numel_padded, dtype=self.dtype, device='cuda', requires_grad=False)
 
     def zero(self):
         """Reset the buffer to zero."""

--- a/verl/workers/critic/megatron_critic.py
+++ b/verl/workers/critic/megatron_critic.py
@@ -15,7 +15,9 @@
 Implement a multiprocess PPOCritic
 """
 
+import importlib
 from functools import partial
+from packaging.version import Version
 from typing import Iterable
 
 import torch
@@ -33,9 +35,13 @@ from verl.utils.torch_functional import masked_mean, broadcast_dict_tensor, spli
 from verl.utils.megatron import sequence_parallel as sp_utils
 from verl.utils.megatron.optimizer_config import OptimizerConfig
 
-from megatron.optimizer import DistributedOptimizer
 from megatron.core import parallel_state as mpu
 from megatron.core.pipeline_parallel import get_forward_backward_func
+megatron_version = Version(importlib.metadata.version('megatron-core'))
+if megatron_version < Version('0.6.0'):
+    from megatron.optimizer import DistributedOptimizer
+else:
+    from megatron.core.optimizer import DistributedOptimizer
 
 
 class MegatronPPOCritic(BasePPOCritic):
@@ -209,12 +215,19 @@ class MegatronPPOCritic(BasePPOCritic):
             self.critic_optimizer.zero_grad()
             # use use_contiguous_buffers_in_local_ddp and no overlap_dp_param_comm
             for chunk in self.critic_module:
-                chunk.zero_grad_buffer(zero_buffer=(not self.critic_optimizer_config.use_distributed_optimizer))
+                if megatron_version < Version('0.6.0'):
+                    chunk.zero_grad_buffer(zero_buffer=(not self.critic_optimizer_config.use_distributed_optimizer))
+                else:
+                    chunk.zero_grad_buffer()
 
             metric_micro_batch = self.forward_backward_batch(data)
 
-            update_successful, grad_norm, num_zeros_in_grad = self.critic_optimizer.step(
-                self.megatron_config, self.megatron_config.timers)
+            if megatron_version < Version('0.6.0'):
+                update_successful, grad_norm, num_zeros_in_grad = self.critic_optimizer.step(
+                    self.megatron_config, self.megatron_config.timers)
+            else:
+                update_successful, grad_norm, num_zeros_in_grad = self.critic_optimizer.step()
+
             if update_successful:
                 # allgather already execute in optimizer.step in new megatron
                 pass

--- a/verl/workers/hybrid_engine/megatron_vllm.py
+++ b/verl/workers/hybrid_engine/megatron_vllm.py
@@ -143,7 +143,7 @@ class AllGatherPPModel:
                     dist.broadcast(tensor=memory_buffer.data, src=global_src, group=self.pp_group, async_op=False)
             else:
                 # a workaround for megatron >= 0.6.0
-                for _, param in sorted(self.pp_models[cur_pp_rank].named_paramters()):
+                for _, param in sorted(self.pp_models[cur_pp_rank].named_parameters()):
                     dist.broadcast(tensor=param.data, src=global_src, group=self.pp_group, async_op=False)
 
     def forward(self, *inputs, **kwargs):

--- a/verl/workers/hybrid_engine/megatron_vllm.py
+++ b/verl/workers/hybrid_engine/megatron_vllm.py
@@ -15,6 +15,8 @@
 This file contains a Megatron style Hybrid Engine that shares the weights of the actor with the inference engine.
 """
 
+import importlib
+from packaging.version import Version
 import torch
 import torch.distributed as dist
 
@@ -30,6 +32,8 @@ from verl.utils.memory_buffer import (
     build_memory_reference_from_module,
     get_weight_buffer_meta_from_module,
 )
+
+megatron_version = megatron_version = Version(importlib.metadata.version('megatron-core'))
 
 
 class AllGatherPPModel:
@@ -81,11 +85,24 @@ class AllGatherPPModel:
 
     def _build_param_buffer(self, pp_rank):
         """Build the parameter buffer in each pp rank"""
-        model = self.pp_models[pp_rank]
-        weight_buffer_meta = get_weight_buffer_meta_from_module(model)
-        self.memory_buffers[pp_rank] = build_memory_buffer(weight_buffer_meta)
+        if megatron_version >= Version('0.6.0') and pp_rank == self._pp_rank:
+            from verl.utils.memory_buffer import MemoryBuffer
+            # The code here is very hard-coded, based on the following assumptions:
+            # 1. `len(_this_rank_models) == 1`
+            # 2. `_this_rank_models[0]` is a instance of `DistributedDataParallel` and `use_distributed_optimizer=True`
+            # 3. Only bfloat16 data type is used in parameters
+            source = self._this_rank_models[0].buffers[0].param_data
+            self.memory_buffers[pp_rank] = {
+                torch.bfloat16: MemoryBuffer(source.numel(), source.numel(), torch.bfloat16, source)
+            }
+        else:
+            model = self.pp_models[pp_rank]
+            weight_buffer_meta = get_weight_buffer_meta_from_module(model)
+            self.memory_buffers[pp_rank] = build_memory_buffer(weight_buffer_meta)
 
     def _build_param_references(self, pp_rank, maintain_weight=False):
+        if megatron_version >= Version('0.6.0') and pp_rank == self._pp_rank:
+            return
         model = self.pp_models[pp_rank]
         build_memory_reference_from_module(model, self.memory_buffers[pp_rank], maintain_weight=maintain_weight)
 
@@ -121,8 +138,13 @@ class AllGatherPPModel:
             global_src = dist.get_global_rank(group=self.pp_group, group_rank=cur_pp_rank)
 
             # NOTE(sgm): the async op may cause memory leakage of the memory_buffer/pp_models
-            for memory_buffer in self.memory_buffers[cur_pp_rank].values():
-                dist.broadcast(tensor=memory_buffer.data, src=global_src, group=self.pp_group, async_op=False)
+            if megatron_version < Version('0.6.0'):
+                for memory_buffer in self.memory_buffers[cur_pp_rank].values():
+                    dist.broadcast(tensor=memory_buffer.data, src=global_src, group=self.pp_group, async_op=False)
+            else:
+                # a workaround for megatron >= 0.6.0
+                for _, param in sorted(self.pp_models[cur_pp_rank].named_paramters()):
+                    dist.broadcast(tensor=param.data, src=global_src, group=self.pp_group, async_op=False)
 
     def forward(self, *inputs, **kwargs):
         try:


### PR DESCRIPTION
## Description
I am opening this PR with the hope of adding veRL support to Megatron 0.6 (although I noticed that the veRL paper seems to have already used Megatron 0.6 as the test version). From my naive perspective, I envision two possible approaches:

1. Communication at the parameter level.
2. Creating a MemoryBuffer in veRL that is fully aligned with the ParamAndGradBuffer in Megatron 0.6, and then performing broadcast and other communication operations based on this buffer.

![communication-demo](https://github.com/user-attachments/assets/2262be9a-f15e-4297-a080-bb296cfd41c5)

In the current draft, when `self._pp_rank == pp_rank`, it directly uses the buffer defined in Megatron 0.6 (without even checking if use_distributed_optimizer is set), and communicates at the parameter level during parameter synchronization—this, of course, incurs some performance overhead.

At the very least, this approach seems feasible.

## Testing

#### PPO training deepseek-llm-7b-chat on GSM8K

- convergence

![2D14E950-E982-45FA-C7E8-8DDBBE088F10](https://github.com/user-attachments/assets/85360dc6-8559-4d1e-bffe-003b95f1a7cd)

- performance

![724101DD-D581-4D27-95FD-9BEEC5F8E772](https://github.com/user-attachments/assets/5e5db9f1-9e86-46cc-be55-0afcdc25fa5c)

![actor_gsm](https://github.com/user-attachments/assets/860dd5d0-bfbb-43fc-9491-8ffe4ce5a8fd)


#### PPO training deepseek-coder-6.7b-instruct on GSM8K + MATH

- convergence

![D7D5550C-5B66-4B3D-B391-083D8FC19B71](https://github.com/user-attachments/assets/e3a74fdb-c950-48bc-8416-785224e00003)


- performance

![86A488BF-3D4F-4C0B-E99C-923903FAEC78](https://github.com/user-attachments/assets/5230a4b7-2165-4f7e-b66f-e38fe707ddc0)

![actor_math](https://github.com/user-attachments/assets/c9f9d86b-e770-4329-8577-abff13e86e23)



The curve demonstrates that this pr does not negatively impact the training convergence. 
The performance showes different trends: improvement in one case and degradation in the other. The reasons for these differences require further analysis.