### PR TITLE
[nit] Explicitly show logits dimension in `dp_worker.py::forward_micro_batch`

### DIFF
--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -134,7 +134,7 @@ class DataParallelPPOActor(BasePPOActor):
                                            use_cache=False)  # prevent model thinks we are generating
                 logits = output.logits
                 logits.div_(temperature)
-                logits = logits[:, -response_length - 1:-1]  # (bsz, response_length)
+                logits = logits[:, -response_length - 1:-1, :]  # (bsz, response_length, vocab_size)
                 log_probs = logprobs_from_logits(logits, micro_batch['responses'])
                 entropy = verl_F.entropy_from_logits(logits)  # (bsz, response_length)
 


### PR DESCRIPTION
The logits is of shape `(bsz, response_length, vocab_size)`. This change doesn't change any execution, but explicitly show the logits shape and easier to understand the code. 