### PR TITLE
[Part 1/2] Refactor actor training logic into ActorEnvironment

### DIFF
--- a/verl/trainer/ppo/actor_env.py
+++ b/verl/trainer/ppo/actor_env.py
@@ -18,7 +18,6 @@ This is the default ActorEnvironment that performs the rollout and actor update.
 import uuid
 import numpy as np
 from copy import deepcopy
-from .ray_trainer import _timer, reduce_metrics, AdvantageEstimator
 
 class ActorEnvironment:
     def __init__(self, config, actor_rollout_wg, reward_fn):
@@ -27,6 +26,8 @@ class ActorEnvironment:
         self.reward_fn = reward_fn
 
     def step(self, timing_raw, gen_batch):
+        from verl.trainer.ppo.ray_trainer import _timer, AdvantageEstimator
+
         # generate a batch
         with _timer('gen', timing_raw):
             gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
@@ -54,6 +55,8 @@ class ActorEnvironment:
         batch = batch.union(gen_batch_output)
 
     def update(self, timing_raw, batch, metrics):
+        from verl.trainer.ppo.ray_trainer import _timer, reduce_metrics
+
         with _timer('update_actor', timing_raw):
             actor_output = self.actor_rollout_wg.update_actor(batch)
         actor_output_metrics = reduce_metrics(actor_output.meta_info['metrics'])

--- a/verl/trainer/ppo/actor_env.py
+++ b/verl/trainer/ppo/actor_env.py
@@ -19,7 +19,9 @@ import uuid
 import numpy as np
 from copy import deepcopy
 
+
 class ActorEnvironment:
+
     def __init__(self, config, actor_rollout_wg, reward_fn):
         self.config = config
         self.actor_rollout_wg = actor_rollout_wg
@@ -48,8 +50,7 @@ class ActorEnvironment:
 
                 del gen_baseline_batch, gen_baseline_output
 
-        batch.non_tensor_batch['uid'] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
-                                                    dtype=object)
+        batch.non_tensor_batch['uid'] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object)
         # repeat to align with repeated responses in rollout
         batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
         batch = batch.union(gen_batch_output)

--- a/verl/trainer/ppo/actor_env.py
+++ b/verl/trainer/ppo/actor_env.py
@@ -25,7 +25,7 @@ class ActorEnvironment:
         self.actor_rollout_wg = actor_rollout_wg
         self.reward_fn = reward_fn
 
-    def step(self, timing_raw, gen_batch):
+    def step(self, batch, gen_batch, timing_raw):
         from verl.trainer.ppo.ray_trainer import _timer, AdvantageEstimator
 
         # generate a batch

--- a/verl/trainer/ppo/actor_env.py
+++ b/verl/trainer/ppo/actor_env.py
@@ -54,6 +54,8 @@ class ActorEnvironment:
         batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
         batch = batch.union(gen_batch_output)
 
+        return batch
+
     def update(self, timing_raw, batch, metrics):
         from verl.trainer.ppo.ray_trainer import _timer, reduce_metrics
 
@@ -61,3 +63,5 @@ class ActorEnvironment:
             actor_output = self.actor_rollout_wg.update_actor(batch)
         actor_output_metrics = reduce_metrics(actor_output.meta_info['metrics'])
         metrics.update(actor_output_metrics)
+
+        return actor_output

--- a/verl/trainer/ppo/actor_env.py
+++ b/verl/trainer/ppo/actor_env.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This is the default ActorEnvironment that performs the rollout and actor update.
+"""
+
+import uuid
+import numpy as np
+from copy import deepcopy
+from .ray_trainer import _timer, reduce_metrics, AdvantageEstimator
+
+class ActorEnvironment:
+    def __init__(self, config, actor_rollout_wg, reward_fn):
+        self.config = config
+        self.actor_rollout_wg = actor_rollout_wg
+        self.reward_fn = reward_fn
+
+    def step(self, timing_raw, gen_batch):
+        # generate a batch
+        with _timer('gen', timing_raw):
+            gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
+
+        if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
+            with _timer('gen_max', timing_raw):
+                gen_baseline_batch = deepcopy(gen_batch)
+                gen_baseline_batch.meta_info['do_sample'] = False
+                gen_baseline_output = self.actor_rollout_wg.generate_sequences(gen_baseline_batch)
+
+                batch = batch.union(gen_baseline_output)
+                reward_baseline_tensor = self.reward_fn(batch)
+                reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
+
+                batch.pop(batch_keys=list(gen_baseline_output.batch.keys()))
+
+                batch.batch['reward_baselines'] = reward_baseline_tensor
+
+                del gen_baseline_batch, gen_baseline_output
+
+        batch.non_tensor_batch['uid'] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
+                                                    dtype=object)
+        # repeat to align with repeated responses in rollout
+        batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
+        batch = batch.union(gen_batch_output)
+
+    def update(self, timing_raw, batch, metrics):
+        with _timer('update_actor', timing_raw):
+            actor_output = self.actor_rollout_wg.update_actor(batch)
+        actor_output_metrics = reduce_metrics(actor_output.meta_info['metrics'])
+        metrics.update(actor_output_metrics)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -934,7 +934,7 @@ class RayPPOTrainer(object):
 
                 with _timer('step', timing_raw):
                     # generate a batch with actor
-                    self.actor_environment.step(timing_raw, gen_batch)
+                    batch = self.actor_environment.step(timing_raw, gen_batch)
 
                     # balance the number of valid tokens on each dp rank.
                     # Note that this breaks the order of data inside the batch.
@@ -1000,7 +1000,7 @@ class RayPPOTrainer(object):
 
                     # implement critic warmup
                     if self.config.trainer.critic_warmup <= self.global_steps:
-                        self.actor_environment.update(timing_raw, batch, metrics)
+                        actor_output = self.actor_environment.update(timing_raw, batch, metrics)
 
                     # validate
                     if self.val_reward_fn is not None and self.config.trainer.test_freq > 0 and \

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -17,13 +17,11 @@ This trainer supports model-agonistic model initialization with huggingface
 """
 
 import os
