### PR TITLE
[misc] feat: spport rmpad/data-packing in FSDP with transformers

### DIFF
--- a/.github/workflows/e2e_gpu.yml
+++ b/.github/workflows/e2e_gpu.yml
@@ -23,6 +23,7 @@ jobs:
       HTTP_PROXY: ${{ secrets.PROXY_HTTP }}
       HTTPS_PROXY: ${{ secrets.PROXY_HTTPS }}
       NO_PROXY: "localhost,127.0.0.1"
+      HF_HUB_ENABLE_HF_TRANSFER: 1
     container:
       image: verlai/verl:vemlp-th2.4.0-cu124-vllm0.6.3-ray2.10-te1.7-v0.0.3
       options: --gpus all --shm-size=10g
@@ -32,7 +33,12 @@ jobs:
             fetch-depth: 0
       - name: Install the current repository
         run: |
+          pip3 install hf_transfer
           pip3 install -e .[test]
+          pip3 install --upgrade transformers
       - name: Running digit completon e2e training tests on 8 L20 GPUs
         run: |
           bash tests/e2e/run_ray_trainer.sh
+      - name: Running digit completon e2e training tests on 8 L20 GPUs (with rmpad)
+        run: |
+          bash test/e2e/run_ray_trainer_rmpad.sh

--- a/.github/workflows/e2e_gpu.yml
+++ b/.github/workflows/e2e_gpu.yml
@@ -35,10 +35,10 @@ jobs:
         run: |
           pip3 install hf_transfer
           pip3 install -e .[test]
-          pip3 install --upgrade transformers
       - name: Running digit completon e2e training tests on 8 L20 GPUs
         run: |
           bash tests/e2e/run_ray_trainer.sh
       - name: Running digit completon e2e training tests on 8 L20 GPUs (with rmpad)
         run: |
+          pip3 install --upgrade transformers
           bash test/e2e/run_ray_trainer_rmpad.sh

--- a/.github/workflows/e2e_gpu.yml
+++ b/.github/workflows/e2e_gpu.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Running digit completon e2e training tests on 8 L20 GPUs (with rmpad)
         run: |
           pip3 install --upgrade transformers
-          bash test/e2e/run_ray_trainer_rmpad.sh
+          bash tests/e2e/run_ray_trainer_rmpad.sh

--- a/.github/workflows/model.yml
+++ b/.github/workflows/model.yml
@@ -1,0 +1,39 @@
+name: model_rmpad
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.py"
+      - .github/workflows/model.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.py"
+      - .github/workflows/model.yml
+
+jobs:
+  e2e_gpu:
+    runs-on: [self-hosted, l20-1]
+    env:
+      HTTP_PROXY: ${{ secrets.PROXY_HTTP }}
+      HTTPS_PROXY: ${{ secrets.PROXY_HTTPS }}
+      NO_PROXY: "localhost,127.0.0.1"
+    container:
+      image: verlai/verl:vemlp-th2.4.0-cu124-vllm0.6.3-ray2.10-te1.7-v0.0.3
+      options: --gpus all --shm-size=10g
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+            fetch-depth: 0
+      - name: Install the current repository and upgrade to latest transformers
+        run: |
+          pip3 install -e .[test]
+          pip3 install --upgrade transformers
+      - name: Running digit completon e2e training tests on 8 L20 GPUs
+        run: |
+          pytest -s tests/model/test_transformer.py

--- a/examples/ppo_trainer/run_deepseek7b_llm.sh
+++ b/examples/ppo_trainer/run_deepseek7b_llm.sh
@@ -9,6 +9,7 @@ python3 -m verl.trainer.main_ppo \
     data.max_response_length=512 \
     actor_rollout_ref.model.path=deepseek-ai/deepseek-llm-7b-chat \
     actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_rmpad=True \
     actor_rollout_ref.actor.ppo_mini_batch_size=256 \
     actor_rollout_ref.actor.ppo_micro_batch_size=32 \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
@@ -21,6 +22,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.log_prob_micro_batch_size=128 \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
+    critic.model.use_rmpad=True \
     critic.model.path=deepseek-ai/deepseek-llm-7b-chat \
     critic.model.enable_gradient_checkpointing=False \
     critic.ppo_micro_batch_size=32 \
@@ -31,7 +33,7 @@ python3 -m verl.trainer.main_ppo \
     trainer.critic_warmup=0 \
     trainer.logger=['console','wandb'] \
     trainer.project_name='verl_example_gsm8k' \
-    trainer.experiment_name='deepseek_llm_7b_function_rm' \
+    trainer.experiment_name='deepseek_llm_7b_function_rm_normpad' \
     trainer.n_gpus_per_node=8 \
     trainer.nnodes=1 \
     trainer.save_freq=-1 \

--- a/examples/ppo_trainer/run_deepseek7b_llm.sh
+++ b/examples/ppo_trainer/run_deepseek7b_llm.sh
@@ -33,7 +33,7 @@ python3 -m verl.trainer.main_ppo \
     trainer.critic_warmup=0 \
     trainer.logger=['console','wandb'] \
     trainer.project_name='verl_example_gsm8k' \
-    trainer.experiment_name='deepseek_llm_7b_function_rm_normpad' \
+    trainer.experiment_name='deepseek_llm_7b_function_rm' \
     trainer.n_gpus_per_node=8 \
     trainer.nnodes=1 \
     trainer.save_freq=-1 \

--- a/examples/ppo_trainer/run_deepseek7b_llm.sh
+++ b/examples/ppo_trainer/run_deepseek7b_llm.sh
@@ -9,7 +9,7 @@ python3 -m verl.trainer.main_ppo \
     data.max_response_length=512 \
     actor_rollout_ref.model.path=deepseek-ai/deepseek-llm-7b-chat \
     actor_rollout_ref.actor.optim.lr=1e-6 \
-    actor_rollout_ref.model.use_rmpad=True \
+    actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.actor.ppo_mini_batch_size=256 \
     actor_rollout_ref.actor.ppo_micro_batch_size=32 \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
@@ -22,7 +22,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.log_prob_micro_batch_size=128 \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
-    critic.model.use_rmpad=True \
+    critic.model.use_remove_padding=True \
     critic.model.path=deepseek-ai/deepseek-llm-7b-chat \
     critic.model.enable_gradient_checkpointing=False \
     critic.ppo_micro_batch_size=32 \

--- a/examples/ppo_trainer/run_gemma.sh
+++ b/examples/ppo_trainer/run_gemma.sh
@@ -9,6 +9,7 @@ python3 -m verl.trainer.main_ppo \
     data.max_response_length=512 \
     actor_rollout_ref.model.path=google/gemma-2-2b-it \
     actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_rmpad=True \
     actor_rollout_ref.actor.ppo_mini_batch_size=128 \
     actor_rollout_ref.actor.ppo_micro_batch_size=4 \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
@@ -21,6 +22,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.log_prob_micro_batch_size=4 \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
+    critic.model.use_rmpad=True \
     critic.model.path=google/gemma-2-2b-it \
     critic.model.enable_gradient_checkpointing=False \
     critic.ppo_micro_batch_size=4 \

--- a/examples/ppo_trainer/run_gemma.sh
+++ b/examples/ppo_trainer/run_gemma.sh
@@ -9,7 +9,7 @@ python3 -m verl.trainer.main_ppo \
     data.max_response_length=512 \
     actor_rollout_ref.model.path=google/gemma-2-2b-it \
     actor_rollout_ref.actor.optim.lr=1e-6 \
-    actor_rollout_ref.model.use_rmpad=True \
+    actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.actor.ppo_mini_batch_size=128 \
     actor_rollout_ref.actor.ppo_micro_batch_size=4 \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
@@ -22,7 +22,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.log_prob_micro_batch_size=4 \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
-    critic.model.use_rmpad=True \
+    critic.model.use_remove_padding=True \
     critic.model.path=google/gemma-2-2b-it \
     critic.model.enable_gradient_checkpointing=False \
     critic.ppo_micro_batch_size=4 \

--- a/examples/ppo_trainer/run_qwen2-7b.sh
+++ b/examples/ppo_trainer/run_qwen2-7b.sh
@@ -17,7 +17,7 @@ python3 -m verl.trainer.main_ppo \
     data.max_response_length=512 \
     actor_rollout_ref.model.path=Qwen/Qwen2-7B-Instruct \
     actor_rollout_ref.actor.optim.lr=1e-6 \
