### PR TITLE
[feat] add wake_up level to reduce vllm GPU memory usage peak

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -435,6 +435,7 @@ class ActorRolloutRefWorker(Worker):
                 lr_scheduler=self.actor_lr_scheduler,
                 processing_class=self.processor if self.processor is not None else self.tokenizer,
                 checkpoint_contents=self.config.actor.checkpoint.contents)
+        torch.cuda.empty_cache()
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def update_actor(self, data: DataProto):


### PR DESCRIPTION
# Reduce GPU Memory Peak Usage with wake_up Levels
This PR introduces the wake-up function in vLLM to reduce peak GPU memory usage during model initialization, especially for large models like Qwen2.5-7B.

**Key Features**
* Parameters:
level=1: Load both model weights and KV cache in a staged manner. (default version)
level=2: Load only model weights gradually.
level=3: Load only the KV cache gradually.
* Helps delay and distribute GPU memory allocation during startup to prevent OOM issues.
* Tested with GRPO on 8 and 32 GPUs: peak GPU memory usage reduced by ~10 GB for Qwen2.5-7B, enabling inference on more constrained hardware.

VLLM code https://github.com/yqyao/vllm/tree/wake_up_v0.8.1