### PR TITLE
[misc] add assertion for normalized ppo_mini_batch_size

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -115,6 +115,7 @@ class ActorRolloutRefWorker(Worker):
         if self._is_actor:
             self.config.actor.ppo_mini_batch_size *= self.config.rollout.n
             self.config.actor.ppo_mini_batch_size //= (self.device_mesh.size() // self.ulysses_sequence_parallel_size)
+            assert self.config.actor.ppo_mini_batch_size > 0, f'ppo_mini_batch_size {self.config.actor.ppo_mini_batch_size} should be larger than 0 after normalization'
             # micro bsz
             if self.config.actor.ppo_micro_batch_size is not None:
                 self.config.actor.ppo_micro_batch_size //= (self.device_mesh.size() //


### PR DESCRIPTION
assert ppo_mini_batch_size > 0 after normalized, could avoid batch.split(self.config.ppo_mini_batch_size) endless loop when ppo_mini_batch_size is 0. It may cause update policy model stuck when pre process data.

loop in tensor_dict.split: 
```
while idx1 < max_size:
    idx0 = idx1
    idx1 = min(max_size, idx1 + split_size)  # will always be 0 when split_size is 0
    split_sizes.append(slice(idx0, idx1))
    batch_sizes.append(
        torch.Size(
            tuple(
                d if i != dim else idx1 - idx0
                for i, d in enumerate(batch_size)
            )
        )
    )
```