### PR TITLE
[bugfix] remove redundant and harmful metric appending

### DIFF
--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -325,6 +325,5 @@ class DataParallelPPOActor(BasePPOActor):
 
                 grad_norm = self._optimizer_step()
                 data = {'actor/grad_norm': grad_norm.detach().item()}
-            append_to_dict(metrics, data)
         self.actor_optimizer.zero_grad()
         return metrics


### PR DESCRIPTION
this line is unnecessary can cause error to metric reduce