### PR TITLE
[Part 1/2] Refactor actor training logic into ActorEnvironment

### DIFF
--- a/verl/trainer/ppo/actor_env.py
+++ b/verl/trainer/ppo/actor_env.py
@@ -21,10 +21,29 @@ from copy import deepcopy
 
 
 class ActorEnvironment:
-    def __init__(self, config, actor_rollout_wg, reward_fn):
+
+    def __init__(self):
+        pass
+
+    def post_init(self, config, actor_rollout_wg, reward_fn, tokenizer, processor):
+        """A post init function that adds the essentials for the training loop
+        after initializing the ActorEnvironment class.
+
+        Args:
+            config: The veRL config.
+            actor_rollout_wg: The actor rollout worker group.
+            reward_fn: The reward function.
+            tokenizer: The tokenizer.
+            processor: The processor (multimodal).
+            
+        Returns:
+            Batch: Enriched batch containing generated sequences, rewards, and metadata
+        """
         self.config = config
         self.actor_rollout_wg = actor_rollout_wg
         self.reward_fn = reward_fn
+        self.tokenizer = tokenizer
+        self.processor = processor
 
     def step(self, batch, gen_batch, timing_raw):
         """Performs a rollout step to generate sequences and compute rewards.

--- a/verl/trainer/ppo/actor_env.py
+++ b/verl/trainer/ppo/actor_env.py
@@ -1,0 +1,68 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This is the default ActorEnvironment that performs the rollout and actor update.
+"""
+
+import uuid
+import numpy as np
+from copy import deepcopy
+
+
+class ActorEnvironment:
+
+    def __init__(self, config, actor_rollout_wg, reward_fn):
+        self.config = config
+        self.actor_rollout_wg = actor_rollout_wg
+        self.reward_fn = reward_fn
+
+    def step(self, batch, gen_batch, timing_raw):
+        from verl.trainer.ppo.ray_trainer import _timer, AdvantageEstimator
+
+        # generate a batch
+        with _timer('gen', timing_raw):
+            gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
+
+        if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
+            with _timer('gen_max', timing_raw):
+                gen_baseline_batch = deepcopy(gen_batch)
+                gen_baseline_batch.meta_info['do_sample'] = False
+                gen_baseline_output = self.actor_rollout_wg.generate_sequences(gen_baseline_batch)
+
+                batch = batch.union(gen_baseline_output)
+                reward_baseline_tensor = self.reward_fn(batch)
+                reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
+
+                batch.pop(batch_keys=list(gen_baseline_output.batch.keys()))
+
+                batch.batch['reward_baselines'] = reward_baseline_tensor
+
+                del gen_baseline_batch, gen_baseline_output
+
+        batch.non_tensor_batch['uid'] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object)
+        # repeat to align with repeated responses in rollout
+        batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
+        batch = batch.union(gen_batch_output)
+
+        return batch
+
+    def update(self, timing_raw, batch, metrics):
+        from verl.trainer.ppo.ray_trainer import _timer, reduce_metrics
+
+        with _timer('update_actor', timing_raw):
+            actor_output = self.actor_rollout_wg.update_actor(batch)
+        actor_output_metrics = reduce_metrics(actor_output.meta_info['metrics'])
+        metrics.update(actor_output_metrics)
+
+        return actor_output

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -401,7 +401,7 @@ class RayPPOTrainer(object):
                  processor=None,
                  reward_fn=None,
                  val_reward_fn=None,
-                 actor_environment=None):
+                 actor_environment=ActorEnvironment()):
 
         # assert torch.cuda.is_available(), 'cuda must be available on driver'
 
@@ -777,13 +777,12 @@ class RayPPOTrainer(object):
         self.actor_rollout_wg.init_model()
 
         # initialize actor environment
-        if self.actor_environment is None:
-            self.actor_environment = ActorEnvironment
-
-        self.actor_environment = self.actor_environment(
-            self.config,
-            self.actor_rollout_wg,
-            self.reward_fn,
+        self.actor_environment.post_init(
+            config=self.config,
+            actor_rollout_wg=self.actor_rollout_wg,
+            reward_fn=self.reward_fn,
+            tokenizer=self.tokenizer,
+            processor=self.processor,
         )
 
     def _save_checkpoint(self):


### PR DESCRIPTION
This is part 1/2 for the issue #501. This PR addresses provides the following features:
- This is a refactor of the actor logic found in `RayPPOTrainer.fit()`, no new functionality added.
- This creates extensibility, allowing the user to define their own ActorEnvironment and pass it through their own `main_ppo.py` script.
- When a user passes a custom environment, it creates the possibility to create a custom handling of rollouts for a use-case, which will enable part 2 of #501.

Part 2 will come in the future after a lot more experimentation on the specific use-case as outlined in #501.