### PR TITLE
[ckpt] feat: integrate checkpoint resume in RL ray trainer

### DIFF
--- a/.github/workflows/e2e_gsm8k.yml
+++ b/.github/workflows/e2e_gsm8k.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           ray stop --force
           python3 examples/data_preprocess/gsm8k.py
-      - name: Running gsm8k e2e training tests on 8 L20 GPUs with rmpad using function rm
+      - name: Running gsm8k e2e training tests on 8 L20 GPUs with rmpad using function rm and save ckpt
         run: |
           ray stop --force
           bash tests/e2e/run_qwen_gsm8k_function_rm.sh
@@ -50,7 +50,7 @@ jobs:
         run: |
           ray stop --force
           bash tests/e2e/run_qwen_gsm8k_function_rm_grpo.sh
-      - name: Running gsm8k e2e without rmpad using function rm
+      - name: Running gsm8k e2e without rmpad using function rm and load ckpt from previous step
         run: |
           ray stop --force
           bash tests/e2e/run_qwen_gsm8k_function_rm_no_rmpad.sh

--- a/tests/checkpoint/test_fsdp_ckpt.py
+++ b/tests/checkpoint/test_fsdp_ckpt.py
@@ -37,8 +37,8 @@ def test_fsdp_ckpt():
 
     with torch.device('cuda'):
         model = AutoModelForCausalLM.from_config(config=config,
-                                                     torch_dtype=torch.bfloat16,
-                                                     attn_implementation='flash_attention_2')
+                                                 torch_dtype=torch.bfloat16,
+                                                 attn_implementation='flash_attention_2')
         model = model.to(device='cuda')
 
     # Wrap model with FSDP

--- a/tests/checkpoint/test_fsdp_ckpt.py
+++ b/tests/checkpoint/test_fsdp_ckpt.py
@@ -21,6 +21,7 @@ from torch.distributed import init_device_mesh
 from verl.utils.distributed import initialize_global_process_group
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import Qwen2Config
 
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy, MixedPrecision, \
             CPUOffload
@@ -32,9 +33,10 @@ def test_fsdp_ckpt():
     device_mesh = init_device_mesh('cuda', mesh_shape=(world_size,), mesh_dim_names=('dp',))
 
     model_name = 'Qwen/Qwen2.5-0.5B-Instruct'
+    config = Qwen2Config(num_hidden_layers=1)
 
     with torch.device('cuda'):
