### PR TITLE
 Implement Dual-Clip PPO Algorithm

### DIFF
--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -28,7 +28,6 @@ actor_rollout_ref:
     use_dynamic_bsz: False
     use_torch_compile: True # False to disable torch compile
     clip_ratio: 0.2
-    use_dual_clip: False # add Dual-clip PPO from https://arxiv.org/pdf/1912.09729
     clip_ratio_c: 3.0 # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
     entropy_coeff: 0.001
     use_kl_loss: False # True for GRPO

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -28,6 +28,8 @@ actor_rollout_ref:
     use_dynamic_bsz: False
     use_torch_compile: True # False to disable torch compile
     clip_ratio: 0.2
+    use_dual_clip: False # add Dual-clip PPO from https://arxiv.org/pdf/1912.09729
+    clip_ratio_c: 3 # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
     entropy_coeff: 0.001
     use_kl_loss: False # True for GRPO
     kl_loss_coef: 0.001 # for grpo

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -29,7 +29,7 @@ actor_rollout_ref:
     use_torch_compile: True # False to disable torch compile
     clip_ratio: 0.2
     use_dual_clip: False # add Dual-clip PPO from https://arxiv.org/pdf/1912.09729
-    clip_ratio_c: 3 # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
+    clip_ratio_c: 3.0 # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
     entropy_coeff: 0.001
     use_kl_loss: False # True for GRPO
     kl_loss_coef: 0.001 # for grpo

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -31,6 +31,8 @@ actor_rollout_ref:
     ppo_max_token_len_per_gpu: 16384 # n * ${data.max_prompt_length} + ${data.max_response_length}
     grad_clip: 1.0
     clip_ratio: 0.2
+    use_dual_clip: False # add Dual-clip PPO from https://arxiv.org/pdf/1912.09729
+    clip_ratio_c: 3i # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
     entropy_coeff: 0.001
     use_kl_loss: False # True for GRPO
     use_torch_compile: True # False to disable torch compile

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -32,7 +32,7 @@ actor_rollout_ref:
     grad_clip: 1.0
     clip_ratio: 0.2
     use_dual_clip: False # add Dual-clip PPO from https://arxiv.org/pdf/1912.09729
-    clip_ratio_c: 3i # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
+    clip_ratio_c: 3.0 # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
     entropy_coeff: 0.001
     use_kl_loss: False # True for GRPO
     use_torch_compile: True # False to disable torch compile

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -31,7 +31,6 @@ actor_rollout_ref:
     ppo_max_token_len_per_gpu: 16384 # n * ${data.max_prompt_length} + ${data.max_response_length}
     grad_clip: 1.0
     clip_ratio: 0.2
