### PR TITLE
In the GRPO example scripts, modify the `entropy_coeff` to 0 to ensure consistency with the GRPO paper.

### DIFF
--- a/examples/grpo_trainer/run_deepseek7b_llm.sh
+++ b/examples/grpo_trainer/run_deepseek7b_llm.sh
@@ -17,6 +17,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \

--- a/examples/grpo_trainer/run_deepseek7b_llm_math.sh
+++ b/examples/grpo_trainer/run_deepseek7b_llm_math.sh
@@ -27,6 +27,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \

--- a/examples/grpo_trainer/run_deepseek7b_llm_math_megatron.sh
+++ b/examples/grpo_trainer/run_deepseek7b_llm_math_megatron.sh
@@ -29,6 +29,7 @@ python3 -m verl.trainer.main_ppo --config-path=config \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=4 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=2 \

--- a/examples/grpo_trainer/run_deepseek7b_llm_megatron.sh
+++ b/examples/grpo_trainer/run_deepseek7b_llm_megatron.sh
@@ -20,6 +20,7 @@ python3 -m verl.trainer.main_ppo --config-path=config \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=4 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=2 \

--- a/examples/grpo_trainer/run_deepseek7b_llm_seq_balance.sh
+++ b/examples/grpo_trainer/run_deepseek7b_llm_seq_balance.sh
@@ -18,6 +18,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \

--- a/examples/grpo_trainer/run_qwen2-7b.sh
+++ b/examples/grpo_trainer/run_qwen2-7b.sh
@@ -19,6 +19,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \

--- a/examples/grpo_trainer/run_qwen2-7b_math.sh
+++ b/examples/grpo_trainer/run_qwen2-7b_math.sh
@@ -27,6 +27,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \

--- a/examples/grpo_trainer/run_qwen2-7b_math_megatron.sh
+++ b/examples/grpo_trainer/run_qwen2-7b_math_megatron.sh
@@ -30,6 +30,7 @@ python3 -m verl.trainer.main_ppo --config-path=config \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=4 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=2 \

--- a/examples/grpo_trainer/run_qwen2-7b_megatron.sh
+++ b/examples/grpo_trainer/run_qwen2-7b_megatron.sh
@@ -22,6 +22,7 @@ python3 -m verl.trainer.main_ppo --config-path=config \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=4 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=2 \

--- a/examples/grpo_trainer/run_qwen2-7b_seq_balance.sh
+++ b/examples/grpo_trainer/run_qwen2-7b_seq_balance.sh
@@ -20,6 +20,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \

--- a/examples/grpo_trainer/run_qwen2_5_vl-7b.sh
+++ b/examples/grpo_trainer/run_qwen2_5_vl-7b.sh
@@ -20,6 +20,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.01 \
     actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \


### PR DESCRIPTION
The existing example GRPO scripts rely on the default configuration in `verl/trainer/config/ppo_trainer.yaml` and set the entropy_coeff to 0.001. This behavior doesn't match what's described in the GRPO paper and is quite hard to notice. In my experiments, it might be causing an entropy explosion, which results in poor performance.


<img width="505" alt="image" src="https://github.com/user-attachments/assets/0b7125c5-03c4-42ef-802c-8f83a76840ce" />


