### PR TITLE
[Fix] RLHFDataset state not fully resumed after loading from checkpoint

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -820,6 +820,8 @@ class RayPPOTrainer(object):
         if os.path.exists(dataloader_local_path):
             dataloader_state_dict = torch.load(dataloader_local_path)
             self.train_dataloader.load_state_dict(dataloader_state_dict)
+            if isinstance(self.train_dataloader.dataset, RLHFDataset):
+                self.train_dataloader.dataset.resume_dataset_state()
         else:
             print(f"Warning: No dataloader state found at {dataloader_local_path}, will start from scratch")
 


### PR DESCRIPTION
## In short
https://github.com/volcengine/verl/commit/96d98ccb2acd1f8e653d167a03ba58a5dff03f01 replaced `DataLoader` with `StatefulDataLoader`, but forgot to call `RLHFDataset. resume_dataset_state`.

---
## In detail:

When serializing `RLHFDataset`, `dataframe` is removed: https://github.com/volcengine/verl/blob/60c921475576e251fa1b846a243bffe8a296c101/verl/utils/dataset/rl_dataset.py#L164-L171
So when loading dataloader state from checkpoint, we should rebuild `dataframe`, otherwise `RLHFDataset` will not have a valid `dataframe`, which will raise an error at: https://github.com/volcengine/verl/blob/60c921475576e251fa1b846a243bffe8a296c101/verl/utils/dataset/rl_dataset.py#L128-L129