-        model = AutoModelForCausalLM.from_pretrained(model_name,
+        model = AutoModelForCausalLM.from_config(config=config,
                                                      torch_dtype=torch.bfloat16,
                                                      attn_implementation='flash_attention_2')
         model = model.to(device='cuda')

--- a/tests/e2e/run_qwen_gsm8k_function_rm.sh
+++ b/tests/e2e/run_qwen_gsm8k_function_rm.sh
@@ -38,5 +38,5 @@ python3 -m verl.trainer.main_ppo \
     trainer.experiment_name='qwen_e2e_ci_function_rm' \
     trainer.n_gpus_per_node=8 \
     trainer.nnodes=1 \
-    trainer.save_freq=-1 \
+    trainer.save_freq=1 \
     trainer.total_training_steps=1 $@

--- a/tests/e2e/run_qwen_gsm8k_function_rm_no_rmpad.sh
+++ b/tests/e2e/run_qwen_gsm8k_function_rm_no_rmpad.sh
@@ -40,5 +40,4 @@ python3 -m verl.trainer.main_ppo \
     trainer.n_gpus_per_node=8 \
     trainer.nnodes=1 \
     trainer.save_freq=-1 \
-    trainer.default_local_dir=checkpoints/${trainer.project_name}/${trainer.experiment_name} \
     trainer.total_training_steps=1 $@

--- a/tests/e2e/run_qwen_gsm8k_function_rm_no_rmpad.sh
+++ b/tests/e2e/run_qwen_gsm8k_function_rm_no_rmpad.sh
@@ -40,4 +40,5 @@ python3 -m verl.trainer.main_ppo \
     trainer.n_gpus_per_node=8 \
     trainer.nnodes=1 \
     trainer.save_freq=-1 \
+    trainer.default_local_dir=checkpoints/${trainer.project_name}/${trainer.experiment_name} \
     trainer.total_training_steps=1 $@

--- a/tests/e2e/run_ray_trainer.sh
+++ b/tests/e2e/run_ray_trainer.sh
@@ -32,7 +32,8 @@ python3 tests/e2e/arithmetic_sequence/rl/main_trainer.py \
     trainer.experiment_name=arithmetic_sequences \
     trainer.logger=['console'] \
     trainer.n_gpus_per_node=1 \
-    trainer.test_freq=1 | tee $OUTPUT_FILE;
+    trainer.test_freq=1 \
+    trainer.save_freq=110 | tee $OUTPUT_FILE;
 
 python3 tests/e2e/check_results.py --output_file=$OUTPUT_FILE
 rm -rf $OUTPUT_FILE

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -152,6 +152,9 @@ trainer:
   nnodes: 1
   n_gpus_per_node: 8
   save_freq: -1
+  # auto: find the last ckpt to resume. If can't find, start from scratch
+  resume_mode: disable # or auto or global_step_x if 
+  resume_from_steps: False
   test_freq: 2
   critic_warmup: 0
   default_hdfs_dir: null

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -154,5 +154,5 @@ trainer:
   save_freq: -1
   test_freq: 2
   critic_warmup: 0
-  default_hdfs_dir: ~/experiments/gsm8k/ppo/${trainer.experiment_name}
+  default_hdfs_dir: null
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -9,6 +9,7 @@ data:
   val_batch_size: 1312
   return_raw_input_ids: False  # This should be set to true when the tokenizer between policy and rm differs
   return_raw_chat: False
+  shuffle: True
 
 actor_rollout_ref:
   hybrid_engine: True

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -153,8 +153,8 @@ trainer:
   n_gpus_per_node: 8
   save_freq: -1
   # auto: find the last ckpt to resume. If can't find, start from scratch
-  resume_mode: disable # or auto or global_step_x if 
-  resume_from_steps: False
+  resume_mode: disable # or auto or resume_path if 
+  resume_from_path: False
   test_freq: 2
   critic_warmup: 0
   default_hdfs_dir: null

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -162,8 +162,8 @@ trainer:
   n_gpus_per_node: 8
   save_freq: -1
   # auto: find the last ckpt to resume. If can't find, start from scratch
-  resume_mode: disable # or auto or global_step_x if 
-  resume_from_steps: False
+  resume_mode: auto # or auto or resume_path if 
+  resume_from_path: False
   test_freq: -1
   critic_warmup: 0
   default_hdfs_dir: null

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -163,5 +163,5 @@ trainer:
   save_freq: -1
   test_freq: -1
   critic_warmup: 0
-  default_hdfs_dir: ~/experiments/gsm8k/ppo/${trainer.experiment_name}
+  default_hdfs_dir: null
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -9,6 +9,7 @@ data:
   val_batch_size: 1312
   return_raw_input_ids: False  # This should be set to true when the tokenizer between policy and rm differs
   return_raw_chat: False
+  shuffle: True
 
 actor_rollout_ref:
   hybrid_engine: True

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -161,6 +161,9 @@ trainer:
   nnodes: 1
   n_gpus_per_node: 8
   save_freq: -1
+  # auto: find the last ckpt to resume. If can't find, start from scratch
+  resume_mode: disable # or auto or global_step_x if 
+  resume_from_steps: False
   test_freq: -1
   critic_warmup: 0
   default_hdfs_dir: null

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -600,14 +600,14 @@ class RayPPOTrainer(object):
                                         f'global_step_{self.global_steps}')
         actor_remote_path = None if self.config.trainer.default_hdfs_dir is None else os.path.join(
             self.config.trainer.default_hdfs_dir, 'actor')
-        self.actor_rollout_wg.save_checkpoint(actor_local_path, actor_remote_path)
+        self.actor_rollout_wg.save_checkpoint(actor_local_path, actor_remote_path, self.global_steps)
 
         if self.use_critic:
             critic_local_path = os.path.join(self.config.trainer.default_local_dir, 'critic',
                                              f'global_step_{self.global_steps}')
             critic_remote_path = None if self.config.trainer.default_hdfs_dir is None else os.path.join(
                 self.config.trainer.default_hdfs_dir, 'critic')
