### PR TITLE
[fix] Skip vllm initialization with weight loading

### DIFF
--- a/scripts/diagnose.py
+++ b/scripts/diagnose.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Diagnose script for checking OS/hardware/python/pip/verl/network.
 The output of this script can be a very good hint to issue/problem.
 """

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -106,6 +106,7 @@ class vLLMRollout(BaseRollout):
                              please increase max_num_batched_tokens or disable chunked prefill')
 
         trust_remote_code = kwargs.get('trust_remote_code', False)
+        load_format = 'dummy' if config.load_format.startswith('dummy') else config.load_format
 
         self.inference_engine = LLM(
             model=model_path,
@@ -119,6 +120,7 @@ class vLLMRollout(BaseRollout):
             disable_mm_preprocessor_cache=True,
             skip_tokenizer_init=False,
             max_model_len=max_model_len,
+            load_format=load_format,
             disable_log_stats=config.disable_log_stats,
             max_num_batched_tokens=max_num_batched_tokens,
             enable_chunked_prefill=config.enable_chunked_prefill,


### PR DESCRIPTION
In version 0.8.2, forgetting to add `dummy` parameter resulted in repeated loading.  And it also needs to be compatible with the default parameter `dummy_dtensor`.