### PR TITLE
[fix] support setting CUDA_VISIBLE_DEVICES environment variable for Ray tasks

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -16,6 +16,7 @@ Note that we don't combine the main with ray_trainer as ray_trainer is used by o
 """
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer
 
+import os
 import ray
 import hydra
 
@@ -59,6 +60,7 @@ def run_ppo(config) -> None:
         # this is for local ray cluster
         ray.init(runtime_env={
             'env_vars': {
+                'CUDA_VISIBLE_DEVICES': os.environ.get('CUDA_VISIBLE_DEVICES'),
                 'TOKENIZERS_PARALLELISM': 'true',
                 'NCCL_DEBUG': 'WARN',
                 'VLLM_LOGGING_LEVEL': 'WARN'


### PR DESCRIPTION
https://github.com/volcengine/verl/issues/589
This update introduces support for setting the CUDA_VISIBLE_DEVICES environment variable for tasks running in Ray. By configuring this environment variable, users can control which GPUs are visible to Ray workers, providing better management of resources, especially in multi-GPU environments.