### PR TITLE
refactor: remove unused `filter_prompts` parameter from `RLHFDataset`

### DIFF
--- a/docs/workers/ray_trainer.rst
+++ b/docs/workers/ray_trainer.rst
@@ -25,7 +25,6 @@ then tokenize.
                                        tokenizer=self.tokenizer,
                                        prompt_key=self.config.data.prompt_key,
                                        max_prompt_length=self.config.data.max_prompt_length,
-                                       filter_prompts=True,
                                        return_raw_chat=self.config.data.get('return_raw_chat', False),
                                        truncation='error')
 

--- a/recipe/prime/prime_ray_trainer.py
+++ b/recipe/prime/prime_ray_trainer.py
@@ -181,7 +181,6 @@ class RayPRIMETrainer(RayPPOTrainer):
                                          tokenizer=self.tokenizer,
                                          prompt_key=self.config.data.prompt_key,
                                          max_prompt_length=self.config.data.max_prompt_length,
-                                         filter_prompts=True,
                                          return_raw_chat=self.config.data.get('return_raw_chat', False),
                                          truncation='error',
                                          filter_overlong_prompts=self.config.data.get('filter_overlong_prompts', False))
@@ -204,7 +203,6 @@ class RayPRIMETrainer(RayPPOTrainer):
                                        tokenizer=self.tokenizer,
                                        prompt_key=self.config.data.prompt_key,
                                        max_prompt_length=self.config.data.max_prompt_length,
-                                       filter_prompts=True,
                                        return_raw_chat=self.config.data.get('return_raw_chat', False),
                                        truncation='error',
                                        filter_overlong_prompts=self.config.data.get('filter_overlong_prompts', False))

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -400,7 +400,6 @@ class RayPPOTrainer(object):
                                          prompt_key=self.config.data.prompt_key,
                                          image_key=self.config.data.get('image_key', 'images'),
                                          max_prompt_length=self.config.data.max_prompt_length,
-                                         filter_prompts=True,
                                          return_raw_chat=self.config.data.get('return_raw_chat', False),
                                          truncation=self.config.data.get('truncation', 'error'),
                                          filter_overlong_prompts=self.config.data.filter_overlong_prompts)
@@ -428,7 +427,6 @@ class RayPPOTrainer(object):
                                        prompt_key=self.config.data.prompt_key,
                                        image_key=self.config.data.get('image_key', 'images'),
                                        max_prompt_length=self.config.data.max_prompt_length,
-                                       filter_prompts=True,
                                        return_raw_chat=self.config.data.get('return_raw_chat', False),
                                        truncation=self.config.data.get('truncation', 'error'),
                                        filter_overlong_prompts=self.config.data.filter_overlong_prompts)

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -84,7 +84,6 @@ class RLHFDataset(Dataset):
                  prompt_key='prompt',
                  image_key='images',
                  max_prompt_length=1024,
-                 filter_prompts=True,
                  cache_dir='~/.cache/verl/rlhf',
                  chat_template_func=None,
                  return_raw_chat=False,
@@ -102,7 +101,6 @@ class RLHFDataset(Dataset):
         self.prompt_key = prompt_key
         self.image_key = image_key
         self.max_prompt_length = max_prompt_length
-        self.filter_prompts = filter_prompts
 
         self.return_raw_chat = return_raw_chat
         self.chat_template_func = chat_template_func


### PR DESCRIPTION
This `filter_prompts` from `RLHFDataset` has never been used, and could just be simply removed