### PR TITLE
[fix] use bicubic resampler for resizing image

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -59,12 +59,12 @@ def process_image(image: dict, max_pixels: int = 2048 * 2048, min_pixels: int = 
     if (image.width * image.height) > max_pixels:
         resize_factor = math.sqrt(max_pixels / (image.width * image.height))
         width, height = int(image.width * resize_factor), int(image.height * resize_factor)
-        image = image.resize((width, height), resample=Image.Resampling.NEAREST)
+        image = image.resize((width, height))
 
     if (image.width * image.height) < min_pixels:
         resize_factor = math.sqrt(min_pixels / (image.width * image.height))
         width, height = int(image.width * resize_factor), int(image.height * resize_factor)
-        image = image.resize((width, height), resample=Image.Resampling.NEAREST)
+        image = image.resize((width, height))
 
     if image.mode != 'RGB':
         image = image.convert('RGB')

--- a/verl/utils/reward_score/geo3k.py
+++ b/verl/utils/reward_score/geo3k.py
@@ -17,7 +17,7 @@ from mathruler.grader import extract_boxed_content, grade_answer
 
 
 def format_reward(predict_str: str) -> float:
-    pattern = re.compile(r'<think>.*</think>.*', re.DOTALL)
+    pattern = re.compile(r'<think>.*</think>.*\\boxed\{.*\}.*', re.DOTALL)
     match_result = re.fullmatch(pattern, predict_str)
     return 1.0 if match_result else 0.0
 


### PR DESCRIPTION
Similar to https://github.com/hiyouga/LLaMA-Factory/issues/7125

Change the downsample strategy from nearest to bicubic