### PR TITLE
fix: update assertion of ppo_mini_batch_size and ppo_micro_batch_size_per_gpu

### DIFF
--- a/tests/e2e/run_ray_trainer.sh
+++ b/tests/e2e/run_ray_trainer.sh
@@ -17,14 +17,14 @@ python3 tests/e2e/arithmetic_sequence/rl/main_trainer.py \
     data.return_raw_input_ids=True \
     actor_rollout_ref.model.path=tests/e2e/arithmetic_sequence/model \
     actor_rollout_ref.model.external_lib=tests.e2e.envs.digit_completion \
-    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=200 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=128 \
     actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.actor.optim.lr=1e-4 \
     actor_rollout_ref.actor.use_kl_loss=False \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=200 \
     actor_rollout_ref.rollout.name=hf \
     actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
-    critic.ppo_micro_batch_size_per_gpu=200 \
+    critic.ppo_micro_batch_size_per_gpu=128 \
     critic.model.path=tests/e2e/arithmetic_sequence/model \
     critic.optim.lr=1e-3 \
     algorithm.use_kl_in_reward=False \

--- a/tests/e2e/run_ray_trainer_fire_sampling.sh
+++ b/tests/e2e/run_ray_trainer_fire_sampling.sh
@@ -18,7 +18,7 @@ python3 tests/e2e/arithmetic_sequence/rl/main_trainer.py \
     data.return_raw_input_ids=True \
     actor_rollout_ref.model.path=tests/e2e/arithmetic_sequence/model \
     actor_rollout_ref.model.external_lib=tests.e2e.envs.digit_completion \
-    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=200 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=128 \
     actor_rollout_ref.actor.entropy_coeff=0 \
     actor_rollout_ref.actor.optim.lr=1e-4 \
     actor_rollout_ref.actor.use_kl_loss=False \
@@ -26,7 +26,7 @@ python3 tests/e2e/arithmetic_sequence/rl/main_trainer.py \
     actor_rollout_ref.rollout.name=hf \
     actor_rollout_ref.rollout.use_fire_sampling=True \
     actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
-    critic.ppo_micro_batch_size_per_gpu=200 \
+    critic.ppo_micro_batch_size_per_gpu=128 \
     critic.model.path=tests/e2e/arithmetic_sequence/model \
     critic.optim.lr=1e-3 \
     algorithm.use_kl_in_reward=False \

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -133,6 +133,8 @@ class ActorRolloutRefWorker(Worker):
                     self.device_mesh.size() // self.ulysses_sequence_parallel_size
                 )
                 self.config.actor.ppo_micro_batch_size_per_gpu = self.config.actor.ppo_micro_batch_size
+            
+            if self.config.actor.ppo_micro_batch_size_per_gpu is not None:
                 assert self.config.actor.ppo_mini_batch_size % self.config.actor.ppo_micro_batch_size_per_gpu == 0, (
                     f"normalized ppo_mini_batch_size {self.config.actor.ppo_mini_batch_size} should be divisible by ppo_micro_batch_size_per_gpu {self.config.actor.ppo_micro_batch_size_per_gpu}"
                 )
@@ -711,6 +713,8 @@ class CriticWorker(Worker):
             )
             self.config.ppo_micro_batch_size_per_gpu = self.config.ppo_micro_batch_size
             self.config.forward_micro_batch_size_per_gpu = self.config.forward_micro_batch_size
+
+        if self.config.ppo_micro_batch_size_per_gpu is not None:
             assert self.config.ppo_mini_batch_size % self.config.ppo_micro_batch_size_per_gpu == 0, (
                 f"normalized ppo_mini_batch_size {self.config.ppo_mini_batch_size} should be divisible by ppo_micro_batch_size_per_gpu {self.config.ppo_micro_batch_size_per_gpu}"
             )

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -133,7 +133,7 @@ class ActorRolloutRefWorker(Worker):
                     self.device_mesh.size() // self.ulysses_sequence_parallel_size
                 )
                 self.config.actor.ppo_micro_batch_size_per_gpu = self.config.actor.ppo_micro_batch_size
-            
+
             if self.config.actor.ppo_micro_batch_size_per_gpu is not None:
                 assert self.config.actor.ppo_mini_batch_size % self.config.actor.ppo_micro_batch_size_per_gpu == 0, (
                     f"normalized ppo_mini_batch_size {self.config.actor.ppo_mini_batch_size} should be divisible by ppo_micro_batch_size_per_gpu {self.config.actor.ppo_micro_batch_size_per_gpu}"


### PR DESCRIPTION
original assertion is inside `if`, only executed when `ppo_micro_batch_size` is not None, and otherwise may results in NaN when training

Related to [Issue #405](https://github.com/volcengine/verl/issues/405) and [PR #382](https://github.com/volcengine/verl/pull/382).