-            self.critic_wg.save_checkpoint(critic_local_path, critic_remote_path)
+            self.critic_wg.save_checkpoint(critic_local_path, critic_remote_path, self.global_steps)
 
     def _balance_batch(self, batch: DataProto, metrics, logging_prefix='global_seqlen'):
         """Reorder the data on single controller such that each dp rank gets similar total tokens"""

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -448,7 +448,6 @@ class RayPPOTrainer(object):
 
         self.train_dataloader = DataLoader(dataset=self.train_dataset,
                                            batch_size=self.config.data.train_batch_size,
-                                           shuffle=True,
                                            drop_last=True,
                                            collate_fn=collate_fn,
                                            sampler=sampler)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -596,21 +596,22 @@ class RayPPOTrainer(object):
         self.actor_rollout_wg.init_model()
 
     def _save_checkpoint(self):
-        actor_local_path = os.path.join(self.config.trainer.default_local_dir, 'actor',
-                                        f'global_step_{self.global_steps}')
+        # path: given_path + `/global_step_{global_step}` + `/actor`
+        local_global_step_folder = os.path.join(self.config.trainer.default_local_dir, f'global_step_{self.global_step}')
+        actor_local_path = os.path.join(local_global_step_folder,'actor')
+
         actor_remote_path = None if self.config.trainer.default_hdfs_dir is None else os.path.join(
-            self.config.trainer.default_hdfs_dir, 'actor')
+            self.config.trainer.default_hdfs_dir, f'global_step_{self.global_step}', 'actor')
         self.actor_rollout_wg.save_checkpoint(actor_local_path, actor_remote_path, self.global_steps)
 
         if self.use_critic:
-            critic_local_path = os.path.join(self.config.trainer.default_local_dir, 'critic',
-                                             f'global_step_{self.global_steps}')
+            critic_local_path = os.path.join(local_global_step_folder, 'critic')
             critic_remote_path = None if self.config.trainer.default_hdfs_dir is None else os.path.join(
-                self.config.trainer.default_hdfs_dir, 'critic')
+                self.config.trainer.default_hdfs_dir, f'global_step_{self.global_step}', 'critic')
             self.critic_wg.save_checkpoint(critic_local_path, critic_remote_path, self.global_steps)
         
         # latest checkpointed iteration tracker (for atomic usage)
-        local_latest_checkpointed_iteration = os.path.join(self.config.trainer.default_local_dir,
+        local_latest_checkpointed_iteration = os.path.join(local_global_step_folder,
                                                            'latest_checkpointed_iteration.txt')
         with open(local_latest_checkpointed_iteration, 'w') as f:
             f.write(str(self.global_steps))
@@ -624,6 +625,9 @@ class RayPPOTrainer(object):
             NotImplementedError('load from hdfs is not implemented yet')
         else:
             checkpoint_folder = self.config.trainer.default_local_dir # TODO: check path
+            if not os.path.isabs(checkpoint_folder):
+                working_dir = os.getcwd()
+                checkpoint_folder = os.path.join(working_dir, checkpoint_folder)
             global_step_folder = find_latest_ckpt_path(checkpoint_folder)  # None if no latest
 
         # find global_step_folder
@@ -632,11 +636,14 @@ class RayPPOTrainer(object):
                 print('Training from scratch')
                 return 0
         else:
-            if not (self.config.trainer.resume_from_steps and global_step_folder is not None):
+            if not (self.config.trainer.resume_from_path and global_step_folder is not None):
                 assert isinstance(self.config.trainer.resume_mode, str), "resume ckpt must be str type"
                 assert 'global_step_' in self.config.trainer.resume_mode, "resume ckpt must specify the global_step"
                 global_step_folder = self.config.trainer.resume_mode
-
+                if not os.path.isabs(global_step_folder):
+                    working_dir = os.getcwd()
+                    global_step_folder = os.path.join(working_dir, global_step_folder)
+        print(f'Load from checkpoint folder: {global_step_folder}')
         # set global step
         self.global_step = int(global_step_folder.split('global_step_')[-1])
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -651,8 +651,6 @@ class RayPPOTrainer(object):
         if self.use_critic:
             self.critic_wg.load_checkpoint(critic_path)
 
-        return self.global_step
-
     def _balance_batch(self, batch: DataProto, metrics, logging_prefix='global_seqlen'):
         """Reorder the data on single controller such that each dp rank gets similar total tokens"""
         attention_mask = batch.batch['attention_mask']
@@ -685,6 +683,9 @@ class RayPPOTrainer(object):
                           config=OmegaConf.to_container(self.config, resolve=True))
 
         self.global_steps = 0
