### PR TITLE
[feat] add auto padding for DataProto

### DIFF
--- a/tests/ray/test_auto_padding.py
+++ b/tests/ray/test_auto_padding.py
@@ -1,0 +1,114 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ray
+import torch
+import numpy as np
+
+from verl import DataProto
+from verl.protocol import DataProtoConfig
+from verl.single_controller.base import Worker
+from verl.single_controller.base.decorator import register, Dispatch
+from verl.single_controller.ray.base import RayResourcePool, RayClassWithInitArgs, RayWorkerGroup
+
+# or set env var VERL_AUTO_PADDING = "1" / "true"
+DataProtoConfig.auto_padding = True
+
+
+@ray.remote
+class Actor(Worker):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def add(self, data: DataProto):
+        data.batch['a'] += self.rank
+        return data
+
+
+def test_auto_padding():
+    ray.init(num_cpus=100)
+
+    chunk_size = 4
+    actor_cls = RayClassWithInitArgs(cls=Actor)
+    resource_pool = RayResourcePool(process_on_nodes=[chunk_size], use_gpu=False)
+    actor_wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=actor_cls)
+
+    # test locally first
+    for test_size in range(4, 20):
+        local_data = DataProto.from_dict({"a": torch.zeros(test_size)}, {"na": np.zeros(test_size, dtype=object)})
+        # print(f"before padding, local_data = {local_data}")
+        padding_size = (chunk_size - (test_size % chunk_size)) if (test_size % chunk_size > 0) else 0
+        local_data.padding(padding_size)
+        # print(f"after padding, local_data = {local_data}")
+        assert len(local_data) == len(local_data) + len(
+            local_data
+        ) % chunk_size, f"expecting padded length to be {len(local_data) + len(local_data) % chunk_size}, but got {len(local_data)}"
+        chunked = local_data.chunk(chunk_size)
+        assert len(chunked) == chunk_size, f"during test_size = {test_size}, expecting {chunk_size}, got {chunked}"
+        for dp in chunked:
+            assert len(dp) == test_size // chunk_size + bool(
+                test_size % chunk_size
+            ), f"test size = {test_size}, expecting dp to be length of {test_size // chunk_size + bool(test_size % chunk_size)}, but got {len(dp)}: {dp} {chunked}"
+
+    # test with RayWorkerGroup method decorated as dispatch_mode=Dispatch.DP_COMPUTE_PROTO
+    data = DataProto.from_dict({"a": torch.zeros(10)}, {"na": np.array([str(i) for i in range(10)], dtype=object)})
+    output = actor_wg.add(data)
+
+    print(output.batch["a"])
+    assert len(output) == 10
+
+    data = DataProto.from_dict({"a": torch.zeros(1)}, {"na": np.array([str(i) for i in range(1)], dtype=object)})
+    output = actor_wg.add(data)
+
+    print(output.batch["a"])
+    assert len(output) == 1
+
+    data = DataProto.from_dict({"a": torch.zeros(8)}, {"na": np.array([str(i) for i in range(8)], dtype=object)})
+    output = actor_wg.add(data)
+
+    print(output.batch["a"])
+    assert len(output) == 8
+
+    # test data proto specific config
+    DataProtoConfig.auto_padding = False
+
+    data = DataProto.from_dict({"a": torch.zeros(10)}, {"na": np.array([str(i) for i in range(10)], dtype=object)},
+                               auto_padding=True)
+    output = actor_wg.add(data)
+    print(output.batch["a"])
+    assert len(output) == 10
+
+    data = DataProto.from_single_dict({
+        "a": torch.zeros(1),
+        "na": np.array([str(i) for i in range(1)], dtype=object)
+    },
+                                      auto_padding=True)
+    output = actor_wg.add(data)
+
+    print(output.batch["a"])
+    assert len(output) == 1
+
+    data = DataProto.from_single_dict({"a": torch.zeros(8), "na": np.array([str(i) for i in range(8)], dtype=object)})
+    output = actor_wg.add(data)
+
+    print(output.batch["a"])
+    assert len(output) == 8
+
+    ray.shutdown()
+
+
+if __name__ == "__main__":
+    test_auto_padding()

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -49,7 +49,7 @@ class _DataProtoConfigMeta(type):
     def auto_padding(self):
         enabled_by_env = os.getenv("VERL_AUTO_PADDING", "FALSE").upper() in ["TRUE", "1"]
         return enabled_by_env or self._config.get(self._verl_auto_padding, False)
-    
+
     @auto_padding.setter
     def auto_padding(self, enabled: bool):
         assert isinstance(enabled, bool), f"enabled must be a boolean, got {enabled} as {type(enabled)}"
@@ -60,9 +60,7 @@ class DataProtoConfig(metaclass=_DataProtoConfigMeta):
     pass
 
 
-
 _padding_size_key = "_padding_size_key_x123d"
-
 
 
 def pad_dataproto_to_divisor(data: 'DataProto', size_divisor: int):
