### PR TITLE
Fix padding length for sglang rollout in veRL

### DIFF
--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -210,7 +210,6 @@ class SGLangRollout(BaseRollout):
             idx_list.append(_pre_process_inputs(self.pad_token_id, idx[i]))
 
         do_sample = prompts.meta_info.get("do_sample", True)
-        pad_length = self.config.response_length
         if not do_sample:
             # kwargs = {
             #     'top_p': 1.0,

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -229,11 +229,10 @@ class SGLangRollout(BaseRollout):
                 top_k=-1,
                 ignore_eos=False,
                 min_new_tokens=0,
-                max_new_tokens=4096,
+                max_new_tokens=self.config.response_length,
                 skip_special_tokens=True,
                 spaces_between_special_tokens=True,
             )
-            pad_length = max(pad_length, 4096)
         # users can customize different sampling_params at different run
         with self.update_sampling_params(**kwargs):
             print(f"{self.sampling_params=}")

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -248,9 +248,9 @@ class SGLangRollout(BaseRollout):
         response = out[0].to(idx.device)
         log_probs = out[1].to(idx.device)
 
-        if response.shape[1] < pad_length:
-            response = pad_sequence_to_length(response, pad_length, self.pad_token_id)
-            log_probs = pad_sequence_to_length(log_probs, pad_length, self.pad_token_id)
+        if response.shape[1] < self.config.response_length:
+            response = pad_sequence_to_length(response, self.config.response_length, self.pad_token_id)
+            log_probs = pad_sequence_to_length(log_probs, self.config.response_length, self.pad_token_id)
         if self.config.n > 1 and do_sample:
             idx = idx.repeat_interleave(self.config.n, dim=0)
             attention_mask = attention_mask.repeat_interleave(self.config.n, dim=0)


### PR DESCRIPTION
Fixed a portion of the issues encountered during VLM GPTO training as mentioned in the article. 
https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/rlhf/verl/veRL-VLM.md

When do_sample=False, different models under DP output sequences of inconsistent lengths, which may be padded to different lengths, ultimately causing shape inconsistencies during output and resulting in errors in collect_dp_compute_data_proto. The following situation occurred: 
```
DataProto(batch=TensorDict(
    fields={
        attention_mask: Tensor(shape=torch.Size([151, 5120]), device=cpu, dtype=torch.int64, is_shared=False),
        input_ids: Tensor(shape=torch.Size([151, 5120]), device=cpu, dtype=torch.int64, is_shared=False),
        position_ids: Tensor(shape=torch.Size([151, 5120]), device=cpu, dtype=torch.int64, is_shared=False),
        prompts: Tensor(shape=torch.Size([151, 1024]), device=cpu, dtype=torch.int64, is_shared=False),
        responses: Tensor(shape=torch.Size([151, 4096]), device=cpu, dtype=torch.int64, is_shared=False)},
    batch_size=torch.Size([151]),
    device=cpu,
    is_shared=False), non_tensor_batch={}, meta_info={}), DataProto(batch=TensorDict(
    fields={
        attention_mask: Tensor(shape=torch.Size([151, 5120]), device=cpu, dtype=torch.int64, is_shared=False),
        input_ids: Tensor(shape=torch.Size([151, 5120]), device=cpu, dtype=torch.int64, is_shared=False),
        position_ids: Tensor(shape=torch.Size([151, 5120]), device=cpu, dtype=torch.int64, is_shared=False),
        prompts: Tensor(shape=torch.Size([151, 1024]), device=cpu, dtype=torch.int64, is_shared=False),
        responses: Tensor(shape=torch.Size([151, 4096]), device=cpu, dtype=torch.int64, is_shared=False)},
    batch_size=torch.Size([151]),
    device=cpu,
    is_shared=False), non_tensor_batch={}, meta_info={}), DataProto(batch=TensorDict(
    fields={
        attention_mask: Tensor(shape=torch.Size([151, 3072]), device=cpu, dtype=torch.int64, is_shared=False),
        input_ids: Tensor(shape=torch.Size([151, 3072]), device=cpu, dtype=torch.int64, is_shared=False),
        position_ids: Tensor(shape=torch.Size([151, 3072]), device=cpu, dtype=torch.int64, is_shared=False),
        prompts: Tensor(shape=torch.Size([151, 1024]), device=cpu, dtype=torch.int64, is_shared=False),
        responses: Tensor(shape=torch.Size([151, 2048]), device=cpu, dtype=torch.int64, is_shared=False)},
    batch_size=torch.Size([151]),
    device=cpu,
    is_shared=False), non_tensor_batch={}, meta_info={}), DataProto(batch=TensorDict(
    fields={
        attention_mask: Tensor(shape=torch.Size([151, 3072]), device=cpu, dtype=torch.int64, is_shared=False),
        input_ids: Tensor(shape=torch.Size([151, 3072]), device=cpu, dtype=torch.int64, is_shared=False),
        position_ids: Tensor(shape=torch.Size([151, 3072]), device=cpu, dtype=torch.int64, is_shared=False),
        prompts: Tensor(shape=torch.Size([151, 1024]), device=cpu, dtype=torch.int64, is_shared=False),
        responses: Tensor(shape=torch.Size([151, 2048]), device=cpu, dtype=torch.int64, is_shared=False)},
    batch_size=torch.Size([151]),
    device=cpu,
    is_shared=False), non_tensor_batch={}, meta_info={})]
```

This modification resolves this issue.