+
+        # load checkpoint before doing anything
+        self._load_checkpoint()
 
         # perform validation before training
         # currently, we only support validation using the reward_function.

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -106,7 +106,7 @@ def find_latest_ckpt_path(path, directory_format="global_step_{}"):
 
     tracker_file = get_checkpoint_tracker_filename(path)
     if not os.path.exists(tracker_file):
-        print("Checkpoint does not exist: %s", tracker_file)
+        print("Checkpoint tracker file does not exist: %s", tracker_file)
         return None
 
     with open(tracker_file, "rb") as f:

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -51,6 +51,7 @@ class BaseCheckpointManager:
 
         assert isinstance(self.model, FSDP)
         self.rank = torch.distributed.get_rank()
+        self.world_size = torch.distributed.get_world_size()
 
     def load_checkpoint(self, *args, **kwargs):
         raise NotImplementedError

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -109,7 +109,7 @@ def find_latest_ckpt_path(path, directory_format="global_step_{}"):
         print("Checkpoint does not exist: %s", tracker_file)
         return None
 
-    with os.path.exists(tracker_file, "rb", skip_encryption=True) as f:
+    with open(tracker_file, "rb") as f:
         iteration = int(f.read().decode())
     ckpt_path = os.path.join(path, directory_format.format(iteration))
     if not os.path.exists(ckpt_path):

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -119,6 +119,7 @@ def find_latest_ckpt_path(path, directory_format="global_step_{}"):
     print("Found checkpoint: %s", ckpt_path)
     return ckpt_path
 