-    actor_rollout_ref.model.use_rmpad=True \
+    actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.actor.ppo_mini_batch_size=256 \
     actor_rollout_ref.actor.ppo_micro_batch_size=16 \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
@@ -30,7 +30,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.log_prob_micro_batch_size=16 \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
-    critic.model.use_rmpad=True \
+    critic.model.use_remove_padding=True \
     critic.model.path=Qwen/Qwen2-7B-Instruct \
     critic.model.enable_gradient_checkpointing=False \
     critic.ppo_micro_batch_size=16 \

--- a/examples/ppo_trainer/run_qwen2-7b.sh
+++ b/examples/ppo_trainer/run_qwen2-7b.sh
@@ -17,6 +17,7 @@ python3 -m verl.trainer.main_ppo \
     data.max_response_length=512 \
     actor_rollout_ref.model.path=Qwen/Qwen2-7B-Instruct \
     actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_rmpad=True \
     actor_rollout_ref.actor.ppo_mini_batch_size=256 \
     actor_rollout_ref.actor.ppo_micro_batch_size=16 \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
@@ -29,6 +30,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.log_prob_micro_batch_size=16 \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
+    critic.model.use_rmpad=True \
     critic.model.path=Qwen/Qwen2-7B-Instruct \
     critic.model.enable_gradient_checkpointing=False \
     critic.ppo_micro_batch_size=16 \

--- a/examples/ppo_trainer/run_qwen2-7b_rm.sh
+++ b/examples/ppo_trainer/run_qwen2-7b_rm.sh
@@ -18,6 +18,7 @@ python3 -m verl.trainer.main_ppo \
     data.return_raw_chat=True \
     actor_rollout_ref.model.path=Qwen/Qwen2-7B-Instruct \
     actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_rmpad=True \
     actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.1 \
     actor_rollout_ref.actor.ppo_mini_batch_size=256 \
     actor_rollout_ref.actor.ppo_micro_batch_size=16 \
@@ -31,6 +32,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.log_prob_micro_batch_size=16 \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
+    critic.model.use_rmpad=True \
     critic.optim.lr_warmup_steps_ratio=0.05 \
     critic.model.path=Qwen/Qwen2-7B-Instruct \
     critic.model.enable_gradient_checkpointing=False \
@@ -40,6 +42,7 @@ python3 -m verl.trainer.main_ppo \
     critic.model.fsdp_config.optimizer_offload=False \
     reward_model.enable=True \
     reward_model.model.path=sfairXC/FsfairX-Gemma2-RM-v0.1\
+    reward_model.model.use_rmpad=True \
     reward_model.model.fsdp_config.param_offload=True \
     reward_model.micro_batch_size=16 \
     algorithm.kl_ctrl.kl_coef=0.001 \

--- a/examples/ppo_trainer/run_qwen2-7b_rm.sh
+++ b/examples/ppo_trainer/run_qwen2-7b_rm.sh
@@ -18,7 +18,7 @@ python3 -m verl.trainer.main_ppo \
     data.return_raw_chat=True \
     actor_rollout_ref.model.path=Qwen/Qwen2-7B-Instruct \
     actor_rollout_ref.actor.optim.lr=1e-6 \
-    actor_rollout_ref.model.use_rmpad=True \
+    actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.1 \
     actor_rollout_ref.actor.ppo_mini_batch_size=256 \
     actor_rollout_ref.actor.ppo_micro_batch_size=16 \
@@ -32,7 +32,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.log_prob_micro_batch_size=16 \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
-    critic.model.use_rmpad=True \
+    critic.model.use_remove_padding=True \
     critic.optim.lr_warmup_steps_ratio=0.05 \
     critic.model.path=Qwen/Qwen2-7B-Instruct \
     critic.model.enable_gradient_checkpointing=False \
@@ -42,7 +42,7 @@ python3 -m verl.trainer.main_ppo \
     critic.model.fsdp_config.optimizer_offload=False \
     reward_model.enable=True \
     reward_model.model.path=sfairXC/FsfairX-Gemma2-RM-v0.1\
-    reward_model.model.use_rmpad=True \
+    reward_model.model.use_remove_padding=True \
     reward_model.model.fsdp_config.param_offload=True \
     reward_model.micro_batch_size=16 \
     algorithm.kl_ctrl.kl_coef=0.001 \

--- a/examples/ppo_trainer/run_qwen2.5-32b.sh
+++ b/examples/ppo_trainer/run_qwen2.5-32b.sh
@@ -18,6 +18,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.model.path=Qwen/Qwen2.5-32B-Instruct \
     actor_rollout_ref.model.enable_gradient_checkpointing=False \
     actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_rmpad=True \
     actor_rollout_ref.actor.ppo_mini_batch_size=256 \
     actor_rollout_ref.actor.ppo_micro_batch_size=16 \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
@@ -30,6 +31,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.log_prob_micro_batch_size=128 \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
+    critic.model.use_rmpad=True \
     critic.model.path=Qwen/Qwen2.5-32B-Instruct \
     critic.model.enable_gradient_checkpointing=False \
     critic.ppo_micro_batch_size=32 \

--- a/examples/ppo_trainer/run_qwen2.5-32b.sh
+++ b/examples/ppo_trainer/run_qwen2.5-32b.sh
@@ -18,7 +18,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.model.path=Qwen/Qwen2.5-32B-Instruct \
     actor_rollout_ref.model.enable_gradient_checkpointing=False \
     actor_rollout_ref.actor.optim.lr=1e-6 \
-    actor_rollout_ref.model.use_rmpad=True \
+    actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.actor.ppo_mini_batch_size=256 \
     actor_rollout_ref.actor.ppo_micro_batch_size=16 \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
@@ -31,7 +31,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.log_prob_micro_batch_size=128 \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
-    critic.model.use_rmpad=True \
+    critic.model.use_remove_padding=True \
     critic.model.path=Qwen/Qwen2.5-32B-Instruct \
     critic.model.enable_gradient_checkpointing=False \
     critic.ppo_micro_batch_size=32 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pybind11",
     "ray",
     "tensordict",
-    "transformers",
+    "transformers<4.48",
     "vllm<=0.6.3",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pandas
 pybind11
 ray
 tensordict<0.6
-transformers
+transformers<4.48
 vllm<=0.6.3

--- a/tests/e2e/arithmetic_sequence/rl/config/ray_trainer.yaml
+++ b/tests/e2e/arithmetic_sequence/rl/config/ray_trainer.yaml
@@ -14,6 +14,7 @@ actor_rollout_ref:
   hybrid_engine: True
   model:
     path: ~/verl/tests/e2e/arithmetic_sequence/model
+    tokenizer_path: ${actor_rollout_ref.model.path}
     external_lib: tests.e2e.envs.digit_completion
     override_config: {}
     enable_gradient_checkpointing: False

--- a/tests/e2e/arithmetic_sequence/rl/config/ray_trainer.yaml
+++ b/tests/e2e/arithmetic_sequence/rl/config/ray_trainer.yaml
@@ -17,6 +17,7 @@ actor_rollout_ref:
     external_lib: tests.e2e.envs.digit_completion
     override_config: {}
     enable_gradient_checkpointing: False
+    use_remove_padding: False
   actor:
     strategy: fsdp  # This is for backward-compatibility
     ppo_mini_batch_size: 200
@@ -76,6 +77,7 @@ critic:
     override_config: {}
     external_lib: ${actor_rollout_ref.model.external_lib}
     enable_gradient_checkpointing: False
+    use_remove_padding: False
     fsdp_config:
       param_offload: False
       grad_offload: False
@@ -104,6 +106,7 @@ reward_model:
     path: ~/models/FsfairX-LLaMA3-RM-v0.1
     external_lib: ${actor_rollout_ref.model.external_lib}
     offload: False
+    use_remove_padding: False
     fsdp_config:
       min_num_params: 0
   micro_batch_size: 8

--- a/tests/e2e/arithmetic_sequence/rl/main_trainer.py
+++ b/tests/e2e/arithmetic_sequence/rl/main_trainer.py
@@ -119,7 +119,7 @@ def main(config):
     pprint(OmegaConf.to_container(config, resolve=True))  # resolve=True will eval symbol values
 
     # download the checkpoint from hdfs
-    local_path = copy_local_path_from_hdfs(config.actor_rollout_ref.model.path)
+    local_path = copy_local_path_from_hdfs(config.actor_rollout_ref.model.tokenizer_path)
     local_path = os.path.expanduser(local_path)
     # instantiate tokenizern
     tokenizer = AutoTokenizer.from_pretrained(local_path)

