### PR TITLE
[bugfix] Fix position embedding processing for Qwen2.5-VL

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -163,7 +163,8 @@ class RLHFDataset(Dataset):
 
         prompt_with_chat_template = self.tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=False)
 
-        if self.image_key in row_dict:  # expand image token
+        is_multi_modal = self.image_key in row_dict
+        if is_multi_modal:  # expand image token
             raw_prompt = prompt_with_chat_template.replace('<image>', '<|vision_start|><|image_pad|><|vision_end|>')
             row_dict['multi_modal_data'] = {'image': [process_image(image) for image in row_dict.pop(self.image_key)]}
             image_inputs = self.processor.image_processor(row_dict['multi_modal_data']['image'], return_tensors='pt')
@@ -194,7 +195,7 @@ class RLHFDataset(Dataset):
                                                                          left_pad=True,
                                                                          truncation=self.truncation)
 
-        if self.image_key in row_dict:
+        if is_multi_modal:
             from verl.models.transformers.qwen2_vl import get_rope_index
 
             position_ids = get_rope_index(


### PR DESCRIPTION
[bugfix] Fix position embedding processing for Qwen2.5-VL

In the `RLHFDataset.__getitem__` method, a bug was identified in how multimodal position IDs (3D in Qwen2.5-VL) are determined. Previously, the code checked for `self.image_key in row_dict` to decide whether to use multimodal position IDs. However, since `self.image_key` is popped from `row_dict` during image token expansion, this check incorrectly fails for subsequent operations.

This causes the VL model to use incorrect position IDs, resulting in significant performance degradation. 

<img width="349" alt="image" src="https://github.com/user-attachments/assets/79790bbf-239e-4667-a2c5-d63d91d63165" />


The fix introduces an explicit `is_multi_modal` flag to properly track multimodal content throughout the processing pipeline.