### PR TITLE
fix: remove torch.cuda.set_device in cpu-only ray remoter

### DIFF
--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -148,12 +148,6 @@ class Worker(WorkerHelper):
             self.local_rank = int(os.environ['LOCAL_RANK'])
         ###
 
-        ###
-        # [SUPPORT AMD: torch]
-        if "AMD" in torch.cuda.get_device_name():
-            cuda_visible_devices = str(local_rank)
-        ###
-
         store = {
             '_world_size': world_size,
             '_rank': rank,
@@ -168,12 +162,6 @@ class Worker(WorkerHelper):
         meta = WorkerMeta(store=store)
         self._configure_with_meta(meta=meta)
 
-        ###
-        # [SUPPORT AMD: torch]
-        # torch.cuda.set_device(local_rank)
-        if "AMD" in torch.cuda.get_device_name():
-            torch.cuda.set_device(int(cuda_visible_devices))
-        ###
 
     def _configure_with_meta(self, meta: WorkerMeta):
         """


### PR DESCRIPTION
When I run verl in rocm devices, I got the following error:

[36m(TaskRunner pid=1221, ip=33.198.200.45)[0m DeprecationWarning: `ray.state.available_resources_per_node` is a private attribute and access will be removed in a future Ray version.
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m Uncaught exception in compile_worker subprocess
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m Traceback (most recent call last):
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m   File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/torch/_inductor/compile_worker/__main__.py", line 38, in main
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m     pre_fork_setup()
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m   File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/torch/_inductor/async_compile.py", line 59, in pre_fork_setup
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m     caching_device_properties()
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m   File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/torch/_inductor/async_compile.py", line 75, in caching_device_properties
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m     device_interface.Worker.get_device_properties()
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m   File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/torch/_dynamo/device_interface.py", line 185, in get_device_properties
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m     device_prop = [
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m   File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/torch/_dynamo/device_interface.py", line 186, in <listcomp>
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m     torch.cuda.get_device_properties(i)
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m   File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/torch/cuda/__init__.py", line 527, in get_device_properties
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m     return _get_device_properties(device)  # type: ignore[name-defined]
[36m(WorkerDict pid=20504, ip=33.198.200.45)[0m **RuntimeError: device >= 0 && device < num_gpus INTERNAL** ASSERT FAILED at "/data/fuweiy/pytorch_build/pytorch/aten/src/ATen/hip/HIPContext.cpp":50, please report a bug to PyTorch. device=1, num_gpus=
Traceback (most recent call last):
  File "/checkpoint/binary/train_package/verl/trainer/main_ppo.py", line 199, in <module>
    main()
  File "/checkpoint/binary/train_package/verl/trainer/main_ppo.py", line 85, in main
    run_ppo(cfg)
  File "/checkpoint/binary/train_package/verl/trainer/main_ppo.py", line 96, in run_ppo
    ray.get(runner.run.remote(config))
  File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
  File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/ray/_private/worker.py", line 2782, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/ray/_private/worker.py", line 929, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(ActorDiedError): [36mray::TaskRunner.run()[39m (pid=1221, ip=33.198.200.45, actor_id=5a9adcd01a8070a64764d1e801000000, repr=<main_ppo.TaskRunner object at 0x7fd0a65c1d80>)
  File "/checkpoint/binary/train_package/verl/trainer/main_ppo.py", line 194, in run
    trainer.init_workers()
  File "/checkpoint/binary/train_package/verl/trainer/ppo/ray_trainer.py", line 653, in init_workers
    self.critic_wg.init_model()
  File "/checkpoint/binary/train_package/verl/single_controller/ray/base.py", line 42, in func
    output = ray.get(output)
ray.exceptions.ActorDiedError: The actor died because of an error raised in its creation task, [36mray::GoRFn0WorkerDict_0:3:WorkerDict.__init__()[39m (pid=20727, ip=33.198.200.45, actor_id=b2d4d9931d5772e0ad9b387901000000, repr=<verl.single_controller.ray.base.WorkerDict object at 0x7fa366e34340>)
  File "/checkpoint/binary/train_package/verl/single_controller/ray/base.py", line 463, in __init__
    super().__init__()
  **File "/checkpoint/binary/train_package/verl/single_controller/base/worker.py", line 175, in __init__
    torch.cuda.set_device(int(cuda_visible_devices))
  File "/opt/conda/envs/python3.10.13/lib/python3.10/site-packages/torch/cuda/__init__.py", line 478, in set_device
    torch._C._cuda_setDevice(device)
RuntimeError: HIP error: invalid device ordinal
HIP kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.**
For debugging consider passing AMD_SERIALIZE_KERNEL=3
Compile with `TORCH_USE_HIP_DSA` to enable device-side assertions.


the root cause is that we call torch.cuda.set_device() inside:
`runner = TaskRunner.remote()`
`ray.get(runner.run.remote(config))`

and runner.run is a ray remote function which only allocates with a cpu resource only:
`@ray.remote(num_cpus=1)  # please make sure main_task is not scheduled on head`
`class TaskRunner:`
 So if we all torch.cuda.set_device inside run.remote, no cuda(rocm) device can be found 