--- a/tests/e2e/run_ray_trainer_rmpad.sh
+++ b/tests/e2e/run_ray_trainer_rmpad.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+python3 tests/e2e/arithmetic_sequence/rl/main_trainer.py \
+    data.train_files=tests/e2e/arithmetic_sequence/data/train.parquet \
+    data.val_files=tests/e2e/arithmetic_sequence/data/test.parquet \
+    actor_rollout_ref.model.path=Qwen/Qwen2.5-0.5B \
+    actor_rollout_ref.model.use_remove_padding=True \
+    critic.model.path=Qwen/Qwen2.5-0.5B \
+    critic.model.use_remove_padding=True \
+    trainer.total_epochs=1 \

--- a/tests/e2e/run_ray_trainer_rmpad.sh
+++ b/tests/e2e/run_ray_trainer_rmpad.sh
@@ -5,7 +5,9 @@ set -e -x
 python3 tests/e2e/arithmetic_sequence/rl/main_trainer.py \
     data.train_files=tests/e2e/arithmetic_sequence/data/train.parquet \
     data.val_files=tests/e2e/arithmetic_sequence/data/test.parquet \
-    actor_rollout_ref.model.path=Qwen/Qwen2.5-0.5B \
+    actor_rollout_ref.model.path=tests/e2e/arithmetic_sequence/model \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
     actor_rollout_ref.model.tokenizer_path=tests/e2e/arithmetic_sequence/model \
     critic.model.path=Qwen/Qwen2.5-0.5B \
     critic.model.use_remove_padding=True \

--- a/tests/e2e/run_ray_trainer_rmpad.sh
+++ b/tests/e2e/run_ray_trainer_rmpad.sh
@@ -6,7 +6,7 @@ python3 tests/e2e/arithmetic_sequence/rl/main_trainer.py \
     data.train_files=tests/e2e/arithmetic_sequence/data/train.parquet \
     data.val_files=tests/e2e/arithmetic_sequence/data/test.parquet \
     actor_rollout_ref.model.path=Qwen/Qwen2.5-0.5B \
-    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.tokenizer_path=tests/e2e/arithmetic_sequence/model \
     critic.model.path=Qwen/Qwen2.5-0.5B \
     critic.model.use_remove_padding=True \
-    trainer.total_epochs=1 \
+    trainer.total_epochs=1

--- a/tests/model/test_transformer.py
+++ b/tests/model/test_transformer.py
@@ -5,9 +5,16 @@ from verl.utils.model import create_random_mask, compute_position_id_with_mask
 from verl.utils.torch_functional import masked_mean, log_probs_from_logits_all_rmpad, logprobs_from_logits
 from flash_attn.bert_padding import unpad_input, pad_input, index_first_axis, rearrange
 
+from transformers import LlamaConfig, MistralConfig, GemmaConfig, Qwen2Config
 # TODO(sgm): add more models for test
 # we only need one scale for each model
-test_cases = ['deepseek-ai/deepseek-llm-7b-chat', 'Qwen/Qwen2-7B-Instruct']
+test_configs = [
+    LlamaConfig(num_hidden_layers=1),
+    MistralConfig(num_hidden_layers=1),
+    GemmaConfig(num_hidden_layers=1),
+    Qwen2Config(num_hidden_layers=1)
+]
+# test_cases = ['deepseek-ai/deepseek-llm-7b-chat', 'Qwen/Qwen2-7B-Instruct']
 
 
 def test_hf_casual_models():
@@ -15,8 +22,8 @@ def test_hf_casual_models():
     seqlen = 128
     response_length = 127
 
-    for test_case in test_cases:
-        config = AutoConfig.from_pretrained(test_case)
+    for config in test_configs:
+        # config = AutoConfig.from_pretrained(test_case)
         with torch.device('cuda'):
             model = AutoModelForCausalLM.from_config(config=config,
                                                      torch_dtype=torch.bfloat16,
@@ -73,8 +80,8 @@ def test_hf_value_models():
     batch_size = 4
     seqlen = 128
 
-    for test_case in test_cases:
-        config = AutoConfig.from_pretrained(test_case)
+    for config in test_configs:
+        # config = AutoConfig.from_pretrained(test_case)
         config.num_labels = 1
         setattr(config, 'classifier_dropout', 0)
         setattr(config, 'hidden_dropout', 0)

--- a/tests/model/test_transformer.py
+++ b/tests/model/test_transformer.py
@@ -39,8 +39,8 @@ def test_hf_casual_models():
         origin_logits = model(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids, use_cache=False).logits
         
         torch.testing.assert_close(masked_mean(pad_logits, attention_mask[:, :, None]), 
-                                   masked_mean(origin_logits, attention_mask[:, :, None])) , \
-                                   f'{test_case} rmpad and non-rmpad logits are not equal'
+                                   masked_mean(origin_logits, attention_mask[:, :, None]), 
+                                   msg=f'{test_case} rmpad and non-rmpad logits are not equal')
     print(f'Check pass')
 
 def test_hf_value_models():
@@ -53,6 +53,7 @@ def test_hf_value_models():
                   'Qwen/Qwen2-7B-Instruct']
     for test_case in test_cases:
         config = AutoConfig.from_pretrained(test_case)
+        config.num_labels = 1
         setattr(config, 'classifier_dropout', 0)
         setattr(config, 'hidden_dropout', 0)
         model = AutoModelForTokenClassification.from_pretrained(test_case, torch_dtype=torch.bfloat16,
@@ -82,10 +83,10 @@ def test_hf_value_models():
         pad_logits = pad_input(rmpad_logits.squeeze(0), indices, batch_size, seqlen=seqlen)
 
         torch.testing.assert_close(masked_mean(pad_logits, attention_mask[:, :, None]), 
-                                   masked_mean(origin_logits, attention_mask[:, :, None])) , \
-                                   f'{test_case} rmpad and non-rmpad logits are not equal'
+                                   masked_mean(origin_logits, attention_mask[:, :, None]),
+                                   msg=f'{test_case} rmpad and non-rmpad logits are not equal')
     print('Value model check pass')
 
 if __name__ == '__main__':
-    test_hf_casual_models()
+    # test_hf_casual_models()
     test_hf_value_models()

--- a/tests/model/test_transformer.py
+++ b/tests/model/test_transformer.py
@@ -1,11 +1,11 @@
-from transformers import AutoModelForCausalLM, AutoConfig
+from transformers import AutoModelForCausalLM, AutoConfig, AutoModelForTokenClassification, AutoTokenizer
 
 import torch
 from verl.utils.model import create_random_mask, compute_position_id_with_mask
 from verl.utils.torch_functional import masked_mean
-from flash_attn.bert_padding import unpad_input, pad_input
+from flash_attn.bert_padding import unpad_input, pad_input, index_first_axis, rearrange
 
-def test_hf_models():
+def test_hf_casual_models():
     batch_size = 4
     seqlen = 128
 
@@ -23,14 +23,14 @@ def test_hf_models():
                                             max_ratio_of_left_padding=0.1,
                                             max_ratio_of_valid_token=0.8,
                                             min_ratio_of_valid_token=0.5)
-        position_ids = compute_position_id_with_mask(attention_mask)
+        position_ids = compute_position_id_with_mask(attention_mask) # TODO(sgm): we can construct the position_ids_rmpad here
 
         input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(input_ids.unsqueeze(-1), attention_mask) # input_ids_rmpad (total_nnz, ...)
         input_ids_rmpad = input_ids_rmpad.transpose(0, 1) # (1, total_nnz)
 
         # unpad the position_ids to align the rotary
-        position_ids_rmpad, position_indices, _, _ = unpad_input(position_ids.unsqueeze(-1), attention_mask) # input_ids_rmpad (total_nnz, ...)
-        position_ids_rmpad = position_ids_rmpad.transpose(0, 1) # (1, total_nnz)
+        position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."),
+                                      indices).transpose(0, 1)
 
         # input with input_ids_rmpad and postition_ids to enable flash attention varlen
         rmpad_logits = model(input_ids_rmpad, position_ids=position_ids_rmpad, use_cache=False).logits # (1, total_nnz, vocab_size)
@@ -41,7 +41,51 @@ def test_hf_models():
         torch.testing.assert_close(masked_mean(pad_logits, attention_mask[:, :, None]), 
                                    masked_mean(origin_logits, attention_mask[:, :, None])) , \
                                    f'{test_case} rmpad and non-rmpad logits are not equal'
