### PR TITLE
support multiturn prompt for SFT

### DIFF
--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -89,6 +89,9 @@ class FSDPSFTTrainer(object):
         if self.config.data.chat_template is not None:
             raise ValueError('Apply Chat template from config is not supported yet.')
 
+        if self.tokenizer.chat_template is None:
+            logger.log(msg="Empty chat template!", level=logging.WARNING)
+
         # normalize dp size
         self._normalize_config_bsz()
 


### PR DESCRIPTION
# What is this PR about

Current implementation of [SFTDataset](https://github.com/volcengine/verl/blob/main/verl/utils/dataset/sft_dataset.py#L110-L121) only supports single turn prompt. This PR adds support for multi-turn prompt which is in messages format.