### PR TITLE
fix rloo adv estimator

### DIFF
--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -172,24 +172,19 @@ def compute_rloo_outcome_advantage(token_level_rewards: torch.Tensor,
     scores = token_level_rewards.sum(dim=-1)
 
     id2score = defaultdict(list)
-    id2mean = {}
+    id2sum = {}
 
     with torch.no_grad():
         bsz = scores.shape[0]
         for i in range(bsz):
             id2score[index[i]].append(scores[i])
         for idx in id2score:
-            if len(id2score[idx]) == 1:
-                id2mean[idx] = torch.tensor(0.0)
-            elif len(id2score[idx]) > 1:
-                id2mean[idx] = torch.mean(torch.tensor(id2score[idx]))
-            else:
-                raise ValueError(f"no score in prompt index: {idx}")
+            id2sum[idx] = torch.sum(torch.tensor(id2score[idx]))
         for i in range(bsz):
             response_num = len(id2score[index[i]])
-            if response_num > 1:
-                scores[i] = scores[i] * response_num / (response_num -
-                                                        1) - id2mean[index[i]] * response_num / (response_num - 1)
+            baseline = (id2sum[index[i]] - scores[i])  / (response_num - 1)
+            scores[i] = scores[i] - baseline
+
         scores = scores.unsqueeze(-1).tile([1, response_length]) * eos_mask
 
     return scores, scores


### PR DESCRIPTION
The previous implementation of RLOO is somehow problematic, we align the algo impl with trl:
https://github.com/huggingface/trl/blob/v0.16.0/trl/trainer/rloo_trainer.py#L431-L435

![image](https://github.com/user-attachments/assets/de4057c1-3f33-4af0-829f-558727a082b3)