-
     print(f'Check pass')
+
+def test_hf_value_models():
+    batch_size = 4
+    seqlen = 128
+
+    # TODO(sgm): add more models for test
+    # we only need one scale for each model
+    test_cases = ['deepseek-ai/deepseek-llm-7b-chat',
+                  'Qwen/Qwen2-7B-Instruct']
+    for test_case in test_cases:
+        config = AutoConfig.from_pretrained(test_case)
+        setattr(config, 'classifier_dropout', 0)
+        setattr(config, 'hidden_dropout', 0)
+        model = AutoModelForTokenClassification.from_pretrained(test_case, torch_dtype=torch.bfloat16,
+                                                        config=config,
+                                                        attn_implementation='flash_attention_2')
+        model = model.to(device='cuda')
+        input_ids = torch.randint(low=0, high=config.vocab_size, size=(batch_size, seqlen), device='cuda')
+        attention_mask = create_random_mask(input_ids=input_ids,
+                                            max_ratio_of_left_padding=0.1,
+                                            max_ratio_of_valid_token=0.8,
+                                            min_ratio_of_valid_token=0.5)
+        position_ids = compute_position_id_with_mask(attention_mask) # TODO(sgm): we can construct the position_ids_rmpad here
+
+        input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(input_ids.unsqueeze(-1), attention_mask) # input_ids_rmpad (total_nnz, ...)
+        input_ids_rmpad = input_ids_rmpad.transpose(0, 1) # (1, total_nnz)
+
+        # unpad the position_ids to align the rotary
+        position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."),
+                                      indices).transpose(0, 1)
+        
+        origin_logits = model(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids, use_cache=False).logits
+        print(f'origin_logits: {origin_logits.shape}')
+
+        # input with input_ids_rmpad and postition_ids to enable flash attention varlen
+        rmpad_logits = model(input_ids_rmpad, position_ids=position_ids_rmpad, use_cache=False).logits # (1, total_nnz, vocab_size)
+        print(f'rmpad_logits: {rmpad_logits.shape}')
+        pad_logits = pad_input(rmpad_logits.squeeze(0), indices, batch_size, seqlen=seqlen)
+
+        torch.testing.assert_close(masked_mean(pad_logits, attention_mask[:, :, None]), 
+                                   masked_mean(origin_logits, attention_mask[:, :, None])) , \
+                                   f'{test_case} rmpad and non-rmpad logits are not equal'
+    print('Value model check pass')
+
 if __name__ == '__main__':
-    test_hf_models()
+    test_hf_casual_models()
+    test_hf_value_models()

--- a/tests/model/test_transformer.py
+++ b/tests/model/test_transformer.py
@@ -5,43 +5,51 @@ from verl.utils.model import create_random_mask, compute_position_id_with_mask
 from verl.utils.torch_functional import masked_mean
 from flash_attn.bert_padding import unpad_input, pad_input, index_first_axis, rearrange
 
+
 def test_hf_casual_models():
     batch_size = 4
     seqlen = 128
 
     # TODO(sgm): add more models for test
     # we only need one scale for each model
-    test_cases = ['deepseek-ai/deepseek-llm-7b-chat',
-                  'Qwen/Qwen2-7B-Instruct']
+    test_cases = ['deepseek-ai/deepseek-llm-7b-chat', 'Qwen/Qwen2-7B-Instruct']
     for test_case in test_cases:
         config = AutoConfig.from_pretrained(test_case)
-        model = AutoModelForCausalLM.from_pretrained(test_case, torch_dtype=torch.bfloat16,
-                                                        attn_implementation='flash_attention_2')
+        model = AutoModelForCausalLM.from_pretrained(test_case,
+                                                     torch_dtype=torch.bfloat16,
+                                                     attn_implementation='flash_attention_2')
         model = model.to(device='cuda')
         input_ids = torch.randint(low=0, high=config.vocab_size, size=(batch_size, seqlen), device='cuda')
         attention_mask = create_random_mask(input_ids=input_ids,
                                             max_ratio_of_left_padding=0.1,
                                             max_ratio_of_valid_token=0.8,
                                             min_ratio_of_valid_token=0.5)
-        position_ids = compute_position_id_with_mask(attention_mask) # TODO(sgm): we can construct the position_ids_rmpad here
+        position_ids = compute_position_id_with_mask(
+            attention_mask)  # TODO(sgm): we can construct the position_ids_rmpad here
 
-        input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(input_ids.unsqueeze(-1), attention_mask) # input_ids_rmpad (total_nnz, ...)
-        input_ids_rmpad = input_ids_rmpad.transpose(0, 1) # (1, total_nnz)
+        input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
+            input_ids.unsqueeze(-1), attention_mask)  # input_ids_rmpad (total_nnz, ...)
+        input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # (1, total_nnz)
 
         # unpad the position_ids to align the rotary
         position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."),
-                                      indices).transpose(0, 1)
+                                              indices).transpose(0, 1)
 
         # input with input_ids_rmpad and postition_ids to enable flash attention varlen
-        rmpad_logits = model(input_ids_rmpad, position_ids=position_ids_rmpad, use_cache=False).logits # (1, total_nnz, vocab_size)
+        rmpad_logits = model(input_ids_rmpad, position_ids=position_ids_rmpad,
+                             use_cache=False).logits  # (1, total_nnz, vocab_size)
         pad_logits = pad_input(rmpad_logits.squeeze(0), indices, batch_size, seqlen=seqlen)
 
-        origin_logits = model(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids, use_cache=False).logits
-        
-        torch.testing.assert_close(masked_mean(pad_logits, attention_mask[:, :, None]), 
-                                   masked_mean(origin_logits, attention_mask[:, :, None]), 
+        origin_logits = model(input_ids=input_ids,
+                              attention_mask=attention_mask,
+                              position_ids=position_ids,
+                              use_cache=False).logits
+
+        torch.testing.assert_close(masked_mean(pad_logits, attention_mask[:, :, None]),
+                                   masked_mean(origin_logits, attention_mask[:, :, None]),
                                    msg=f'{test_case} rmpad and non-rmpad logits are not equal')
     print(f'Check pass')
+
 
 def test_hf_value_models():
     batch_size = 4
@@ -49,43 +57,50 @@ def test_hf_value_models():
 
     # TODO(sgm): add more models for test
     # we only need one scale for each model
-    test_cases = ['deepseek-ai/deepseek-llm-7b-chat',
-                  'Qwen/Qwen2-7B-Instruct']
+    test_cases = ['deepseek-ai/deepseek-llm-7b-chat', 'Qwen/Qwen2-7B-Instruct']
     for test_case in test_cases:
         config = AutoConfig.from_pretrained(test_case)
         config.num_labels = 1
         setattr(config, 'classifier_dropout', 0)
         setattr(config, 'hidden_dropout', 0)
-        model = AutoModelForTokenClassification.from_pretrained(test_case, torch_dtype=torch.bfloat16,
-                                                        config=config,
-                                                        attn_implementation='flash_attention_2')
+        model = AutoModelForTokenClassification.from_pretrained(test_case,
+                                                                torch_dtype=torch.bfloat16,
+                                                                config=config,
+                                                                attn_implementation='flash_attention_2')
         model = model.to(device='cuda')
         input_ids = torch.randint(low=0, high=config.vocab_size, size=(batch_size, seqlen), device='cuda')
         attention_mask = create_random_mask(input_ids=input_ids,
                                             max_ratio_of_left_padding=0.1,
                                             max_ratio_of_valid_token=0.8,
                                             min_ratio_of_valid_token=0.5)
-        position_ids = compute_position_id_with_mask(attention_mask) # TODO(sgm): we can construct the position_ids_rmpad here
+        position_ids = compute_position_id_with_mask(
+            attention_mask)  # TODO(sgm): we can construct the position_ids_rmpad here
 
-        input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(input_ids.unsqueeze(-1), attention_mask) # input_ids_rmpad (total_nnz, ...)
-        input_ids_rmpad = input_ids_rmpad.transpose(0, 1) # (1, total_nnz)
+        input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
+            input_ids.unsqueeze(-1), attention_mask)  # input_ids_rmpad (total_nnz, ...)
+        input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # (1, total_nnz)
 
         # unpad the position_ids to align the rotary
         position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."),
-                                      indices).transpose(0, 1)
-        
-        origin_logits = model(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids, use_cache=False).logits
+                                              indices).transpose(0, 1)
+
+        origin_logits = model(input_ids=input_ids,
+                              attention_mask=attention_mask,
+                              position_ids=position_ids,
+                              use_cache=False).logits
         print(f'origin_logits: {origin_logits.shape}')
 
         # input with input_ids_rmpad and postition_ids to enable flash attention varlen