-import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
 from pprint import pprint
 from typing import Type, Dict
-from copy import deepcopy
 
 import ray
 import numpy as np
@@ -35,6 +33,7 @@ from verl.single_controller.base import Worker
 from verl.single_controller.ray import RayResourcePool, RayWorkerGroup, RayClassWithInitArgs
 from verl.single_controller.ray.base import create_colocated_worker_cls
 from verl.trainer.ppo import core_algos
+from verl.trainer.ppo.actor_env import ActorEnvironment
 from verl.utils.seqlen_balancing import get_seqlen_balanced_partitions, log_seqlen_unbalance
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path
 from verl.utils.dataset.rl_dataset import RLHFDataset, collate_fn
@@ -401,7 +400,8 @@ class RayPPOTrainer(object):
                  ray_worker_group_cls: RayWorkerGroup = RayWorkerGroup,
                  processor=None,
                  reward_fn=None,
-                 val_reward_fn=None):
+                 val_reward_fn=None,
+                 actor_environment: ActorEnvironment = ActorEnvironment):
 
         # assert torch.cuda.is_available(), 'cuda must be available on driver'
 
@@ -410,6 +410,7 @@ class RayPPOTrainer(object):
         self.config = config
         self.reward_fn = reward_fn
         self.val_reward_fn = val_reward_fn
+        self.actor_environment = actor_environment
 
         self.hybrid_engine = config.actor_rollout_ref.hybrid_engine
         assert self.hybrid_engine, 'Currently, only support hybrid engine'
@@ -932,31 +933,8 @@ class RayPPOTrainer(object):
                 is_last_step = self.global_steps >= self.total_training_steps
 
                 with _timer('step', timing_raw):
-                    # generate a batch
-                    with _timer('gen', timing_raw):
-                        gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
-
-                    if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
-                        with _timer('gen_max', timing_raw):
-                            gen_baseline_batch = deepcopy(gen_batch)
-                            gen_baseline_batch.meta_info['do_sample'] = False
-                            gen_baseline_output = self.actor_rollout_wg.generate_sequences(gen_baseline_batch)
-
-                            batch = batch.union(gen_baseline_output)
-                            reward_baseline_tensor = self.reward_fn(batch)
-                            reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
-
-                            batch.pop(batch_keys=list(gen_baseline_output.batch.keys()))
-
-                            batch.batch['reward_baselines'] = reward_baseline_tensor
-
-                            del gen_baseline_batch, gen_baseline_output
-
-                    batch.non_tensor_batch['uid'] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
-                                                             dtype=object)
-                    # repeat to align with repeated responses in rollout
-                    batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
-                    batch = batch.union(gen_batch_output)
+                    # generate a batch with actor
+                    self.actor_environment.step(timing_raw, gen_batch)
 
                     # balance the number of valid tokens on each dp rank.
                     # Note that this breaks the order of data inside the batch.
@@ -1022,11 +1000,7 @@ class RayPPOTrainer(object):
 
                     # implement critic warmup
                     if self.config.trainer.critic_warmup <= self.global_steps:
-                        # update actor
-                        with _timer('update_actor', timing_raw):
-                            actor_output = self.actor_rollout_wg.update_actor(batch)
-                        actor_output_metrics = reduce_metrics(actor_output.meta_info['metrics'])
-                        metrics.update(actor_output_metrics)
+                        self.actor_environment.update(timing_raw, batch, metrics)
 
                     # validate
                     if self.val_reward_fn is not None and self.config.trainer.test_freq > 0 and \


### PR DESCRIPTION
This is part 1/2 for the issue #501. This PR addresses provides the following features:
- This is a refactor of the actor logic found in `RayPPOTrainer.fit()`, no new functionality added.
- This creates extensibility, allowing the user to define their own ActorEnvironment and pass it through their own `main_ppo.py` script.
- When a user passes a custom environment, it creates the possibility to create a custom handling of rollouts for a use-case, which will enable part 2 of #501.

Part 2 will come in the future after a lot more experimentation on the specific use-case as outlined in #501.