### PR TITLE
[CI] feat: auto cancel previous CI in the same PR

### DIFF
--- a/.github/workflows/dataset.yml
+++ b/.github/workflows/dataset.yml
@@ -18,6 +18,11 @@ on:
       - "**/*.py"
       - .github/workflows/dataset.yml
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read

--- a/.github/workflows/e2e_digit_completion.yml
+++ b/.github/workflows/e2e_digit_completion.yml
@@ -19,6 +19,11 @@ on:
       - .github/workflows/e2e_digit_completion.yml
       - "tests/e2e/*.sh"
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read

--- a/.github/workflows/e2e_gsm8k.yml
+++ b/.github/workflows/e2e_gsm8k.yml
@@ -19,6 +19,11 @@ on:
       - .github/workflows/e2e_gsm8k.yml
       - "tests/e2e/*.sh"
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read

--- a/.github/workflows/e2e_gsm8k_megatron.yml
+++ b/.github/workflows/e2e_gsm8k_megatron.yml
@@ -19,6 +19,11 @@ on:
       - .github/workflows/e2e_gsm8k_megatron.yml
       - "tests/e2e/*.sh"
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read

--- a/.github/workflows/e2e_lora.yml
+++ b/.github/workflows/e2e_lora.yml
@@ -19,6 +19,11 @@ on:
       - .github/workflows/e2e_lora.yml
       - "tests/e2e/*.sh"
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read

--- a/.github/workflows/e2e_sft.yml
+++ b/.github/workflows/e2e_sft.yml
@@ -19,6 +19,11 @@ on:
       - .github/workflows/e2e_sft.yml
       - "tests/e2e/*.sh"
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read

--- a/.github/workflows/ray_test.yml
+++ b/.github/workflows/ray_test.yml
@@ -18,6 +18,11 @@ on:
       - "**/*.py"
       - .github/workflows/ray_test.yml
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -18,6 +18,11 @@ on:
       - "**/*.py"
       - .github/workflows/sandbox.yml
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run sanity test
         run: |
           pytest -s -x tests/sanity
-      - name: Run untility test
+      - name: Run utility test
         run: |
           pytest -s -x tests/utility
       - name: Run license test

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -18,6 +18,11 @@ on:
       - "**/*.py"
       - .github/workflows/sanity.yml
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read

--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -18,6 +18,11 @@ on:
       - "**/*.py"
       - .github/workflows/vllm.yml
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read

--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -56,7 +56,7 @@ jobs:
           pip3 install --upgrade vllm
           cd tests/rollout
           torchrun --standalone --nnodes=1 --nproc_per_node=4 $(which pytest) -s test_vllm_spmd.py
-      - name: Run QWen 0.5B generation test
+      - name: Run Qwen 0.5B generation test
         run: |
           cd tests/generation
           bash ./run_gen_qwen05.sh 4 $HOME/data/gen/qwen_05_gen_test.parquet

--- a/.github/workflows/yapf_format.yml
+++ b/.github/workflows/yapf_format.yml
@@ -18,6 +18,11 @@ on:
       - "**/*.py"
       - .github/workflows/yapf_format.yml
 
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 # Declare permissions just read content.
 permissions: 
   contents: read


### PR DESCRIPTION
- [x] Add concurrency to workflows to cancel previous workflows when new commit is pushed to the same branch.
- [ ] Cancel all workflows/jobs from the same commit if any fails? (Not sure whether we really need it)

Note: we leave out `secrets_scan.yml` and `scorecard.yml` to avoid any possible leakage or security risk, which also cost little.