### PR TITLE
[bugfix] Grammar Error of eos_token_id in naive_rollout.py

### DIFF
--- a/verl/workers/rollout/naive/naive_rollout.py
+++ b/verl/workers/rollout/naive/naive_rollout.py
@@ -57,8 +57,8 @@ class NaiveRollout(BaseRollout):
 
         # used to construct attention_mask
         eos_token_id = prompts.meta_info['eos_token_id']
-        if isinstance(eos_token, int):
-            eos_token = [eos_token]
+        if isinstance(eos_token_id, int):
+            eos_token_id = [eos_token_id]
 
         batch_size = idx.size(0)
         prompt_length = idx.size(1)


### PR DESCRIPTION
虽然 naive_rollout 大概率没什么人用，但这里存在语法错误，eos_token 和 eos_token_id