@@ -341,10 +339,18 @@ class DataProto:
             else:
                 raise ValueError(f'Unsupported type in data {type(val)}')
 
-        return DataProto.from_dict(tensors=tensors, non_tensors=non_tensors, meta_info=meta_info, auto_padding=auto_padding)
+        return DataProto.from_dict(tensors=tensors,
+                                   non_tensors=non_tensors,
+                                   meta_info=meta_info,
+                                   auto_padding=auto_padding)
 
     @classmethod
-    def from_dict(cls, tensors: Dict[str, torch.Tensor], non_tensors=None, meta_info=None, num_batch_dims=1, auto_padding=False):
+    def from_dict(cls,
+                  tensors: Dict[str, torch.Tensor],
+                  non_tensors=None,
+                  meta_info=None,
+                  num_batch_dims=1,
+                  auto_padding=False):
         """Create a DataProto from a dict of tensors. This assumes that
         1. All the tensor in tensors have the same dim0
         2. Only dim0 is the batch dim
@@ -626,11 +632,11 @@ class DataProto:
                     yield d
 
         return iter(get_data())
-    
+
     def is_padding_enabled(self):
         dataproto_specific_padding = self.meta_info.get(DataProtoConfig._verl_auto_padding, False)
         return dataproto_specific_padding or DataProtoConfig.auto_padding
-    
+
     def padding(self, padding_size, padding_candidate=""):
         """Pad the DataProto by concating with padding_candidate.repeat(padding_size)
 
@@ -677,7 +683,7 @@ class DataProto:
                 DataProto(batch=batch_lst[i], non_tensor_batch=non_tensor_batch_lst[i], meta_info=self.meta_info))
 
         return output
