### PR TITLE
Resolve the issue of PRIME getting stuck during math verification.

### DIFF
--- a/verl/utils/reward_score/prime_math/__init__.py
+++ b/verl/utils/reward_score/prime_math/__init__.py
@@ -34,23 +34,33 @@ BAD_SUBSTRINGS = ["^{", "^("]
 BAD_REGEXES = ["\^[0-9]+\^", "\^[0-9][0-9]+"]
 TUPLE_CHARS = "()[]"
 
+
 def timeout(timeout_seconds: int = 8):
     if os.name == "posix":
         import signal
+
         def decorator(func):
+
             def handler(signum, frame):
                 raise TimeoutError("Operation timed out!")
+
             def wrapper(*args, **kwargs):
                 old_handler = signal.getsignal(signal.SIGALRM)
                 signal.signal(signal.SIGALRM, handler)
                 signal.alarm(timeout_seconds)
+
                 try:
                     return func(*args, **kwargs)
                 finally:
                     signal.alarm(0)
                     signal.signal(signal.SIGALRM, old_handler)
+
             return wrapper
+
         return decorator
+    else:
+        raise NotImplementedError(f"Unsupported OS: {os.name}")
+
 
 def _sympy_parse(expr: str):
     """Parses an expression with sympy."""
@@ -224,6 +234,7 @@ def should_allow_eval(expr: str):
             return False
 
     return True
+
 
 @timeout(timeout_seconds=10)
 def are_equal_under_sympy(ground_truth_normalized: str, given_normalized: str):


### PR DESCRIPTION
Since searching for an appropriate `simplify` algorithm may cause `sympy.simplify` to timeout, and `ProcessPool` may get stuck due to excessive concurrency, the timeout mechanism in `verl/verl/workers/reward_manager/prime.py` cannot capture the timeout. To address this issue, a timeout detection mechanism is added to `verl/verl/utils/reward_score/prime_math/__init__.py` for `sympy.simplify` to solve it easily.