### PR TITLE
[fix] support for extra_info in prime mode

### DIFF
--- a/verl/workers/reward_manager/prime.py
+++ b/verl/workers/reward_manager/prime.py
@@ -43,7 +43,12 @@ async def single_compute_score(evaluation_func, completion, reference, task, tas
         return None  # Default value for failed rows
 
 
-async def parallel_compute_score_async(evaluation_func, completions, references, tasks, extra_info=None, num_processes=64):
+async def parallel_compute_score_async(evaluation_func,
+                                       completions,
+                                       references,
+                                       tasks,
+                                       extra_info=None,
+                                       num_processes=64):
     scores = []
     with ProcessPoolExecutor(max_workers=num_processes) as executor:
         if extra_info is None:

--- a/verl/workers/reward_manager/prime.py
+++ b/verl/workers/reward_manager/prime.py
@@ -22,7 +22,7 @@ from verl import DataProto
 from verl.utils.reward_score import _default_compute_score
 
 
-async def single_compute_score(evaluation_func, completion, reference, task, executor, timeout=300.):
+async def single_compute_score(evaluation_func, completion, reference, task, task_extra_info, executor, timeout=300.):
     loop = asyncio.get_running_loop()
     try:
         # Ensure process_completion is called properly
@@ -30,7 +30,7 @@ async def single_compute_score(evaluation_func, completion, reference, task, exe
             asyncio.wait_for(
                 loop.run_in_executor(
                     executor,
-                    partial(evaluation_func, task, completion, reference)  # Ensure synchronous
+                    partial(evaluation_func, task, completion, reference, task_extra_info)  # Ensure synchronous
                 ),
                 timeout=timeout)
         ]
@@ -43,13 +43,15 @@ async def single_compute_score(evaluation_func, completion, reference, task, exe
         return None  # Default value for failed rows
 
 
-async def parallel_compute_score_async(evaluation_func, completions, references, tasks, num_processes=64):
+async def parallel_compute_score_async(evaluation_func, completions, references, tasks, extra_info=None, num_processes=64):
     scores = []
     with ProcessPoolExecutor(max_workers=num_processes) as executor:
+        if extra_info is None:
+            extra_info = [None] * len(tasks)
         # Create tasks for all rows
         tasks_async = [
-            single_compute_score(evaluation_func, completion, reference, task, executor, timeout=300.)
-            for completion, reference, task in zip(completions, references, tasks)
+            single_compute_score(evaluation_func, completion, reference, task, task_extra_info, executor, timeout=300.)
+            for completion, reference, task, task_extra_info in zip(completions, references, tasks, extra_info)
         ]
         # to prevent very occasional starvation caused by some anomalous programs ( like infinite loop ), the exceptions in async programs will instantly halt the evaluation, and all summoned processes will be killed.
         try:
@@ -104,14 +106,16 @@ class PrimeRewardManager:
         response_str = self.tokenizer.batch_decode(response_ids, skip_special_tokens=True)
         ground_truth = [data_item.non_tensor_batch['reward_model']['ground_truth'] for data_item in data]
         data_sources = data.non_tensor_batch['data_source']
+        extra_info = data.non_tensor_batch.get('extra_info', [None] * len(data_sources))
 
-        assert len(response_str) == len(ground_truth) == len(data_sources)
+        assert len(response_str) == len(ground_truth) == len(data_sources) == len(extra_info)
         try:
             scores = asyncio.run(
                 parallel_compute_score_async(self.compute_score,
                                              response_str,
                                              ground_truth,
                                              data_sources,
+                                             extra_info,
                                              num_processes=64))
         except asyncio.TimeoutError as e:
             print('Global timeout in reward computing! Setting all as 0.')


### PR DESCRIPTION
### What does this PR do?
In the `naive` mode, passing `extra_info` information for reward function calculation is supported(https://github.com/volcengine/verl/pull/266), but the support for the `prime` mode is missing. This will cause the reward functions that use `extra_info` to fail to produce correct results in the `prime` mode. This commit fixes this issue.
### Who can review?
@PeterSH6 @vermouth1992 @hiyouga or other people who have the authority?
