### PR TITLE
Add `mathruler` to requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ torchdata
 transformers
 # vllm==0.6.3.post1
 wandb
+mathruler


### PR DESCRIPTION
Which is required here:
https://github.com/volcengine/verl/blob/776b0a9ddc5a5a8c7d9adf07172cac774ab2afc7/verl/utils/reward_score/geo3k.py#L16