### PR TITLE
Fix: Undefined variable name in the print_rank_0 statement

### DIFF
--- a/verl/models/llama/megatron/checkpoint_utils/llama_loader.py
+++ b/verl/models/llama/megatron/checkpoint_utils/llama_loader.py
@@ -339,7 +339,7 @@ def load_state_dict_to_megatron_llama(state_dict,
         chunk_shape = obj_list[0]
         if chunk_shape is None:
             # all or none ranks in the mp_group should reach here
-            print_rank_0(f"tp_shard tensor:[{name}] not in state_dict, skip loading")
+            print_rank_0(f"tp_shard tensor:[{q_name, k_name, v_name}] not in state_dict, skip loading")
             return
 
         if tensor is None:

--- a/verl/models/qwen2/megatron/checkpoint_utils/qwen2_loader.py
+++ b/verl/models/qwen2/megatron/checkpoint_utils/qwen2_loader.py
@@ -345,7 +345,7 @@ def load_state_dict_to_megatron_qwen2(state_dict,
         chunk_shape = obj_list[0]
         if chunk_shape is None:
             # all or none ranks in the mp_group should reach here
-            print_rank_0(f"tp_shard tensor:[{name}] not in state_dict, skip loading")
+            print_rank_0(f"tp_shard tensor:[{q_name, k_name, v_name}] not in state_dict, skip loading")
             return
 
         if tensor is None:


### PR DESCRIPTION
This PR addresses the issue where the variable name is not defined, causing a runtime error. The fix ensures that the correct variable is used for logging the message when the tensor is not found in the state dictionary.