+
 def get_checkpoint_tracker_filename(root_path: str):
     """
     Tracker file rescords the latest chckpoint during training to restart from.

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -98,3 +98,29 @@ class BaseCheckpointManager:
         torch.cuda.set_rng_state(rng_state['cuda'])
         np.random.set_state(rng_state['numpy'])
         random.setstate(rng_state['random'])
+
+
+def find_latest_ckpt_path(path, directory_format="global_step_{}"):
+    if path is None:
+        return None
+
+    tracker_file = get_checkpoint_tracker_filename(path)
+    if not os.path.exists(tracker_file):
+        print("Checkpoint does not exist: %s", tracker_file)
+        return None
+
+    with os.path.exists(tracker_file, "rb", skip_encryption=True) as f:
+        iteration = int(f.read().decode())
+    ckpt_path = os.path.join(path, directory_format.format(iteration))
+    if not os.path.exists(ckpt_path):
+        print("Checkpoint does not exist: %s", ckpt_path)
+        return None
+
+    print("Found checkpoint: %s", ckpt_path)
+    return ckpt_path
+
+def get_checkpoint_tracker_filename(root_path: str):
+    """
+    Tracker file rescords the latest chckpoint during training to restart from.
+    """
+    return os.path.join(root_path, "latest_checkpointed_iteration.txt")

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -93,12 +93,7 @@ class FSDPCheckpointManager(BaseCheckpointManager):
         if self.lr_scheduler is not None:
             self.lr_scheduler.load_state_dict(lr_scheduler_state_dict)
 
-    def save_checkpoint(self,
-                        local_path: str,
-                        global_step: int,
-                        remove_previous_ckpt=True,
-                        *args,
-                        **kwargs):
+    def save_checkpoint(self, local_path: str, global_step: int, remove_previous_ckpt=True, *args, **kwargs):
         # record the previous global step
         self.previous_global_step = global_step
 
@@ -139,7 +134,6 @@ class FSDPCheckpointManager(BaseCheckpointManager):
                 torch.save(model_state_dict, model_path)
                 torch.save(optimizer_state_dict, optim_path)  # TODO: address optimizer is None
                 torch.save(extra_state_dict, extra_path)
-
 
         # wait for everyone to dump to local
         torch.distributed.barrier()

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -95,7 +95,6 @@ class FSDPCheckpointManager(BaseCheckpointManager):
 
     def save_checkpoint(self,
                         local_path: str,
-                        hdfs_path: str,
                         global_step: int,
                         remove_previous_ckpt=True,
                         *args,
@@ -141,8 +140,6 @@ class FSDPCheckpointManager(BaseCheckpointManager):
                 torch.save(optimizer_state_dict, optim_path)  # TODO: address optimizer is None
                 torch.save(extra_state_dict, extra_path)
 
-        if hdfs_path is not None:
-            raise NotImplementedError('upload model to hdfs_path is not supported yet')
 
         # wait for everyone to dump to local
         torch.distributed.barrier()
@@ -152,8 +149,6 @@ class FSDPCheckpointManager(BaseCheckpointManager):
             os.makedirs(hf_local_path, exist_ok=True)
             self.model._fsdp_wrapped_module.config.save_pretrained(hf_local_path)
             self.tokenizer.save_pretrained(hf_local_path)
-            if hdfs_path is not None:
-                raise NotImplementedError('upload tokenizer to hdfs_path is not supported yet')
 
         torch.distributed.barrier()
 

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -53,9 +53,9 @@ class FSDPCheckpointManager(BaseCheckpointManager):
             return
 
         # every rank download its own checkpoint
-        remote_model_path = os.path.join(path, f'model_rank_{self.rank}.pt')
-        remote_optim_path = os.path.join(path, f'optim_rank_{self.rank}.pt')
-        remote_extra_state_path = os.path.join(path, f'extra_state_rank_{self.rank}.pt')
+        remote_model_path = os.path.join(path, f'model_world_size_{self.world_size}_rank_{self.rank}.pt')
+        remote_optim_path = os.path.join(path, f'optim_world_size_{self.world_size}_rank_{self.rank}.pt')
+        remote_extra_state_path = os.path.join(path, f'extra_state_world_size_{self.world_size}_rank_{self.rank}.pt')
         print(
             f'[rank-{self.rank}]: Loading from {remote_model_path} and {remote_optim_path} and {remote_extra_state_path}'
         )
@@ -124,9 +124,9 @@ class FSDPCheckpointManager(BaseCheckpointManager):
                     'lr_scheduler': lr_scheduler_state_dict,
                     'rng': self.get_rng_state(),
                 }
-                model_path = os.path.join(local_path, f'model_rank_{self.rank}.pt')
-                optim_path = os.path.join(local_path, f'optim_rank_{self.rank}.pt')
-                extra_path = os.path.join(local_path, f'extra_state_rank_{self.rank}.pt')
+                model_path = os.path.join(local_path, f'model_world_size_{self.world_size}_rank_{self.rank}.pt')
+                optim_path = os.path.join(local_path, f'optim_world_size_{self.world_size}_rank_{self.rank}.pt')
+                extra_path = os.path.join(local_path, f'extra_state_world_size_{self.world_size}_rank_{self.rank}.pt')
 
                 print(f'[rank-{self.rank}]: Saving model to {os.path.abspath(model_path)}')
                 print(f'[rank-{self.rank}]: Saving checkpoint to {os.path.abspath(model_path)}')

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -15,7 +15,7 @@
 from omegaconf import ListConfig
 import os
 from typing import List, Union
-
+import copy
 import pandas as pd
 
 import torch
@@ -73,7 +73,8 @@ class RLHFDataset(Dataset):
         if not isinstance(parquet_files, (List, ListConfig)):
             parquet_files = [parquet_files]
 
-        self.parquet_files = parquet_files
+        self.parquet_files = copy.deepcopy(parquet_files)
+        self.original_parquet_files = copy.deepcopy(parquet_files) # use for resume
         self.cache_dir = os.path.expanduser(cache_dir)
         self.tokenizer = tokenizer
 
@@ -85,12 +86,16 @@ class RLHFDataset(Dataset):
         self.chat_template_func = chat_template_func
         self.truncation = truncation
 
+        # whether to store the dataset in state_dict()
+        # default not store
+        self.serialize_dataset = False
         self._download()
         self._read_files_and_tokenize()
 
-    def _download(self):
+    def _download(self, use_origin_parquet=False):
         from verl.utils.fs import copy_local_path_from_hdfs
-        for i, parquet_file in enumerate(self.parquet_files):
+        parquet_files = self.parquet_files if not use_origin_parquet else self.original_parquet_files
+        for i, parquet_file in enumerate(parquet_files):
             self.parquet_files[i] = copy_local_path_from_hdfs(src=parquet_file, cache_dir=self.cache_dir)
 
     def _read_files_and_tokenize(self):
@@ -111,6 +116,15 @@ class RLHFDataset(Dataset):
                                                              axis=1)]
 
         print(f'filter dataset len: {len(self.dataframe)}')
+    
+    def resume_dataset_state(self):
+        self.serialize_dataset = False if hasattr(self, 'original_parquet_files') else True
+        # resume dataframe if not it's serialized in data.pt
+        if not self.serialize_dataset:
+            self._download(use_origin_parquet=True) # download and resume from original parquet files
+            self._read_files_and_tokenize()
+        else:
+            print(r'old dataloader ckpt file is used, please train from scratch for better ckpt performance')
 
     def __len__(self):
         return len(self.dataframe)
@@ -147,3 +161,12 @@ class RLHFDataset(Dataset):
         row_dict["index"] = index
 
         return row_dict
+
+    def __getstate__(self):
+        if not self.serialize_dataset:
+            state = self.__dict__.copy()
+
+            if 'dataframe' in state:
+                del state['dataframe']
+            return state
+        return self.__dict__.copy()

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -74,7 +74,7 @@ class RLHFDataset(Dataset):
             parquet_files = [parquet_files]
 
         self.parquet_files = copy.deepcopy(parquet_files)
-        self.original_parquet_files = copy.deepcopy(parquet_files) # use for resume
+        self.original_parquet_files = copy.deepcopy(parquet_files)  # use for resume
         self.cache_dir = os.path.expanduser(cache_dir)
         self.tokenizer = tokenizer
 
@@ -116,12 +116,12 @@ class RLHFDataset(Dataset):
                                                              axis=1)]
 
         print(f'filter dataset len: {len(self.dataframe)}')
-    
+
     def resume_dataset_state(self):
         self.serialize_dataset = False if hasattr(self, 'original_parquet_files') else True
         # resume dataframe if not it's serialized in data.pt
         if not self.serialize_dataset:
-            self._download(use_origin_parquet=True) # download and resume from original parquet files
+            self._download(use_origin_parquet=True)  # download and resume from original parquet files
             self._read_files_and_tokenize()
         else:
             print(r'old dataloader ckpt file is used, please train from scratch for better ckpt performance')

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -560,9 +560,10 @@ class ActorRolloutRefWorker(Worker):
                                      load_grad=self._is_offload_grad)
 
         self.checkpoint_manager.load_checkpoint(path=path, del_local_after_load=del_local_after_load)
-        
+
         if self._is_offload_param:
             offload_fsdp_param_and_grad(module=self.actor_module_fsdp, offload_grad=self._is_offload_grad)
+
 
 class CriticWorker(Worker):
 
@@ -838,6 +839,7 @@ class CriticWorker(Worker):
         torch.distributed.barrier()
         if self._is_offload_param:
             offload_fsdp_param_and_grad(module=self.critic_module, offload_grad=self._is_offload_grad)
+
 
 # TODO(sgm): we may need to extract it to dp_reward_model.py
 class RewardModelWorker(Worker):

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -37,6 +37,7 @@ from verl.utils.fsdp_utils import offload_fsdp_optimizer, offload_fsdp_param_and
 from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.flops_counter import FlopsCounter
+from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
 
 from codetiming import Timer
@@ -386,6 +387,10 @@ class ActorRolloutRefWorker(Worker):
 
         if self._is_actor:
             self.flops_counter = FlopsCounter(self.actor_model_config)
+            self.checkpoint_manager = FSDPCheckpointManager(model=self.actor_module_fsdp,
+                                                            optimizer=self.actor.actor_optimizer,
+                                                            lr_scheduler=self.actor_lr_scheduler,
+                                                            tokenizer=self.tokenizer)
 
         torch.cuda.empty_cache()
 
@@ -532,7 +537,8 @@ class ActorRolloutRefWorker(Worker):
         return output
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
-    def save_checkpoint(self, local_path, hdfs_path=None):
+    def save_checkpoint(self, local_path, hdfs_path=None, global_step=0):
+        # only support save and load ckpt for actor
         assert self._is_actor
         import torch
         if self._is_offload_param:
@@ -540,21 +546,7 @@ class ActorRolloutRefWorker(Worker):
                                      device_id=torch.cuda.current_device(),
                                      load_grad=self._is_offload_grad)
 
-        # TODO: support DCP and save sharded checkpoints
-        import torch.distributed
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, StateDictType, FullStateDictConfig
-        cfg = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
-        with FSDP.state_dict_type(self.actor.actor_module, StateDictType.FULL_STATE_DICT, cfg):
-            state_dict = self.actor.actor_module.state_dict()
-        if self.rank == 0:
-            print(f'Saving actor checkpoint to {local_path}')
-            os.makedirs(local_path, exist_ok=True)
-            self.actor_module.save_pretrained(local_path, state_dict=state_dict)
-            self.tokenizer.save_pretrained(local_path)
-            if hdfs_path is not None:
-                print(f'Uploading actor checkpoint to {hdfs_path}')
-                hdfs_io.makedirs(hdfs_path, exist_ok=True)
-                hdfs_io.copy(src=local_path, dst=hdfs_path, dirs_exist_ok=True)
+        self.checkpoint_manager.save_checkpoint(local_path=local_path, hdfs_path=hdfs_path, global_step=global_step)
 
         torch.distributed.barrier()
         if self._is_offload_param:
@@ -739,6 +731,10 @@ class CriticWorker(Worker):
                                             critic_optimizer=self.critic_optimizer)
 
         self.flops_counter = FlopsCounter(self.critic_model_config)
+        self.checkpoint_manager = FSDPCheckpointManager(model=self.critic_module,
+                                                        optimizer=self.critic_optimizer,
+                                                        lr_scheduler=self.critic_lr_scheduler,
+                                                        tokenizer=self.tokenizer)
 
         torch.cuda.empty_cache()
 
@@ -805,28 +801,14 @@ class CriticWorker(Worker):
         return output
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
-    def save_checkpoint(self, local_path, hdfs_path=None):
+    def save_checkpoint(self, local_path, hdfs_path=None, global_step=0):
         import torch
         if self._is_offload_param:
             load_fsdp_param_and_grad(module=self.critic_module,
                                      device_id=torch.cuda.current_device(),
                                      load_grad=self._is_offload_grad)
 
-        # TODO: support DCP and save sharded checkpoints
-        import torch.distributed
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, StateDictType, FullStateDictConfig
-        cfg = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
-        with FSDP.state_dict_type(self.critic_module, StateDictType.FULL_STATE_DICT, cfg):
-            state_dict = self.critic_module.state_dict()
-        if self.rank == 0:
-            print(f'Saving critic checkpoint to {local_path}')
-            os.makedirs(local_path, exist_ok=True)
-            self.critic_module._fsdp_wrapped_module.save_pretrained(local_path, state_dict=state_dict)
-            self.tokenizer.save_pretrained(local_path)
-            if hdfs_path is not None:
-                print(f'Uploading critic checkpoint to {hdfs_path}')
-                hdfs_io.makedirs(hdfs_path, exist_ok=True)
-                hdfs_io.copy(src=local_path, dst=hdfs_path, dirs_exist_ok=True)
+        self.checkpoint_manager.save_checkpoint(local_path=local_path, hdfs_path=hdfs_path, global_step=global_step)
 
         torch.distributed.barrier()
         if self._is_offload_param:


### PR DESCRIPTION
**Features:**
- Save actor and critic checkpoint:
  - Model
  - Optimizer
  - lr_scheduler
  - rng_state
  - dataloader
- A complete checkpoint represents that dataloader, actor and critic (if any) state are properly saved
- By default, we will not save the dataset but only store the dataloader (with sampler) state

**Usage:**
- Support resume mode: auto, disable and resume_from_path
   - auto: veRL will automatically check the latest checkpoint from `trainer.default_local_dir`
   - disable: veRL will always train from scratch
   - resume_from_path: When setting `resume_from_path`=True, then user only need to set the resume_mode to the checkpoint path that you want to load.

**TODO:**
- Support SFT resume in the next PR
- Support uploader

**Relevant issue:**
- https://github.com/volcengine/verl/issues/76
- https://github.com/volcengine/verl/issues/143