### PR TITLE
validate `use_remove_padding` when applying sequence parallelism

### DIFF
--- a/verl/utils/config.py
+++ b/verl/utils/config.py
@@ -86,4 +86,13 @@ def validate_config(config):
             assert config.critic.ppo_mini_batch_size % config.critic.ppo_micro_batch_size == 0
             assert config.critic.ppo_micro_batch_size * sp_size >= n_gpus
 
+    # Check if use_remove_padding is enabled when using sequence parallelism
+    if config.actor_rollout_ref.actor.ulysses_sequence_parallel_size > 1:
+        assert config.actor_rollout_ref.actor.use_remove_padding, \
+            "When using sequence parallelism for actor, you must enable `use_remove_padding`."
+    
+    if config.actor_rollout_ref.ref.ulysses_sequence_parallel_size > 1:
+        assert config.actor_rollout_ref.ref.use_remove_padding, \
+            "When using sequence parallelism for ref policy, you must enable `use_remove_padding`."
+
     print("[validate_config] All configuration checks passed successfully!")


### PR DESCRIPTION
This is because the ulysses_sp is activated only when `use_remove_padding` is enabled:

https://github.com/volcengine/verl/blob/ab525bce267e4b3805ceabac8441afc4385bba96/verl/workers/actor/dp_actor.py#L71-L128

Without this check, users may encounter OOM issues when the set sp_size > 1 but `use_remove_padding` is mistakenly disabled.