-    
+
     def index_select(self, index):
         """index select along the batch dimension
 

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -46,14 +46,14 @@ class _DataProtoConfigMeta(type):
     _verl_auto_padding = "_verl_auto_padding"
 
     @property
-    def auto_padding(self):
+    def auto_padding(cls):
         enabled_by_env = os.getenv("VERL_AUTO_PADDING", "FALSE").upper() in ["TRUE", "1"]
-        return enabled_by_env or self._config.get(self._verl_auto_padding, False)
+        return enabled_by_env or cls._config.get(cls._verl_auto_padding, False)
 
     @auto_padding.setter
-    def auto_padding(self, enabled: bool):
+    def auto_padding(cls, enabled: bool):
         assert isinstance(enabled, bool), f"enabled must be a boolean, got {enabled} as {type(enabled)}"
-        self._config[self._verl_auto_padding] = enabled
+        cls._config[cls._verl_auto_padding] = enabled
 
 
 class DataProtoConfig(metaclass=_DataProtoConfigMeta):

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -83,6 +83,7 @@ def _split_args_kwargs_data_proto(chunks, *args, __padding_127xcd7=False, **kwar
 
     return splitted_args, splitted_kwargs
 
+
 def dispatch_one_to_all(worker_group, *args, **kwargs):
     args = tuple([arg] * worker_group.world_size for arg in args)
     kwargs = {k: [v] * worker_group.world_size for k, v in kwargs.items()}

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -53,7 +53,7 @@ def _split_args_kwargs_data_proto(chunks, *args, __padding_127xcd7=False, **kwar
     padding_size = None
     for arg in args:
         assert isinstance(arg, (DataProto, DataProtoFuture))
-        if isinstance(arg, DataProto) and __padding_127xcd7 and arg.is_dp_padding_enabled():
+        if isinstance(arg, DataProto) and __padding_127xcd7 and arg.is_padding_enabled():
             # for padding, we only support DataProto with same length
             if data_proto_len is None:
                 data_proto_len = len(arg)
@@ -69,7 +69,7 @@ def _split_args_kwargs_data_proto(chunks, *args, __padding_127xcd7=False, **kwar
 
     for key, val in kwargs.items():
         assert isinstance(val, (DataProto, DataProtoFuture))
-        if isinstance(val, DataProto) and __padding_127xcd7 and val.is_dp_padding_enabled():
+        if isinstance(val, DataProto) and __padding_127xcd7 and val.is_padding_enabled():
             # for padding, we only support DataProto with same length
             if data_proto_len is None:
                 data_proto_len = len(val)
@@ -297,9 +297,14 @@ def collect_dp_compute(worker_group, output):
 
 
 def dispatch_dp_compute_data_proto(worker_group, *args, **kwargs):
+    from verl.protocol import DataProtoConfig
     from verl.single_controller.base.worker_group import WorkerGroup
     assert isinstance(worker_group, WorkerGroup)
-    splitted_args, splitted_kwargs = _split_args_kwargs_data_proto(worker_group.world_size, *args, **kwargs)
+    splitted_args, splitted_kwargs = _split_args_kwargs_data_proto(
+        worker_group.world_size,
+        *args,
+        __padding_127xcd7=True,  # enable for dp_compute
+        **kwargs)
     return splitted_args, splitted_kwargs
 
 

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -16,7 +16,9 @@ from enum import Enum
 from functools import wraps
 from typing import Dict, List, Tuple
 from types import FunctionType
+
 from verl.protocol import DataProtoFuture
+from verl.protocol import _padding_size_key
 
 # here we add a magic number of avoid user-defined function already have this attribute
 MAGIC_ATTR = 'attrs_3141562937'
@@ -42,20 +44,44 @@ class Execute(Enum):
     RANK_ZERO = 1
 
 
-def _split_args_kwargs_data_proto(chunks, *args, **kwargs):
+def _split_args_kwargs_data_proto(chunks, *args, __padding_127xcd7=False, **kwargs):
     from verl.protocol import DataProto, DataProtoFuture
     splitted_args = []
+    splitted_kwargs = {}
+
+    data_proto_len = None
+    padding_size = None
     for arg in args:
         assert isinstance(arg, (DataProto, DataProtoFuture))
+        if isinstance(arg, DataProto) and __padding_127xcd7 and arg.is_dp_padding_enabled():
+            # for padding, we only support DataProto with same length
+            if data_proto_len is None:
+                data_proto_len = len(arg)
+                padding_size = (chunks - (data_proto_len % chunks)) if (data_proto_len % chunks > 0) else 0
+                splitted_kwargs[_padding_size_key] = padding_size
+            else:
+                assert data_proto_len == len(arg), (f"expecting all arg share same length of {data_proto_len}, "
+                                                    f"but got {len(arg)}")
+                data_proto_len = len(arg)
+            arg.padding(padding_size=padding_size)
+
         splitted_args.append(arg.chunk(chunks=chunks))
 
-    splitted_kwargs = {}
     for key, val in kwargs.items():
         assert isinstance(val, (DataProto, DataProtoFuture))
+        if isinstance(val, DataProto) and __padding_127xcd7 and val.is_dp_padding_enabled():
+            # for padding, we only support DataProto with same length
+            if data_proto_len is None:
+                data_proto_len = len(val)
+                padding_size = chunks - (data_proto_len % chunks)
+                splitted_kwargs[_padding_size_key] = padding_size
+            else:
+                assert data_proto_len == len(val), (f"expecting all arg share same length of {data_proto_len}, "
+                                                    f"but got {len(val)}")
+                data_proto_len = len(val)
         splitted_kwargs[key] = val.chunk(chunks=chunks)
 
     return splitted_args, splitted_kwargs
-
 
 def dispatch_one_to_all(worker_group, *args, **kwargs):
     args = tuple([arg] * worker_group.world_size for arg in args)

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -116,7 +116,7 @@ class Worker(WorkerHelper):
             os.environ.update(rank_zero_info)
 
     def __init__(self, cuda_visible_devices=None) -> None:
-        # construct a meta from envrionment variable. Note that the import must be inside the class because it is executed remotely
+        # construct a meta from environment variable. Note that the import must be inside the class because it is executed remotely
         import os
 
         ###
@@ -124,9 +124,11 @@ class Worker(WorkerHelper):
         import torch
         ###
 
+        amd_enabled = torch.cuda.is_available() and "AMD" in torch.cuda.get_device_name()
+
         ###
         # [SUPPORT AMD: torch]
-        if "AMD" in torch.cuda.get_device_name():
+        if amd_enabled:
             os.environ['CUDA_VISIBLE_DEVICES'] = os.environ.get('ROCR_VISIBLE_DEVICES')
             os.environ['LOCAL_RANK'] = os.environ.get('RAY_LOCAL_RANK')
         ###
@@ -144,13 +146,8 @@ class Worker(WorkerHelper):
 
         ###
         # [SUPPORT AMD: torch]
-        if "AMD" in torch.cuda.get_device_name():
+        if amd_enabled:
             self.local_rank = int(os.environ['LOCAL_RANK'])
-        ###
-
-        ###
-        # [SUPPORT AMD: torch]
-        if "AMD" in torch.cuda.get_device_name():
             cuda_visible_devices = str(local_rank)
         ###
 
@@ -171,7 +168,7 @@ class Worker(WorkerHelper):
         ###
         # [SUPPORT AMD: torch]
         # torch.cuda.set_device(local_rank)
-        if "AMD" in torch.cuda.get_device_name():
+        if amd_enabled:
             torch.cuda.set_device(int(cuda_visible_devices))
         ###
 

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -46,7 +46,7 @@ def func_generator(self, method_name, dispatch_fn, collect_fn, execute_fn, block
         if padding_count > 0:
             if isinstance(output, DataProto):
                 indices = [i for i in range(len(output))][:-padding_count]
-                output = output.index_select(indices)
+                output = output.select_idxs(indices)
             elif isinstance(output, list):
                 output = output[:-padding_count]
         return output


### PR DESCRIPTION
Instead of requiring user to manually repeat `DataProto` to meat the dp size of a `WorkerGroup`, auto_padding options pad the DataProto when chunk is called.
This feat is turned off by default and can be activate globally as well as dataproto-specifically