### PR TITLE
Typo in the rank zero code

### DIFF
--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -317,7 +317,7 @@ class RayWorkerGroup(WorkerGroup):
         return new_worker_group_dict
 
     def execute_rank_zero_sync(self, method_name: str, *args, **kwargs):
-        return ray.get(self.execute_all_async(method_name, **args, **kwargs))
+        return ray.get(self.execute_rank_zero_async(method_name, *args, **kwargs))
 
     def execute_rank_zero_async(self, method_name: str, *args, **kwargs):
         remote_call = getattr(self._workers[0], method_name)


### PR DESCRIPTION
The original Ray controller method `execute_rank_zero_sync()` is not functional. Fixed.