### PR TITLE
[tracking] swanlab add `verl` config

### DIFF
--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -58,7 +58,7 @@ class Tracking(object):
                 swanlab.login(SWANLAB_API_KEY)  # NOTE: previous login information will be overwritten
             swanlab.init(project=project_name,
                          experiment_name=experiment_name,
-                         config=config,
+                         config={"FRAMEWORK": "veRL", **config},
                          logdir=SWANLAB_LOG_DIR,
                          mode=SWANLAB_MODE)
             self.logger["swanlab"] = swanlab

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -58,7 +58,10 @@ class Tracking(object):
                 swanlab.login(SWANLAB_API_KEY)  # NOTE: previous login information will be overwritten
             swanlab.init(project=project_name,
                          experiment_name=experiment_name,
-                         config={"FRAMEWORK": "veRL", **config},
+                         config={
+                             "FRAMEWORK": "veRL",
+                             **config
+                         },
                          logdir=SWANLAB_LOG_DIR,
                          mode=SWANLAB_MODE)
             self.logger["swanlab"] = swanlab


### PR DESCRIPTION
Add `verl` as the `framework` parameter to the SwanLab config table, so more developers can see that this training comes from `verl`.