### PR TITLE
adds support for override compute path

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -22,7 +22,18 @@ import hydra
 
 @hydra.main(config_path='config', config_name='ppo_trainer', version_base=None)
 def main(config):
-    run_ppo(config)
+    # Get the compute_score_path from config if specified
+    compute_score_path = config.get('compute_score_path', None)
+    
+    # Import the custom compute_score if path is provided
+    compute_score = None
+    if compute_score_path:
+        module_path, function_name = compute_score_path.rsplit('.', 1)
+        import importlib
+        module = importlib.import_module(module_path)
+        compute_score = getattr(module, function_name)
+    
+    run_ppo(config, compute_score)
 
 
 def run_ppo(config, compute_score=None):

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -22,10 +22,8 @@ import hydra
 
 @hydra.main(config_path='config', config_name='ppo_trainer', version_base=None)
 def main(config):
-    # Get the compute_score_path from config if specified
+    # Get the compute_score_path and import custom reward function if provided
     compute_score_path = config.get('compute_score_path', None)
-    
-    # Import the custom compute_score if path is provided
     compute_score = None
     if compute_score_path:
         module_path, function_name = compute_score_path.rsplit('.', 1)


### PR DESCRIPTION
It looks like main_ppo is setup to take custom reward function via the `compute_score` function, but currently there's no way to override it from `main()`.

This allows for passing in custom reward function via config, e.g.:

```
python3 -m verl.trainer.main_ppo \
    data.train_files=$DATA_DIR/train.parquet \
    data.val_files=$DATA_DIR/test.parquet \
    ...
    +compute_score_path=your_dataset.scoring_fn \
```