### PR TITLE
fix: the error is not raised when using both megatron and hf inference

### DIFF
--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -280,7 +280,7 @@ class ActorRolloutRefWorker(MegatronWorker):
                                                            layer_name_mapping=layer_name_mapping)
             log_gpu_memory_usage('After building sharding manager', logger=logger)
         else:
-            NotImplementedError('Only vllmRollout is supported with Megatron now')
+            raise NotImplementedError('Only vllmRollout is supported with Megatron now')
 
         return rollout, sharding_manager
 


### PR DESCRIPTION
Hi there, when using both megatron and `actor_rollout_ref.rollout.name=hf`, the NotImplementedError is not raised. The PR fixes it.
```
(TaskRunner pid=229016)   File "/root/verl/verl/workers/megatron_workers.py", line 285, in _build_rollout                                                                            
(TaskRunner pid=229016)     return rollout, sharding_manager                                                                                                                         
(TaskRunner pid=229016) UnboundLocalError: local variable 'rollout' referenced before assignment 
```