### PR TITLE
[BREAKING config] feat: add mlflow val generation log and uri config

### DIFF
--- a/examples/split_placement/config/ppo_trainer_split.yaml
+++ b/examples/split_placement/config/ppo_trainer_split.yaml
@@ -159,7 +159,7 @@ trainer:
   project_name: verl_examples
   experiment_name: gsm8k
   logger: [ 'console', 'wandb' ]
-  val_generations_to_log_to_wandb: 0
+  log_val_generations: 0
   nnodes: 1
   n_gpus_per_node: 8
   save_freq: -1

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -178,7 +178,7 @@ trainer:
   project_name: verl_examples
   experiment_name: gsm8k
   logger: ['console', 'wandb']
-  val_generations_to_log_to_wandb: 0
+  log_val_generations: 0
   nnodes: 1
   n_gpus_per_node: 8
   save_freq: -1

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -182,7 +182,7 @@ trainer:
   project_name: verl_examples
   experiment_name: gsm8k
   logger: [ 'console', 'wandb' ]
-  val_generations_to_log_to_wandb: 0
+  log_val_generations: 0
   nnodes: 1
   n_gpus_per_node: 8
   save_freq: -1

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -462,7 +462,7 @@ class RayPPOTrainer(object):
     def _maybe_log_val_generations(self, inputs, outputs, scores):
         """Log a table of validation samples to the configured logger (wandb or swanlab)"""
 
-        generations_to_log = self.config.trainer.val_generations_to_log_to_wandb
+        generations_to_log = self.config.trainer.log_val_generations
 
         if generations_to_log == 0:
             return


### PR DESCRIPTION
### Changes

- Add mlflow validation generation in `ValidationGenerationsLogger` in the form of MLFlow artifact files.
- Add the config of `MLFLOW_TRACKING_URI` in mlflow tracking. 
- rename `val_generations_to_log_to_wandb` to `log_val_generations`

### Test
Tested in the self-host mlflow servers. 