### PR TITLE
[rollout]: fix incorrect response_attention_mask in vLLM rollout

### DIFF
--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -138,13 +138,20 @@ def masked_whiten(values, mask, shift_mean=True):
     return whitened
 
 
-def get_eos_mask(response_id: torch.Tensor, eos_token: int = 2, dtype=torch.int64):
+def get_eos_mask(response_id: torch.Tensor, eos_token: Union[int, List[int]] = 2, dtype=torch.int64):
     '''
-    e.g. end of sentence token=1
+    e.g. end of sentence token can be int or list: 1 or [1, 2]
     response_id: [0, 0, 2, 42, 3, 5, 1, 0, 0]
     eos_mask:     [1, 1, 1, 1,  1, 1, 1, 0, 0]
     '''
-    eos_mask = response_id.eq(eos_token).long()
+    if isinstance(eos_token, int):
+        eos_token = [eos_token]
+    
+    eos_mask = torch.zeros_like(response_id, dtype=torch.bool)
+    for token in eos_token:
+        eos_mask |= response_id.eq(token)
+    
+    eos_mask = eos_mask.long()
     eos_mask = (torch.cumsum(eos_mask, dim=1) - eos_mask).bool()
     eos_mask = torch.logical_not(eos_mask).to(dtype)
     return eos_mask

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -140,7 +140,8 @@ def masked_whiten(values, mask, shift_mean=True):
 
 def get_eos_mask(response_id: torch.Tensor, eos_token: Union[int, List[int]] = 2, dtype=torch.int64):
     '''
-    e.g. end of sentence token can be int or list: 1 or [1, 2]
+    end of sentence token can be int or list: 1 or [1, 2]
+    e.g. eos_token=1
     response_id: [0, 0, 2, 42, 3, 5, 1, 0, 0]
     eos_mask:     [1, 1, 1, 1,  1, 1, 1, 0, 0]
     '''

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -149,7 +149,7 @@ class ActorRolloutRefWorker(Worker):
                                role='actor'):
         from verl.utils.model import print_model_size, update_model_config
         from verl.utils.torch_dtypes import PrecisionType
-        from transformers import AutoModelForCausalLM, AutoConfig
+        from transformers import AutoModelForCausalLM, AutoConfig, GenerationConfig
         from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy, MixedPrecision, CPUOffload
         from torch import optim
 
@@ -170,6 +170,9 @@ class ActorRolloutRefWorker(Worker):
 
         # override model kwargs
         actor_model_config = AutoConfig.from_pretrained(local_path, trust_remote_code=trust_remote_code)
+
+        self.generation_config = GenerationConfig.from_pretrained(
+            local_path, trust_remote_code=trust_remote_code)
 
         if use_remove_padding:
             from verl.models.registry import check_model_support_rmpad
@@ -445,7 +448,10 @@ class ActorRolloutRefWorker(Worker):
                                      load_grad=self._is_offload_grad)
 
         prompts.batch = prompts.batch.cuda()
-        meta_info = {'eos_token_id': self.tokenizer.eos_token_id, 'pad_token_id': self.tokenizer.pad_token_id}
+        meta_info = {
+            'eos_token_id': self.generation_config.eos_token_id,
+            'pad_token_id': self.generation_config.pad_token_id
+        }
         prompts.meta_info.update(meta_info)
         with self.rollout_sharding_manager:
             log_gpu_memory_usage('After entering rollout sharding manager', logger=logger)

--- a/verl/workers/rollout/naive/naive_rollout.py
+++ b/verl/workers/rollout/naive/naive_rollout.py
@@ -57,6 +57,8 @@ class NaiveRollout(BaseRollout):
 
         # used to construct attention_mask
         eos_token_id = prompts.meta_info['eos_token_id']
+        if isinstance(eos_token, int):
+            eos_token = [eos_token]
 
         batch_size = idx.size(0)
         prompt_length = idx.size(1)
@@ -90,7 +92,8 @@ class NaiveRollout(BaseRollout):
 
             attention_mask = torch.cat((attention_mask, prev_attention_mask), dim=-1)
 
-            prev_attention_mask = torch.logical_and(idx_next != eos_token_id, prev_attention_mask.bool())
+            for token_id in eos_token_id:
+                prev_attention_mask = torch.logical_and(idx_next != token_id, prev_attention_mask.bool())
             prev_attention_mask.to(attention_mask.dtype)
 
             position_ids = torch.cat((position_ids, position_ids[:, -1:] + 1), dim=-1)


### PR DESCRIPTION
This PR addresses issue https://github.com/volcengine/verl/issues/212.

The changes include:
- read eos_token_id from generation_config to ensure alignment with vLLM
- modified the get_eos_mask function to accept both int and list types for the eos_token parameter.