### PR TITLE
Update vLLM>=0.7 doc

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -103,6 +103,7 @@ class vLLMRollout(BaseRollout):
             disable_log_stats=config.disable_log_stats,
             max_num_batched_tokens=max_num_batched_tokens,
             enable_chunked_prefill=config.enable_chunked_prefill,
+            enable_prefix_caching=True,
         )
 
         # Offload vllm model to reduce peak memory usage


### PR DESCRIPTION
Because of the ongoing updates in vLLM, I noticed that veRL currently cannot integrate with the nightly build of vLLM directly. The new DP feature in the nightly version can no longer be bypassed by simply adjusting the `data_parallel_size` parameter, and resolving this requires further investigation.

As a temporary workaround, I recommend a customized installation of vLLM if the V1 engine is required. I have updated the relevant documentation accordingly to reflect this guidance.