### PR TITLE
[misc] Add Ray Serve to requirements to support multi-node training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ peft
 pyarrow>=15.0.0
 pybind11
 pylatexenc
-ray
+ray[data,train,tune,serve]
 tensordict<0.6
 transformers
 vllm==0.6.3.post1


### PR DESCRIPTION
This PR adds Ray Serve to the requirements to enable support for multi-node training. It addresses the issue described here:  https://github.com/volcengine/verl/issues/87#issuecomment-2659493418