-    use_dual_clip: False # add Dual-clip PPO from https://arxiv.org/pdf/1912.09729
     clip_ratio_c: 3.0 # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
     entropy_coeff: 0.001
     use_kl_loss: False # True for GRPO

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -294,8 +294,8 @@ def compute_policy_loss(old_log_prob, log_prob, advantages, eos_mask, cliprange,
         ppo_kl: (float)
             the estimated KL divergence between the latest updating policy and the old sampling policy
     """
-    assert clip_ratio_c > 1.0 , f"The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0, but get the value: {clip_ratio_c}."
-    
+    assert clip_ratio_c > 1.0, f"The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0, but get the value: {clip_ratio_c}."
+
     negative_approx_kl = log_prob - old_log_prob
     ratio = torch.exp(negative_approx_kl)
     ppo_kl = verl_F.masked_mean(-negative_approx_kl, eos_mask)

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -287,19 +287,18 @@ class DataParallelPPOActor(BasePPOActor):
 
                     clip_ratio = self.config.clip_ratio
                     entropy_coeff = self.config.entropy_coeff
-                    use_dual_clip = self.config.get('use_dual_clip', False)
-                    clip_ratio_c = self.config.get('clip_ratio_c', 3)
+                    clip_ratio_c = self.config.get('clip_ratio_c', 3.0)
 
                     # all return: (bsz, response_length)
                     entropy, log_prob = self._forward_micro_batch(micro_batch=data, temperature=temperature)
 
-                    pg_loss, pg_clipfrac, ppo_kl = core_algos.compute_policy_loss(old_log_prob=old_log_prob,
-                                                                                  log_prob=log_prob,
-                                                                                  advantages=advantages,
-                                                                                  eos_mask=response_mask,
-                                                                                  cliprange=clip_ratio,
-                                                                                  use_dual_clip=use_dual_clip,
-                                                                                  clip_ratio_c=clip_ratio_c)
+                    pg_loss, pg_clipfrac, ppo_kl, pg_clipfrac_lower = core_algos.compute_policy_loss(
+                        old_log_prob=old_log_prob,
+                        log_prob=log_prob,
+                        advantages=advantages,
+                        eos_mask=response_mask,
+                        cliprange=clip_ratio,
+                        clip_ratio_c=clip_ratio_c)
                     # compute entropy loss from entropy
                     entropy_loss = verl_F.masked_mean(entropy, response_mask)
 
@@ -330,6 +329,7 @@ class DataParallelPPOActor(BasePPOActor):
                         'actor/pg_loss': pg_loss.detach().item(),
                         'actor/pg_clipfrac': pg_clipfrac.detach().item(),
                         'actor/ppo_kl': ppo_kl.detach().item(),
+                        'actor/pg_clipfrac_lower': pg_clipfrac_lower.detach().item(),
                     }
                     append_to_dict(metrics, data)
 

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -287,6 +287,8 @@ class DataParallelPPOActor(BasePPOActor):
 
                     clip_ratio = self.config.clip_ratio
                     entropy_coeff = self.config.entropy_coeff
+                    use_dual_clip = self.config.get('use_dual_clip', False)
+                    clip_ratio_c = self.config.get('clip_ratio_c', 3)
 
                     # all return: (bsz, response_length)
                     entropy, log_prob = self._forward_micro_batch(micro_batch=data, temperature=temperature)
@@ -295,7 +297,9 @@ class DataParallelPPOActor(BasePPOActor):
                                                                                   log_prob=log_prob,
                                                                                   advantages=advantages,
                                                                                   eos_mask=response_mask,
-                                                                                  cliprange=clip_ratio)
+                                                                                  cliprange=clip_ratio,
+                                                                                  use_dual_clip=use_dual_clip,
+                                                                                  clip_ratio_c=clip_ratio_c)
                     # compute entropy loss from entropy
                     entropy_loss = verl_F.masked_mean(entropy, response_mask)
 

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -277,7 +277,6 @@ class MegatronPPOActor(BasePPOActor):
 
             clip_ratio = meta_info['clip_ratio']
             entropy_coeff = meta_info['entropy_coeff']
-            use_dual_clip = meta_info['use_dual_clip']
             clip_ratio_c = meta_info['clip_ratio_c']
 
             # compute policy loss
@@ -286,13 +285,12 @@ class MegatronPPOActor(BasePPOActor):
             logits_back = logits.clone()
             log_prob = vocab_parallel_log_probs_from_logits(logits, responses)
             logits = logits_back
-            pg_loss, pg_clipfrac, ppo_kl = core_algos.compute_policy_loss(old_log_prob=old_log_prob,
-                                                                          log_prob=log_prob,
-                                                                          advantages=advantages,
-                                                                          eos_mask=response_mask,
-                                                                          cliprange=clip_ratio,
-                                                                          use_dual_clip=use_dual_clip,
-                                                                          clip_ratio_c=clip_ratio_c)
+            pg_loss, pg_clipfrac, ppo_kl, pg_clipfrac_lower = core_algos.compute_policy_loss(old_log_prob=old_log_prob,
+                                                                                             log_prob=log_prob,
+                                                                                             advantages=advantages,
+                                                                                             eos_mask=response_mask,
+                                                                                             cliprange=clip_ratio,
+                                                                                             clip_ratio_c=clip_ratio_c)
             entropy_loss = vocab_parallel_compute_entropy_loss(logits, eos_mask=response_mask)
             policy_loss = pg_loss - entropy_loss * entropy_coeff
 
@@ -314,7 +312,8 @@ class MegatronPPOActor(BasePPOActor):
                 'actor/entropy_loss': entropy_loss.detach().item(),
                 'actor/pg_loss': pg_loss.detach().item(),
                 'actor/pg_clipfrac': pg_clipfrac.detach().item(),
-                'actor/ppo_kl': ppo_kl.detach().item()
+                'actor/ppo_kl': ppo_kl.detach().item(),
+                'actor/pg_clipfrac_lower': pg_clipfrac_lower.detach().item()
             }
             append_to_dict(stats, metrics)
             return policy_loss, stats
@@ -328,12 +327,10 @@ class MegatronPPOActor(BasePPOActor):
             if forward_only:
                 meta_info = None
             else:
-                use_dual_clip = self.config.get('use_dual_clip', False)
-                clip_ratio_c = self.config.get('clip_ratio_c', 3)
+                clip_ratio_c = self.config.get('clip_ratio_c', 3.0)
                 meta_info = {
                     'clip_ratio': self.config.clip_ratio,
                     'entropy_coeff': self.config.entropy_coeff,
-                    'use_dual_clip': use_dual_clip,
                     'clip_ratio_c': clip_ratio_c
                 }
             return output, partial(loss_func, data=batch, meta_info=meta_info)


### PR DESCRIPTION
Add the [Dual-Clip PPO](https://arxiv.org/pdf/1912.09729) algorithm to enhance the current PPO implementations. The Dual-Clip PPO introduces a approach by applying a lower bound to the policy ratio when the advantage is less than zero, when multiplied by a huge raito, does not exceed a specified lower bound. The concept is illustrated in the figure below:
<img width="626" alt="Clipboard_Screenshot_1743047374" src="https://github.com/user-attachments/assets/93952edc-30c8-477e-bc3d-4770fabe55b8" />
So, the finall loss of the ppo is 
<img width="624" alt="Clipboard_Screenshot_1743047410" src="https://github.com/user-attachments/assets/5900490b-f64a-4bde-87d6-8359615b3337" />
This adjustment leads to a modified final loss calculation for the PPO, which could potentially improve training stability and performance in certain scenarios. I believe integrating this feature could provide significant benefits, and I look forward to feedback on this suggestion.
