### PR TITLE
[fix] Fix evaluation file path in remax training scripts.

### DIFF
--- a/examples/remax_trainer/run_qwen2.5-3b_seq_balance.sh
+++ b/examples/remax_trainer/run_qwen2.5-3b_seq_balance.sh
@@ -8,7 +8,7 @@ export VLLM_ATTENTION_BACKEND=XFORMERS
 python3 -m verl.trainer.main_ppo \
     algorithm.adv_estimator=remax \
     data.train_files=$HOME/data/gsm8k/train.parquet \
-    data.val_files=$HOME/data/gsm8k/train.parquet \
+    data.val_files=$HOME/data/gsm8k/test.parquet \
     data.train_batch_size=512 \
     data.max_prompt_length=512 \
     data.max_response_length=1024 \

--- a/examples/remax_trainer/run_qwen2.5-7b_seq_balance.sh
+++ b/examples/remax_trainer/run_qwen2.5-7b_seq_balance.sh
@@ -8,7 +8,7 @@ export VLLM_ATTENTION_BACKEND=XFORMERS
 python3 -m verl.trainer.main_ppo \
     algorithm.adv_estimator=remax \
     data.train_files=$HOME/data/gsm8k/train.parquet \
-    data.val_files=$HOME/data/gsm8k/train.parquet \
+    data.val_files=$HOME/data/gsm8k/test.parquet \
     data.train_batch_size=1024 \
     data.max_prompt_length=512 \
     data.max_response_length=1024 \


### PR DESCRIPTION
The current training script utilizes the same file during training and evaluation. It is surmised that this may be incorrect.