### PR TITLE
[fix] fix OOM when megatron loading large model by only rank 0 loads weights

### DIFF
--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -295,19 +295,22 @@ def load_megatron_model_weights(config,
         print(f"load from local dir {config.model.path}")
         local_model_path = config.model.path
 
-    # TODO: to find a better way to load mistral7b-rm lm_head
-    if 'mistral7b-rm' in config.model.path:
-        model = MistralForSequenceClassification.from_pretrained(local_model_path)  # use score head instead of lm_head
-        state_dict = model.state_dict()
-        state_dict['lm_head.weight'] = state_dict['score.weight']
-        state_dict['model.embed_tokens.weight'] = state_dict[
-            'model.embed_tokens.weight'][:32000]  # workaround, 32001 -> 32000
-        is_value_model = True
-    else:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-        model = AutoModelForCausalLM.from_pretrained(local_model_path)
-        state_dict = model.state_dict()
+    from verl.utils.fsdp_utils import get_init_weight_context_manager
+    init_context = get_init_weight_context_manager(use_meta_tensor=not model_config.tie_word_embeddings)
+    with init_context(), warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        # TODO: to find a better way to load mistral7b-rm lm_head
+        if 'mistral7b-rm' in config.model.path:
+            model = MistralForSequenceClassification.from_pretrained(
+                local_model_path)  # use score head instead of lm_head
+            state_dict = model.state_dict()
+            state_dict['lm_head.weight'] = state_dict['score.weight']
+            state_dict['model.embed_tokens.weight'] = state_dict[
+                'model.embed_tokens.weight'][:32000]  # workaround, 32001 -> 32000
+            is_value_model = True
+        else:
+            model = AutoModelForCausalLM.from_pretrained(local_model_path)
+            state_dict = model.state_dict()
 
     from verl.models.weight_loader_registry import get_weight_loader
     print(f'before weight loader: architectures = {architectures}...')


### PR DESCRIPTION
**Problem**
Currently, when the Megatron worker loads a model, every rank loads the checkpoint (ckpt). For large models, this often causes out-of-memory (OOM) errors.

**Solution**
To address this, we've modified the process so that only rank 0 loads the actual model weights. This significantly reduces memory usage during model loading and prevents OOM issues.

**Test**
The solution has been tested on a 4 node H800 system, with each node equipped with 800GB of RAM, successfully loading the Megatron Qwen2.5-32B model without encountering OOM errors.