### PR TITLE
[misc] add trust_remote_code param for loading custom tokenizer

### DIFF
--- a/verl/trainer/main_generation.py
+++ b/verl/trainer/main_generation.py
@@ -58,8 +58,8 @@ def main_task(config):
     OmegaConf.resolve(config)
     local_path = copy_to_local(config.model.path)
     from verl.utils import hf_tokenizer
-    trust_remote_code=config.data.get('trust_remote_code', False)
-    tokenizer = hf_tokenizer(local_path,trust_remote_code=trust_remote_code)
+    trust_remote_code = config.data.get('trust_remote_code', False)
+    tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
 
     if config.rollout.temperature == 0.:
         assert config.data.n_samples == 1, 'When temperature=0, n_samples must be 1.'

--- a/verl/trainer/main_generation.py
+++ b/verl/trainer/main_generation.py
@@ -58,7 +58,8 @@ def main_task(config):
     OmegaConf.resolve(config)
     local_path = copy_to_local(config.model.path)
     from verl.utils import hf_tokenizer
-    tokenizer = hf_tokenizer(local_path)
+    trust_remote_code=config.data.get('trust_remote_code', False)
+    tokenizer = hf_tokenizer(local_path,trust_remote_code=trust_remote_code)
 
     if config.rollout.temperature == 0.:
         assert config.data.n_samples == 1, 'When temperature=0, n_samples must be 1.'

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -88,8 +88,8 @@ class TaskRunner:
 
         # instantiate tokenizer
         from verl.utils import hf_tokenizer, hf_processor
-        trust_remote_code=config.data.get('trust_remote_code', False)
-        tokenizer = hf_tokenizer(local_path,trust_remote_code=trust_remote_code)
+        trust_remote_code = config.data.get('trust_remote_code', False)
+        tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
         processor = hf_processor(local_path, use_fast=True)  # used for multimodal LLM, could be none
 
         # define worker classes

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -88,7 +88,8 @@ class TaskRunner:
 
         # instantiate tokenizer
         from verl.utils import hf_tokenizer, hf_processor
-        tokenizer = hf_tokenizer(local_path)
+        trust_remote_code=config.data.get('trust_remote_code', False)
+        tokenizer = hf_tokenizer(local_path,trust_remote_code=trust_remote_code)
         processor = hf_processor(local_path, use_fast=True)  # used for multimodal LLM, could be none
 
         # define worker classes


### PR DESCRIPTION
This parameter is required during the custom tokenizer loading phase, for example, when using `moonshotai/Moonlight-16B-A3B-Instruct`. And since the tokenizer falls under the configuration of data, I placed it under `config.data`.