### PR TITLE
[dev] feat: default VSCode repo settings to help consistency with CI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "pylint.enabled": true,
+    "[python]": {
+        "editor.defaultFormatter": "eeyore.yapf",
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "never",
+        }
+    }
+}


### PR DESCRIPTION
This PR adds default VSCode repo settings to help keep consistent with the CI, which:

1. enable the `pylint` linter extension
2. set the default formatter as `yapf`
3. but don't organize imports for now (since we haven't got a functionality for this)