-        rmpad_logits = model(input_ids_rmpad, position_ids=position_ids_rmpad, use_cache=False).logits # (1, total_nnz, vocab_size)
+        rmpad_logits = model(input_ids_rmpad, position_ids=position_ids_rmpad,
+                             use_cache=False).logits  # (1, total_nnz, vocab_size)
         print(f'rmpad_logits: {rmpad_logits.shape}')
         pad_logits = pad_input(rmpad_logits.squeeze(0), indices, batch_size, seqlen=seqlen)
 
-        torch.testing.assert_close(masked_mean(pad_logits, attention_mask[:, :, None]), 
+        torch.testing.assert_close(masked_mean(pad_logits, attention_mask[:, :, None]),
                                    masked_mean(origin_logits, attention_mask[:, :, None]),
                                    msg=f'{test_case} rmpad and non-rmpad logits are not equal')
     print('Value model check pass')
+
 
 if __name__ == '__main__':
     # test_hf_casual_models()

--- a/tests/model/test_transformer.py
+++ b/tests/model/test_transformer.py
@@ -103,5 +103,5 @@ def test_hf_value_models():
 
 
 if __name__ == '__main__':
-    # test_hf_casual_models()
+    test_hf_casual_models()
     test_hf_value_models()

--- a/tests/model/test_transformer.py
+++ b/tests/model/test_transformer.py
@@ -1,0 +1,47 @@
+from transformers import AutoModelForCausalLM, AutoConfig
+
+import torch
+from verl.utils.model import create_random_mask, compute_position_id_with_mask
+from verl.utils.torch_functional import masked_mean
+from flash_attn.bert_padding import unpad_input, pad_input
+
+def test_hf_models():
+    batch_size = 4
+    seqlen = 128
+
+    # TODO(sgm): add more models for test
+    # we only need one scale for each model
+    test_cases = ['deepseek-ai/deepseek-llm-7b-chat',
+                  'Qwen/Qwen2-7B-Instruct']
+    for test_case in test_cases:
+        config = AutoConfig.from_pretrained(test_case)
+        model = AutoModelForCausalLM.from_pretrained(test_case, torch_dtype=torch.bfloat16,
+                                                        attn_implementation='flash_attention_2')
+        model = model.to(device='cuda')
+        input_ids = torch.randint(low=0, high=config.vocab_size, size=(batch_size, seqlen), device='cuda')
+        attention_mask = create_random_mask(input_ids=input_ids,
+                                            max_ratio_of_left_padding=0.1,
+                                            max_ratio_of_valid_token=0.8,
+                                            min_ratio_of_valid_token=0.5)
+        position_ids = compute_position_id_with_mask(attention_mask)
+
+        input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(input_ids.unsqueeze(-1), attention_mask) # input_ids_rmpad (total_nnz, ...)
+        input_ids_rmpad = input_ids_rmpad.transpose(0, 1) # (1, total_nnz)
+
+        # unpad the position_ids to align the rotary
+        position_ids_rmpad, position_indices, _, _ = unpad_input(position_ids.unsqueeze(-1), attention_mask) # input_ids_rmpad (total_nnz, ...)
+        position_ids_rmpad = position_ids_rmpad.transpose(0, 1) # (1, total_nnz)
+
+        # input with input_ids_rmpad and postition_ids to enable flash attention varlen
+        rmpad_logits = model(input_ids_rmpad, position_ids=position_ids_rmpad, use_cache=False).logits # (1, total_nnz, vocab_size)
+        pad_logits = pad_input(rmpad_logits.squeeze(0), indices, batch_size, seqlen=seqlen)
+
+        origin_logits = model(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids, use_cache=False).logits
+        
+        torch.testing.assert_close(masked_mean(pad_logits, attention_mask[:, :, None]), 
+                                   masked_mean(origin_logits, attention_mask[:, :, None])) , \
+                                   f'{test_case} rmpad and non-rmpad logits are not equal'
+
+    print(f'Check pass')
+if __name__ == '__main__':
+    test_hf_models()

--- a/tests/rollout/run_fsdp_vllm.py
+++ b/tests/rollout/run_fsdp_vllm.py
@@ -127,9 +127,8 @@ def main():
     for i in range(batch_size):
         idx_list.append(_pre_process_inputs(pad_token_id, input_ids[i]))
     print('start generation')
-    while True:
-        outputs = llm.generate(prompt_token_ids=idx_list, sampling_params=sampling_params, use_tqdm=False)
-        vllm_output = outputs[0].cuda()
+    outputs = llm.generate(prompt_token_ids=idx_list, sampling_params=sampling_params, use_tqdm=False)
+    vllm_output = outputs[0].cuda()
     if torch.distributed.get_rank() == 0:
         print(f'hf response: {tokenizer.batch_decode(response)}')
         print(f'vllm response: {tokenizer.batch_decode(vllm_output)}')

--- a/tests/rollout/run_fsdp_vllm.py
+++ b/tests/rollout/run_fsdp_vllm.py
@@ -127,8 +127,9 @@ def main():
     for i in range(batch_size):
         idx_list.append(_pre_process_inputs(pad_token_id, input_ids[i]))
     print('start generation')
-    outputs = llm.generate(prompt_token_ids=idx_list, sampling_params=sampling_params, use_tqdm=False)
-    vllm_output = outputs[0].cuda()
+    while True:
+        outputs = llm.generate(prompt_token_ids=idx_list, sampling_params=sampling_params, use_tqdm=False)
+        vllm_output = outputs[0].cuda()
     if torch.distributed.get_rank() == 0:
         print(f'hf response: {tokenizer.batch_decode(response)}')
         print(f'vllm response: {tokenizer.batch_decode(vllm_output)}')

--- a/verl/models/registry.py
+++ b/verl/models/registry.py
@@ -17,6 +17,32 @@ from typing import List, Optional, Type
 
 import torch.nn as nn
 
+# Supported models using HF Rmpad
+# TODO(sgm): HF may supported more than listed here, we should add more after testing
+from transformers import LlamaConfig, MistralConfig, GemmaConfig, Qwen2Config
+
+_RMPAD_MODELS = {
+    'LlamaForCausalLM': LlamaConfig,
+    'MistralForCausalLM': MistralConfig,
+    'GemmaForCausalLM': GemmaConfig,
+    'Qwen2ForCausalLM': Qwen2Config
+}
+
+
+def if_support_rmpad(model_archs: List[str]):
+    if isinstance(model_archs, list):
+        for model_arch in model_archs:
+            if model_arch in _RMPAD_MODELS.keys():
+                return
+        raise ValueError(f"Model architectures {model_archs} are not supported for now. "
+                         f"RMPad supported architectures: {_RMPAD_MODELS.keys()}")
+    elif isinstance(model_archs, str):
+        if not model_archs in _RMPAD_MODELS.keys():
+            raise ValueError(f"Model architecture {model_archs} is not supported for now. "
+                             f"RMPad supported architectures: {_RMPAD_MODELS.keys()}")
+
+
+# Supported models in Megatron-LM
 # Architecture -> (module, class).
 _MODELS = {
     "LlamaForCausalLM":

--- a/verl/models/registry.py
+++ b/verl/models/registry.py
@@ -29,7 +29,7 @@ _RMPAD_MODELS = {
 }
 
 
-def if_support_rmpad(model_archs: List[str]):
+def check_model_support_rmpad(model_archs: List[str]):
     if isinstance(model_archs, list):
         for model_arch in model_archs:
             if model_arch in _RMPAD_MODELS.keys():

--- a/verl/models/registry.py
+++ b/verl/models/registry.py
@@ -21,19 +21,14 @@ import torch.nn as nn
 # TODO(sgm): HF may supported more than listed here, we should add more after testing
 from transformers import LlamaConfig, MistralConfig, GemmaConfig, Qwen2Config
 
-_REOVEPAD_MODELS = {
-    'llama': LlamaConfig,
-    'mistral': MistralConfig,
-    'gemma': GemmaConfig,
-    'qwen2': Qwen2Config
-}
+_REOVEPAD_MODELS = {'llama': LlamaConfig, 'mistral': MistralConfig, 'gemma': GemmaConfig, 'qwen2': Qwen2Config}
 
 
 def check_model_support_rmpad(model_type: str):
     assert isinstance(model_type, str)
     if not model_type in _REOVEPAD_MODELS.keys():
         raise ValueError(f"Model architecture {model_type} is not supported for now. "
-                            f"RMPad supported architectures: {_REOVEPAD_MODELS.keys()}")
+                         f"RMPad supported architectures: {_REOVEPAD_MODELS.keys()}")
 
 
 # Supported models in Megatron-LM

--- a/verl/models/registry.py
+++ b/verl/models/registry.py
@@ -21,25 +21,19 @@ import torch.nn as nn
 # TODO(sgm): HF may supported more than listed here, we should add more after testing
 from transformers import LlamaConfig, MistralConfig, GemmaConfig, Qwen2Config
 
-_RMPAD_MODELS = {
-    'LlamaForCausalLM': LlamaConfig,
-    'MistralForCausalLM': MistralConfig,
-    'GemmaForCausalLM': GemmaConfig,
-    'Qwen2ForCausalLM': Qwen2Config
+_REOVEPAD_MODELS = {
+    'llama': LlamaConfig,
+    'mistral': MistralConfig,
+    'gemma': GemmaConfig,
+    'qwen2': Qwen2Config
 }
 
 
-def check_model_support_rmpad(model_archs: List[str]):
-    if isinstance(model_archs, list):
-        for model_arch in model_archs:
-            if model_arch in _RMPAD_MODELS.keys():
-                return
-        raise ValueError(f"Model architectures {model_archs} are not supported for now. "
-                         f"RMPad supported architectures: {_RMPAD_MODELS.keys()}")
-    elif isinstance(model_archs, str):
-        if not model_archs in _RMPAD_MODELS.keys():
-            raise ValueError(f"Model architecture {model_archs} is not supported for now. "
-                             f"RMPad supported architectures: {_RMPAD_MODELS.keys()}")
+def check_model_support_rmpad(model_type: str):
+    assert isinstance(model_type, str)
+    if not model_type in _REOVEPAD_MODELS.keys():
+        raise ValueError(f"Model architecture {model_type} is not supported for now. "
+                            f"RMPad supported architectures: {_REOVEPAD_MODELS.keys()}")
 
 
 # Supported models in Megatron-LM

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -17,7 +17,7 @@ actor_rollout_ref:
     external_lib: null
     override_config: { }
     enable_gradient_checkpointing: False
-    use_rmpad: False
+    use_remove_padding: False
   actor:
     strategy: fsdp  # This is for backward-compatibility
     ppo_mini_batch_size: 256
@@ -84,7 +84,7 @@ critic:
     override_config: { }
     external_lib: ${actor_rollout_ref.model.external_lib}
     enable_gradient_checkpointing: False
-    use_rmpad: False
+    use_remove_padding: False
     fsdp_config:
       param_offload: False
       grad_offload: False
@@ -107,7 +107,7 @@ reward_model:
     input_tokenizer: ${actor_rollout_ref.model.path}  # set this to null if the chat template is identical
     path: ~/models/FsfairX-LLaMA3-RM-v0.1
     external_lib: ${actor_rollout_ref.model.external_lib}
-    use_rmpad: False
+    use_remove_padding: False
     fsdp_config:
       min_num_params: 0
       param_offload: False

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -17,6 +17,7 @@ actor_rollout_ref:
     external_lib: null
     override_config: { }
     enable_gradient_checkpointing: False
+    use_rmpad: False
   actor:
     strategy: fsdp  # This is for backward-compatibility
     ppo_mini_batch_size: 256
@@ -83,6 +84,7 @@ critic:
     override_config: { }
     external_lib: ${actor_rollout_ref.model.external_lib}
     enable_gradient_checkpointing: False
+    use_rmpad: False
     fsdp_config:
       param_offload: False
       grad_offload: False
@@ -105,6 +107,7 @@ reward_model:
     input_tokenizer: ${actor_rollout_ref.model.path}  # set this to null if the chat template is identical
     path: ~/models/FsfairX-LLaMA3-RM-v0.1
     external_lib: ${actor_rollout_ref.model.external_lib}
+    use_rmpad: False
     fsdp_config:
       min_num_params: 0
       param_offload: False

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -465,12 +465,14 @@ def get_unpad_data(attention_mask):
         max_seqlen_in_batch,
     )
 
+
 def prepare_input_for_rmpad(input_ids, attention_mask, position_ids):
-    input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(input_ids.unsqueeze(-1), attention_mask) # input_ids_rmpad (total_nnz, ...)
-    input_ids_rmpad = input_ids_rmpad.transpose(0, 1) # (1, total_nnz)
+    input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
+        input_ids.unsqueeze(-1), attention_mask)  # input_ids_rmpad (total_nnz, ...)
+    input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # (1, total_nnz)
 
     # unpad the position_ids to align the rotary
     position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."),
