### PR TITLE
fix: remove a empty_cache #575 missed

### DIFF
--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -112,7 +112,7 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False):
 
 
 @torch.no_grad()
-def offload_fsdp_model_to_cpu(model: FSDP, empty_cache: bool = True):
+def offload_fsdp_model_to_cpu(model: FSDP):
     assert isinstance(model, FSDP)
     # lazy init FSDP model
     _lazy_init(model, model)
@@ -128,8 +128,6 @@ def offload_fsdp_model_to_cpu(model: FSDP, empty_cache: bool = True):
         # the following still keeps id(._local_shard) != id(.data)
         flat_param._local_shard = flat_param.data
         assert id(flat_param._local_shard) != id(flat_param.data)
-    if empty_cache:
-        torch.cuda.empty_cache()
 
 
 @torch.no_grad()


### PR DESCRIPTION
Pending...
***
~~https://github.com/volcengine/verl/pull/575 removed all `torch.cuda.empty_cache()` in `verl/workers/fsdp_workers.py`, but fsdp_workers calls `offload_fsdp_model_to_cpu`, which has `torch.cuda.empty_cache()` that was missed.~~

https://github.com/volcengine/verl/blob/e7c40b3531f82d4502a0bf8b74f0d3796f9dac82/verl/workers/fsdp_workers.py#L531

https://github.com/volcengine/verl/blob/e7c40b3531f82d4502a0bf8b74f0d3796f9dac82/verl/utils/fsdp_utils.py#L115-L132
