### PR TITLE
Fix checkpoint loading in fsdp_checkpoint_manager.py and ray_trainer.py

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -736,7 +736,7 @@ class RayPPOTrainer(object):
         # TODO: from remote not implemented yet
         dataloader_local_path = os.path.join(global_step_folder, 'data.pt')
         if os.path.exists(dataloader_local_path):
-            dataloader_state_dict = torch.load(dataloader_local_path)
+            dataloader_state_dict = torch.load(dataloader_local_path, weights_only=False)
             self.train_dataloader.load_state_dict(dataloader_state_dict)
         else:
             print(f"Warning: No dataloader state found at {dataloader_local_path}, will start from scratch")

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -73,9 +73,9 @@ class FSDPCheckpointManager(BaseCheckpointManager):
         local_optim_path = copy_to_local(remote_optim_path)
         local_extra_state_path = copy_to_local(remote_extra_state_path)
 
-        model_state_dict = torch.load(local_model_path)
-        optimizer_state_dict = torch.load(local_optim_path)
-        extra_state_dict = torch.load(local_extra_state_path)
+        model_state_dict = torch.load(local_model_path, weights_only=False)
+        optimizer_state_dict = torch.load(local_optim_path, weights_only=False)
+        extra_state_dict = torch.load(local_extra_state_path, weights_only=False)
 
         if del_local_after_load:
             try:


### PR DESCRIPTION
This PR addresses an issue with checkpoint loading by explicitly setting `weights_only=False` in the `torch.load` function calls. This change is necessary because torch 2.6 changed the default value of the `weights_only` parameter from `False` to `True`, causing unpickling errors when loading checkpoints containing numpy arrays.

Changes:
- Modified `torch.load` call in `fsdp_checkpoint_manager.py` to explicitly set `weights_only=False`
- Modified `torch.load` call in `ray_trainer.py` line 739 to explicitly set `weights_only=False` for dataloader state loading

The fix is minimal and only affects the checkpoint loading functionality while ensuring compatibility with torch 2.6.