-                                    indices).transpose(0, 1)
+                                          indices).transpose(0, 1)
 
     return input_ids_rmpad, position_ids_rmpad, indices

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -334,9 +334,11 @@ def log_probs_from_logits_all_rmpad(input_ids_rmpad, logits_rmpad, indices, batc
     for large vocab_size
     
     Args:
-        input_ids: [batch_size, seqlen]
-        attention_mask: [batch_size, seqlen]
+        input_ids_rmpad: [1, total_nnz]
         logits_rmpad: [total_nnz, vocab_size]
+        indices: [total_nnz]
+        batch_size: int
+        seqlen: int
         response_length: int
     """
     from flash_attn.bert_padding import pad_input

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -23,7 +23,8 @@ import torch.distributed
 import torch.nn.functional as F
 from tensordict import TensorDict
 from torch import nn
-
+from flash_attn.bert_padding import unpad_input, pad_input, \
+                                    index_first_axis, rearrange
 try:
     from flash_attn.ops.triton.cross_entropy import cross_entropy_loss
     FLAH_ATTN_CROSS_ENTROPY_LOSS_AVAILABLE = True
@@ -463,3 +464,13 @@ def get_unpad_data(attention_mask):
         cu_seqlens,
         max_seqlen_in_batch,
     )
+
+def prepare_input_for_rmpad(input_ids, attention_mask, position_ids):
+    input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(input_ids.unsqueeze(-1), attention_mask) # input_ids_rmpad (total_nnz, ...)
+    input_ids_rmpad = input_ids_rmpad.transpose(0, 1) # (1, total_nnz)
+
+    # unpad the position_ids to align the rotary
+    position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."),
+                                    indices).transpose(0, 1)
+
+    return input_ids_rmpad, position_ids_rmpad, indices

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -325,6 +325,7 @@ def log_probs_from_logits_response_rmpad(input_ids, attention_mask, logits_rmpad
     output = full_output.squeeze(-1)[:, -response_length - 1:-1]  # [batch_size, response_length]
     return output
 
+
 def log_probs_from_logits_all_rmpad(input_ids_rmpad, logits_rmpad, indices, batch_size, seqlen, response_length):
     """Compute the log_probs from logits with rmpad input_ids and logits. Note that
     logits_rmpad = model(input_ids_rmpad). For each sentences, there is a shift between
@@ -339,7 +340,8 @@ def log_probs_from_logits_all_rmpad(input_ids_rmpad, logits_rmpad, indices, batc
         response_length: int
     """
     from flash_attn.bert_padding import pad_input
-
+    input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # transpose back to [total_nnz, 1]
+    input_ids_rmpad = input_ids_rmpad.squeeze(-1)
     input_ids_rmpad_rolled = torch.roll(input_ids_rmpad, shifts=-1, dims=0)
     full_log_probs_rmpad = logprobs_from_logits(logits=logits_rmpad, labels=input_ids_rmpad_rolled)  # (total_nnz,)
     full_output = pad_input(hidden_states=full_log_probs_rmpad.unsqueeze(-1),
@@ -348,6 +350,7 @@ def log_probs_from_logits_all_rmpad(input_ids_rmpad, logits_rmpad, indices, batc
                             seqlen=seqlen)
     output = full_output.squeeze(-1)[:, -response_length - 1:-1]  # [batch_size, response_length]
     return output
+
 
 from transformers.generation.logits_process import (TemperatureLogitsWarper, TopKLogitsWarper, TopPLogitsWarper)
 

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -298,7 +298,7 @@ def log_probs_from_logits_response(input_ids, logits, response_length):
 
 
 def log_probs_from_logits_response_rmpad(input_ids, attention_mask, logits_rmpad, response_length):
-    """Compute the log_probs from logits with rmpad input_ids and logits. Note that
+    """Compute the log_probs from logits with rmpad logits and pad input. Note that
     logits_rmpad = model(input_ids_rmpad). For each sentences, there is a shift between
     logits and input_ids.
     The reason for this function to is to compute logprobs_from_logits in rmpad mode because it is memory-intensive
@@ -325,6 +325,29 @@ def log_probs_from_logits_response_rmpad(input_ids, attention_mask, logits_rmpad
     output = full_output.squeeze(-1)[:, -response_length - 1:-1]  # [batch_size, response_length]
     return output
 
+def log_probs_from_logits_all_rmpad(input_ids_rmpad, logits_rmpad, indices, batch_size, seqlen, response_length):
+    """Compute the log_probs from logits with rmpad input_ids and logits. Note that
+    logits_rmpad = model(input_ids_rmpad). For each sentences, there is a shift between
+    logits and input_ids.
+    The reason for this function to is to compute logprobs_from_logits in rmpad mode because it is memory-intensive
+    for large vocab_size
+    
+    Args:
+        input_ids: [batch_size, seqlen]
+        attention_mask: [batch_size, seqlen]
+        logits_rmpad: [total_nnz, vocab_size]
+        response_length: int
+    """
+    from flash_attn.bert_padding import pad_input
+
+    input_ids_rmpad_rolled = torch.roll(input_ids_rmpad, shifts=-1, dims=0)
+    full_log_probs_rmpad = logprobs_from_logits(logits=logits_rmpad, labels=input_ids_rmpad_rolled)  # (total_nnz,)
+    full_output = pad_input(hidden_states=full_log_probs_rmpad.unsqueeze(-1),
+                            indices=indices,
+                            batch=batch_size,
+                            seqlen=seqlen)
+    output = full_output.squeeze(-1)[:, -response_length - 1:-1]  # [batch_size, response_length]
+    return output
 
 from transformers.generation.logits_process import (TemperatureLogitsWarper, TopKLogitsWarper, TopPLogitsWarper)
 

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -68,7 +68,7 @@ class DataParallelPPOActor(BasePPOActor):
                                            position_ids=position_ids_rmpad,
                                            use_cache=False)  # prevent model thinks we are generating
                 logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
-                logits_rmpad = logits_rmpad / temperature
+                logits_rmpad /= temperature
                 log_probs = log_probs_from_logits_all_rmpad(input_ids_rmpad=input_ids_rmpad,
                                                             logits_rmpad=logits_rmpad,
                                                             indices=indices,

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -75,7 +75,7 @@ class DataParallelPPOActor(BasePPOActor):
                 logits = output.logits / temperature
                 logits = logits[:, -response_length - 1:-1]
                 log_probs = logprobs_from_logits(logits, micro_batch['responses'])
-                return logits, log_probs
+            return logits, log_probs
 
     def _make_minibatch_iterator(self, data: DataProto) -> Iterable[DataProto]:
         """Make minibatch iterator for updating the actor

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -14,7 +14,7 @@
 """
 Single Process Actor
 """
-from typing import Iterable
+from typing import Iterable, Tuple
 
 import torch
 from torch import nn
@@ -24,7 +24,9 @@ from verl import DataProto
 from verl.trainer.ppo import core_algos
 from verl.workers.actor import BasePPOActor
 from verl.utils.py_functional import append_to_dict
-from verl.utils.torch_functional import logprobs_from_logits
+from verl.utils.torch_functional import logprobs_from_logits, prepare_input_for_rmpad, log_probs_from_logits_response_rmpad
+
+from flash_attn.bert_padding import pad_input, unpad_input
 
 __all__ = ['DataParallelPPOActor']
 
@@ -41,18 +43,39 @@ class DataParallelPPOActor(BasePPOActor):
         super().__init__(config)
         self.actor_module = actor_module
         self.actor_optimizer = actor_optimizer
+        self.use_rmpad = self.config.get('use_rmpad', False)
+        print(f'Actor use_rmpad={self.use_rmpad}')
 
-    def _forward_micro_batch(self, micro_batch, temperature):
+    def _forward_micro_batch(self, micro_batch, temperature) -> Tuple[torch.Tensor, torch.Tensor]:
         response_length = micro_batch['responses'].size(-1)
         with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
-            output = self.actor_module(input_ids=micro_batch['input_ids'],
-                                       attention_mask=micro_batch['attention_mask'],
-                                       position_ids=micro_batch['position_ids'],
-                                       use_cache=False)  # prevent model thinks we are generating
-            logits = output.logits / temperature
-            logits = logits[:, -response_length - 1:-1]
-            log_probs = logprobs_from_logits(logits, micro_batch['responses'])
-            return logits, log_probs
+            input_ids = micro_batch['input_ids']
+            attention_mask = micro_batch['attention_mask']
+            position_ids = micro_batch['position_ids']
+
+            if self.use_rmpad:
+                input_ids_rmpad, position_ids_rmpad, indices = prepare_input_for_rmpad(input_ids, attention_mask, position_ids)
+                # only pass input_ids and position_ids to enable flash_attn_varlen
+                output = self.actor_module(input_ids=input_ids_rmpad,
+                                        attention_mask=None,
+                                        position_ids=position_ids_rmpad,
+                                        use_cache=False)  # prevent model thinks we are generating
+                logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
+                logits_rmpad = logits_rmpad / temperature
+                log_probs = log_probs_from_logits_response_rmpad(input_ids=input_ids,
+                                                                 attention_mask=attention_mask,
+                                                                 logits_rmpad=logits_rmpad,
+                                                                 response_length=response_length) # (batch, seqlen)
+                logits = logits_rmpad
+            else:
+                output = self.actor_module(input_ids=input_ids,
+                                        attention_mask=attention_mask,
+                                        position_ids=position_ids,
+                                        use_cache=False)  # prevent model thinks we are generating
+                logits = output.logits / temperature
+                logits = logits[:, -response_length - 1:-1]
+                log_probs = logprobs_from_logits(logits, micro_batch['responses'])
+                return logits, log_probs
 
     def _make_minibatch_iterator(self, data: DataProto) -> Iterable[DataProto]:
         """Make minibatch iterator for updating the actor
@@ -145,8 +168,17 @@ class DataParallelPPOActor(BasePPOActor):
                                                                               advantages=advantages,
                                                                               eos_mask=response_mask,
                                                                               cliprange=clip_ratio)
-
-                entropy_loss = core_algos.compute_entropy_loss(logits, response_mask)
+                # compute entropy loss
+                if self.use_rmpad:
+                    full_response_mask = attention_mask.clone()
+                    full_response_mask[:, :-response_length] = 0  # set the prompt part to zero
+                    full_response_mask_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
+                        full_response_mask.unsqueeze(-1), attention_mask=attention_mask)
+                    full_response_mask_rmpad = full_response_mask_rmpad.squeeze(-1)  # (total_nnz)
+                    entropy_loss = core_algos.compute_entropy_loss(logits, full_response_mask_rmpad)  # (total_nnz,)
+                else:
+                    entropy_loss = core_algos.compute_entropy_loss(logits, response_mask)
+                # compute policy loss
                 policy_loss = pg_loss - entropy_loss * entropy_coeff
 
                 loss = policy_loss / self.gradient_accumulation

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -24,9 +24,9 @@ from verl import DataProto
 from verl.trainer.ppo import core_algos
 from verl.workers.actor import BasePPOActor
 from verl.utils.py_functional import append_to_dict
-from verl.utils.torch_functional import logprobs_from_logits, prepare_input_for_rmpad, log_probs_from_logits_response_rmpad
+from verl.utils.torch_functional import logprobs_from_logits, log_probs_from_logits_response_rmpad
 
-from flash_attn.bert_padding import pad_input, unpad_input
+from flash_attn.bert_padding import pad_input, unpad_input, rearrange, index_first_axis
 
 __all__ = ['DataParallelPPOActor']
 
@@ -54,8 +54,13 @@ class DataParallelPPOActor(BasePPOActor):
             position_ids = micro_batch['position_ids']
 
             if self.use_rmpad:
-                input_ids_rmpad, position_ids_rmpad, indices = prepare_input_for_rmpad(
-                    input_ids, attention_mask, position_ids)
+                input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
+                    input_ids.unsqueeze(-1), attention_mask)  # input_ids_rmpad (total_nnz, ...)
+                input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # (1, total_nnz)
+
+                # unpad the position_ids to align the rotary
+                position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."),
+                                                      indices).transpose(0, 1)
                 # only pass input_ids and position_ids to enable flash_attn_varlen
                 output = self.actor_module(input_ids=input_ids_rmpad,
                                            attention_mask=None,

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -61,11 +61,12 @@ class DataParallelPPOCritic(BasePPOCritic):
                                             attention_mask=None,
                                             position_ids=position_ids_rmpad,
                                             use_cache=False)  # prevent model thinks we are generating
-                values = output.logits
+                values_rmpad = output.logits
                 values_rmpad = values_rmpad.squeeze(0)  # (total_nnz)
 
                 # pad it back
                 values = pad_input(values_rmpad, indices=indices, batch=batch, seqlen=seqlen).squeeze(-1)
+                values = values[:, -response_length - 1:-1]
             else:    
                 output = self.critic_module(input_ids=input_ids,
                                             attention_mask=attention_mask,

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -40,8 +40,8 @@ class DataParallelPPOCritic(BasePPOCritic):
         super().__init__(config=config)
         self.critic_module = critic_module
         self.critic_optimizer = critic_optimizer
-        self.use_rmpad = self.config.model.get('use_rmpad', False)
-        print(f'Critic use_rmpad={self.use_rmpad}')
+        self.use_remove_padding = self.config.model.get('use_remove_padding', False)
+        print(f'Critic use_remove_padding={self.use_remove_padding}')
 
         assert self.config.ppo_mini_batch_size % self.config.ppo_micro_batch_size == 0
         self.gradient_accumulation = self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size
@@ -54,7 +54,7 @@ class DataParallelPPOCritic(BasePPOCritic):
             attention_mask = micro_batch['attention_mask']
             position_ids = micro_batch['position_ids']
 
-            if self.use_rmpad:
+            if self.use_remove_padding:
                 input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
                     input_ids.unsqueeze(-1), attention_mask)  # input_ids_rmpad (total_nnz, ...)
                 input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # (1, total_nnz)

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -27,9 +27,9 @@ from verl import DataProto
 from verl.trainer.ppo import core_algos
 from verl.workers.critic import BasePPOCritic
 from verl.utils.py_functional import append_to_dict
-from verl.utils.torch_functional import masked_mean, prepare_input_for_rmpad
+from verl.utils.torch_functional import masked_mean
 
-from flash_attn.bert_padding import pad_input, unpad_input
+from flash_attn.bert_padding import pad_input, unpad_input, rearrange, index_first_axis
 
 __all__ = ['DataParallelPPOCritic']
 
@@ -55,8 +55,13 @@ class DataParallelPPOCritic(BasePPOCritic):
             position_ids = micro_batch['position_ids']
 
             if self.use_rmpad:
-                input_ids_rmpad, position_ids_rmpad, indices = prepare_input_for_rmpad(
-                    input_ids, attention_mask, position_ids)
+                input_ids_rmpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
+                    input_ids.unsqueeze(-1), attention_mask)  # input_ids_rmpad (total_nnz, ...)
+                input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # (1, total_nnz)
+
+                # unpad the position_ids to align the rotary
+                position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."),
+                                                      indices).transpose(0, 1)
                 # only pass input_ids and position_ids to enable flash_attn_varlen
                 output = self.critic_module(input_ids=input_ids_rmpad,
                                             attention_mask=None,

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -73,7 +73,7 @@ class DataParallelPPOCritic(BasePPOCritic):
                                             position_ids=position_ids,
                                             use_cache=False)  # prevent model thinks we are generating
                 values = output.logits
-                values = values[:, -response_length - 1:-1]
+                values = values[:, -response_length - 1:-1].squeeze(-1)
             return values
 
     def _make_minibatch_iterator(self, data: DataProto) -> Iterable[DataProto]:

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -55,7 +55,8 @@ class DataParallelPPOCritic(BasePPOCritic):
             position_ids = micro_batch['position_ids']
 
             if self.use_rmpad:
-                input_ids_rmpad, position_ids_rmpad, indices = prepare_input_for_rmpad(input_ids, attention_mask, position_ids)
+                input_ids_rmpad, position_ids_rmpad, indices = prepare_input_for_rmpad(
+                    input_ids, attention_mask, position_ids)
                 # only pass input_ids and position_ids to enable flash_attn_varlen
                 output = self.critic_module(input_ids=input_ids_rmpad,
                                             attention_mask=None,
@@ -67,7 +68,7 @@ class DataParallelPPOCritic(BasePPOCritic):
                 # pad it back
                 values = pad_input(values_rmpad, indices=indices, batch=batch, seqlen=seqlen).squeeze(-1)
                 values = values[:, -response_length - 1:-1]
-            else:    
+            else:
                 output = self.critic_module(input_ids=input_ids,
                                             attention_mask=attention_mask,
                                             position_ids=position_ids,

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -121,8 +121,8 @@ class ActorRolloutRefWorker(Worker):
         actor_model_config = AutoConfig.from_pretrained(local_path, trust_remote_code=trust_remote_code)
 
         if use_rmpad:
-            from verl.models.registry import if_support_rmpad
-            if_support_rmpad(actor_model_config.architectures)
+            from verl.models.registry import check_model_support_rmpad
+            check_model_support_rmpad(actor_model_config.architectures)
 
         override_config_kwargs = {
             'bos_token_id': self.tokenizer.bos_token_id,
@@ -503,8 +503,8 @@ class CriticWorker(Worker):
 
         use_rmpad = config.model.get('use_rmpad', False)
         if use_rmpad:
-            from verl.models.registry import if_support_rmpad
-            if_support_rmpad(critic_model_config.architectures)
+            from verl.models.registry import check_model_support_rmpad
+            check_model_support_rmpad(critic_model_config.architectures)
 
         init_context = get_init_weight_context_manager()
         with init_context(), warnings.catch_warnings():
@@ -760,7 +760,7 @@ class RewardModelWorker(Worker):
                 output = self.reward_module(input_ids=input_ids,
                                             attention_mask=attention_mask,
                                             position_ids=position_ids)
-                rm_score = output.logits  # (batch_size, seq_len, 2)
+                rm_score = output.logits  # (batch_size, seq_len, 1)
                 rm_score = rm_score.squeeze(-1)
             return rm_score
 

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -646,6 +646,7 @@ class CriticWorker(Worker):
         if self._is_offload_param:
             offload_fsdp_param_and_grad(module=self.critic_module, offload_grad=self._is_offload_grad)
 
+
 # TODO(sgm): we may need to extract it to dp_reward_model.py
 class RewardModelWorker(Worker):
     """
@@ -725,7 +726,8 @@ class RewardModelWorker(Worker):
             position_ids = micro_batch['position_ids']
 
             if self.use_rmpad:
-                input_ids_rmpad, position_ids_rmpad, indices = prepare_input_for_rmpad(input_ids, attention_mask, position_ids)
+                input_ids_rmpad, position_ids_rmpad, indices = prepare_input_for_rmpad(
+                    input_ids, attention_mask, position_ids)
                 # only pass input_ids and position_ids to enable flash_attn_varlen
                 output = self.reward_module(input_ids=input_ids_rmpad,
                                             attention_mask=None,

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -122,7 +122,7 @@ class ActorRolloutRefWorker(Worker):
 
         if use_remove_padding:
             from verl.models.registry import check_model_support_rmpad
-            check_model_support_rmpad(actor_model_config.architectures)
+            check_model_support_rmpad(actor_model_config.model_type)
 
         override_config_kwargs = {
             'bos_token_id': self.tokenizer.bos_token_id,
@@ -504,7 +504,7 @@ class CriticWorker(Worker):
         use_remove_padding = config.model.get('use_remove_padding', False)
         if use_remove_padding:
             from verl.models.registry import check_model_support_rmpad
-            check_model_support_rmpad(critic_model_config.architectures)
+            check_model_support_rmpad(critic_model_config.model_type)
 
         init_context = get_init_weight_context_manager()
         with init_context(), warnings.catch_warnings():


### PR DESCRIPTION
- Use `actor_rollout_ref.model.use_rmpad=True` + `critic.model.use_rmpad=True \` + `reward_model.model.use_rmpad=True ` to enable rmpad for different models. Default set to False
- Using `AutoModelForTokenClassification` for Value and Reward Model. Instead of using SeqenceClassification
- Compute logprob convert to `log_probs_from_logits_response_rmpad`

Resolve: https://github.com/volcengine/verl/issues/53

**Comparison using DeepSeek7b and GSM8k:**
About 1.7x speedup compare to no rmpad (original cases)
