### PR TITLE
[misc] fix nan in non_tensor_batch union

### DIFF
--- a/tests/utility/test_tensor_dict_utilities.py
+++ b/tests/utility/test_tensor_dict_utilities.py
@@ -41,8 +41,12 @@ def test_union_tensor_dict():
         data = union_tensor_dict(data1, data_with_copied_obs)
 
     data = np.random.random(100)
-    a = {'a': data}
-    b = {'a': data}
+    data2 = [float('nan') for _ in range(99)]
+    data2.append('nan')
+    data2 = np.array(data2, dtype=object)
+    data3 = np.tile(data2, (2, 1))
+    a = {'a': data, 'b': data2, 'c': data3}
+    b = {'a': data, 'b': data2, 'c': data3}
     b_ = {'a': np.random.random(100)}
     union_numpy_dict(a, b)
     with pytest.raises(AssertionError):

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -84,7 +84,7 @@ def union_numpy_dict(tensor_dict1: dict[np.ndarray], tensor_dict2: dict[np.ndarr
             assert isinstance(tensor_dict2[key], np.ndarray)
             assert isinstance(tensor_dict1[key], np.ndarray)
             # to properly deal with nan and object type
-            assert pd.Series(tensor_dict2[key]).equals(pd.Series(tensor_dict1[key])), \
+            assert pd.DataFrame(tensor_dict2[key]).equals(pd.DataFrame(tensor_dict1[key])), \
                 f'{key} in tensor_dict1 and tensor_dict2 are not the same object'
         tensor_dict1[key] = val
 

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -82,7 +82,7 @@ def union_numpy_dict(tensor_dict1: dict[np.ndarray], tensor_dict2: dict[np.ndarr
         if key in tensor_dict1:
             assert isinstance(tensor_dict2[key], np.ndarray)
             assert isinstance(tensor_dict1[key], np.ndarray)
-            assert np.all(tensor_dict2[key] == tensor_dict1[key]), \
+            assert np.array_equal(tensor_dict2[key] == tensor_dict1[key], equal_nan=True), \
                 f'{key} in tensor_dict1 and tensor_dict2 are not the same object'
         tensor_dict1[key] = val
 

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -18,6 +18,7 @@ We can subclass Protocol to define more detailed batch info with specific keys
 
 import pickle
 import numpy as np
+import pandas as pd
 import copy
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Union
@@ -82,7 +83,8 @@ def union_numpy_dict(tensor_dict1: dict[np.ndarray], tensor_dict2: dict[np.ndarr
         if key in tensor_dict1:
             assert isinstance(tensor_dict2[key], np.ndarray)
             assert isinstance(tensor_dict1[key], np.ndarray)
-            assert np.array_equal(tensor_dict2[key] == tensor_dict1[key], equal_nan=True), \
+            # to properly deal with nan and object type
+            assert pd.Series(tensor_dict2[key]).equals(pd.Series(tensor_dict1[key])), \
                 f'{key} in tensor_dict1 and tensor_dict2 are not the same object'
         tensor_dict1[key] = val
 


### PR DESCRIPTION
- In some cases, there would be a nan value in the np.array.
- We fix it using pandas as np fail to assert array when the type is object