### PR TITLE
[misc] Compatibility Issue with Python 3.9 in FSDP Worker for LLaMA Model

### DIFF
--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 import torch
-from typing import Optional, List, Union, Tuple, Unpack, Callable
+from typing import Optional, List, Union, Tuple, Callable
+import sys
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
 
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb, repeat_kv
 from transformers.cache_utils import Cache


### PR DESCRIPTION
**Fix: Compatibility Issue with Python 3.9 in FSDP Worker for LLaMA Model**

When running the LLaMA model in the FSDP worker, an ImportError occurs due to the use of the Unpack type from the typing module. This type is only available in Python 3.11 and later, but the current environment uses Python 3.9, which does not support it.

**Error Details:**
```
File "/project/Logic-RL-main/verl/models/transformers/llama.py", line 17, in <module>
from typing import Optional, List, Union, Tuple, Unpack, Callable
ImportError: cannot import name 'Unpack' from 'typing' (/opt/miniconda3/envs/verl/lib/python3.9/typing.py)
```
**Solution:**
To resolve this issue, I added conditional imports to handle different Python versions. For Python versions lower than 3.11, the code now uses a fallback or alternative approach to avoid relying on Unpack.