### PR TITLE
Make Math-Verify Optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "datasets",
     "dill",
     "hydra-core",
-    "math-verify",
     "numpy",
     "pandas",
     "peft",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ test = [
 prime = ["pyext"]
 gpu = ["liger-kernel", "flash-attn"]
 sglang = ["sglang[all]==0.4.3.post3"]
+math = ["math-verify"]  # Add math-verify as an optional dependency
 
 # URLs
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ dill
 flash-attn
 hydra-core
 liger-kernel
-math-verify[antlr4_9_3]
 numpy
 pandas
 peft

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ install_requires = [
   'datasets',
   'dill',
   'hydra-core',
-  'math-verify',
   'numpy',
   'pandas',
   'peft',

--- a/setup.py
+++ b/setup.py
@@ -45,12 +45,14 @@ TEST_REQUIRES = ['pytest', 'yapf', 'py-spy']
 PRIME_REQUIRES = ['pyext']
 GEO_REQUIRES = ['mathruler']
 GPU_REQUIRES = ['liger-kernel', 'flash-attn']
+MATH_REQUIRES = ['math-verify']  # Add math-verify as an optional dependency
 
 extras_require = {
   'test': TEST_REQUIRES,
   'prime': PRIME_REQUIRES,
   'geo': GEO_REQUIRES,
   'gpu': GPU_REQUIRES,
+  'math': MATH_REQUIRES,
 }
 
 from pathlib import Path

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -19,12 +19,16 @@ def _default_compute_score(data_source, solution_str, ground_truth, extra_info=N
         from . import gsm8k
         res = gsm8k.compute_score(solution_str, ground_truth)
     elif data_source in ['lighteval/MATH', 'DigitalLearningGmbH/MATH-lighteval']:
-        # from . import math
-        # res = math.compute_score(solution_str, ground_truth)
+        from . import math
+        res = math.compute_score(solution_str, ground_truth)
 
-        # Use Math-Verify (https://github.com/huggingface/Math-Verify) for better evaluation accuracy
-        from . import math_verify
-        res = math_verify.compute_score(solution_str, ground_truth)
+        # [Optional] Math-Verify Integration
+        # For enhanced accuracy, consider utilizing Math-Verify (https://github.com/huggingface/Math-Verify).
+        # Note: Math-Verify needs to be manually installed via pip: `pip install math-verify`.
+        # To use it, override the `compute_score` function with the following implementation:
+
+        # from . import math_verify
+        # res = math_verify.compute_score(solution_str, ground_truth)
     elif data_source in [
             'numina_aops_forum', 'numina_synthetic_math', 'numina_amc_aime', 'numina_synthetic_amc', 'numina_cn_k12',
             'numina_olympiads'

--- a/verl/utils/reward_score/math_verify.py
+++ b/verl/utils/reward_score/math_verify.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from math_verify.metric import math_metric
-from math_verify.parser import LatexExtractionConfig, ExprExtractionConfig
+try:
+    from math_verify.metric import math_metric
+    from math_verify.parser import LatexExtractionConfig, ExprExtractionConfig
+except ImportError:
+    print("To use Math-Verify, please install it first by running `pip install math-verify`.")
 
 
 def compute_score(model_output: str, ground_truth: str) -> bool:
@@ -28,6 +31,6 @@ def compute_score(model_output: str, ground_truth: str) -> bool:
     try:
         ret_score, _ = verify_func([ground_truth_boxed], [model_output])
     except Exception as e:
-        print(e)
+        pass
 
     return ret_score


### PR DESCRIPTION
https://github.com/volcengine/verl/issues/680

Changes:
- Move math-verify to the optional dependencies. Now it can be installed via `cd verl && pip install -e .[math]`
- Revert using naive verifier for math dataset. Users can switch to math-verify or custom a new `compute_score` function.
