### PR TITLE
fix `_build_model_optimizer` when role is rollout, whose `optim_config` is None

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -260,7 +260,7 @@ class ActorRolloutRefWorker(Worker):
         log_gpu_memory_usage('After Actor FSDP init', logger=logger)
 
         # TODO: add more optimizer args into config
-        if role == 'actor':
+        if role == 'actor' and optim_config is not None:
             from verl.utils.torch_functional import get_constant_schedule_with_warmup
             actor_optimizer = optim.AdamW(actor_module_fsdp.parameters(),
                                           lr=optim_config.lr,


### PR DESCRIPTION
When running `main_generation.py`, `ActorRolloutRefWorker` is initialized with `role='rollout'` and its `optim_config` would be set to None in `init_model`.
`_build_model_optimizer` should handle this.