### PR TITLE
[feat] enable FSDP and vLLM 0.8.2 to support DPSK v3 training.

### DIFF
--- a/tests/rollout/test_vllm_spmd.py
+++ b/tests/rollout/test_vllm_spmd.py
@@ -103,25 +103,7 @@ def test_vllm_spmd():
     print('start generation')
     input_ids = input_ids.cuda()
     attention_mask = attention_mask.cuda()
-    batch_size = input_ids.size(0)
-
-    generation_config = GenerationConfig(do_sample=False)
-    actor_model.cuda()
-    output = actor_model.generate(
-        input_ids=input_ids,
-        attention_mask=attention_mask,
-        max_new_tokens=max_response_length,
-        eos_token_id=tokenizer.eos_token_id,
-        pad_token_id=tokenizer.pad_token_id,
-        generation_config=generation_config,
-        output_scores=False,  # this is potentially very large
-        return_dict_in_generate=True,
-        use_cache=False)  # may OOM when use_cache = True
-    seq = output.sequences
-    response = seq[:, max_prompt_length:]
-
-    hf_response_tokens = tokenizer.batch_decode(response)
-
+    
     temperature = 0
     top_p = 1
     kwargs = dict(n=1,
@@ -170,23 +152,27 @@ def test_vllm_spmd():
         trust_remote_code=True,
     )
 
-    # Warmup iterations
+    outputs = llm.generate(preencode_prompts, sampling_params=sampling_params, use_tqdm=False)
+    vllm_response_tokens = []
+    for output in outputs:
+        generated_text = output.outputs[0].text
+        vllm_response_tokens.append(generated_text)
+
     world_size = torch.distributed.get_world_size()
     model = llm.llm_engine.model_executor.driver_worker.worker.model_runner.model
     model.load_weights(
         ((name, param.full_tensor() if world_size != 1 else param) for name, param in state_dict.items()))
-
+    
     outputs = llm.generate(preencode_prompts, sampling_params=sampling_params, use_tqdm=False)
-    vllm_response_tokens = []
+    verl_vllm_response_tokens = []
     for output in outputs:
-        prompt = output.prompt
         generated_text = output.outputs[0].text
-        vllm_response_tokens.append(generated_text)
+        verl_vllm_response_tokens.append(generated_text)
 
     if torch.distributed.get_rank() == 0:
-        print(f'hf response: {hf_response_tokens}')
         print(f'vllm response: {vllm_response_tokens}')
-    assert are_lists_similar(hf_response_tokens, vllm_response_tokens), \
+        print(f'verl-vllm response: {verl_vllm_response_tokens}')
+    assert are_lists_similar(vllm_response_tokens, verl_vllm_response_tokens), \
         f'Strings differ more than 10%:\n'
     print('Check Pass')
     torch.distributed.destroy_process_group()

--- a/tests/rollout/test_vllm_spmd.py
+++ b/tests/rollout/test_vllm_spmd.py
@@ -103,7 +103,7 @@ def test_vllm_spmd():
     print('start generation')
     input_ids = input_ids.cuda()
     attention_mask = attention_mask.cuda()
-    
+
     temperature = 0
     top_p = 1
     kwargs = dict(n=1,
@@ -162,7 +162,7 @@ def test_vllm_spmd():
     model = llm.llm_engine.model_executor.driver_worker.worker.model_runner.model
     model.load_weights(
         ((name, param.full_tensor() if world_size != 1 else param) for name, param in state_dict.items()))
-    
+
     outputs = llm.generate(preencode_prompts, sampling_params=sampling_params, use_tqdm=False)
     verl_vllm_response_tokens = []
     for output in outputs:

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -29,6 +29,7 @@ from verl.utils.debug import log_gpu_memory_usage
 from verl.third_party.vllm import vllm_version
 
 from .base import BaseShardingManager
+from .patch import patched_ds_v3_load_weights
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv('VERL_PPO_LOGGING_LEVEL', 'WARN'))
@@ -94,8 +95,11 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             self.inference_engine.wake_up()
             world_size = torch.distributed.get_world_size()
             model = self.inference_engine.llm_engine.model_executor.driver_worker.worker.model_runner.model
-            loaded_params = model.load_weights(
-                ((name, param.full_tensor() if world_size != 1 else param) for name, param in params.items()))
+            if model.config.architectures[0] in ['DeepseekV2ForCausalLM','DeepseekV3ForCausalLM']:
+                patched_ds_v3_load_weights(model,((name, param.full_tensor() if world_size != 1 and hasattr(param, 'full_tensor') else param) for name, param in params.items()))
+            else:
+                loaded_params = model.load_weights(
+                    ((name, param.full_tensor() if world_size != 1 else param) for name, param in params.items()))
             logger.info(f"vLLM load weights, loaded_params: {len(loaded_params)}")
 
         log_gpu_memory_usage('After sync model weights in sharding manager', logger=logger)

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -96,7 +96,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             world_size = torch.distributed.get_world_size()
             model = self.inference_engine.llm_engine.model_executor.driver_worker.worker.model_runner.model
             if model.config.architectures[0] in ['DeepseekV2ForCausalLM', 'DeepseekV3ForCausalLM']:
-                patched_ds_v3_load_weights(
+                loaded_params = patched_ds_v3_load_weights(
                     model, ((name, param.full_tensor() if world_size != 1 and hasattr(param, 'full_tensor') else param)
                             for name, param in params.items()))
             else:

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -95,8 +95,10 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             self.inference_engine.wake_up()
             world_size = torch.distributed.get_world_size()
             model = self.inference_engine.llm_engine.model_executor.driver_worker.worker.model_runner.model
-            if model.config.architectures[0] in ['DeepseekV2ForCausalLM','DeepseekV3ForCausalLM']:
-                patched_ds_v3_load_weights(model,((name, param.full_tensor() if world_size != 1 and hasattr(param, 'full_tensor') else param) for name, param in params.items()))
+            if model.config.architectures[0] in ['DeepseekV2ForCausalLM', 'DeepseekV3ForCausalLM']:
+                patched_ds_v3_load_weights(
+                    model, ((name, param.full_tensor() if world_size != 1 and hasattr(param, 'full_tensor') else param)
+                            for name, param in params.items()))
             else:
                 loaded_params = model.load_weights(
                     ((name, param.full_tensor() if world_size != 1 else param) for name, param in params.items()))

--- a/verl/workers/sharding_manager/patch/__init__.py
+++ b/verl/workers/sharding_manager/patch/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .fsdp_vllm_patch import patched_ds_v3_load_weights

--- a/verl/workers/sharding_manager/patch/fsdp_vllm_patch.py
+++ b/verl/workers/sharding_manager/patch/fsdp_vllm_patch.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import torch
 from torch import nn
 from typing import Optional, Union, Iterable, Tuple, Set

--- a/verl/workers/sharding_manager/patch/fsdp_vllm_patch.py
+++ b/verl/workers/sharding_manager/patch/fsdp_vllm_patch.py
@@ -1,0 +1,106 @@
+import torch
+from torch import nn
+from typing import Optional, Union, Iterable, Tuple, Set
+from transformers import PretrainedConfig
+from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader, maybe_remap_kv_scale_name)
+from vllm.model_executor.models.utils import is_pp_missing_parameter
+
+def patched_ds_v3_load_weights(model: nn.Module, weights: Iterable[Tuple[str, torch.Tensor]]) -> Set[str]:
+    def get_spec_layer_idx_from_weight_name(config: PretrainedConfig,
+                                        weight_name: str) -> Optional[int]:
+        if hasattr(config,
+                "num_nextn_predict_layers") and (config.num_nextn_predict_layers
+                                                    > 0):
+            layer_idx = config.num_hidden_layers
+            for i in range(config.num_nextn_predict_layers):
+                if weight_name.startswith(f"model.layers.{layer_idx+i}."):
+                    return layer_idx + i
+        return None
+
+    import re
+    def get_layer_index(layer_name: str) -> int:
+        pattern = r"layers\.(\d+)" 
+        match = re.search(pattern, layer_name)
+        if match:
+            return int(match.group(1))
+        raise ValueError(f"Unable to parse layer index from '{layer_name}'")
+
+    stacked_params_mapping = [
+        ("gate_up_proj", "gate_proj", 0),
+        ("gate_up_proj", "up_proj", 1),
+    ]
+
+    expert_params_mapping = FusedMoE.make_expert_params_mapping(
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        num_experts=model.config.n_routed_experts
+    )
+    params_dict = dict(model.named_parameters())
+    loaded_params: Set[str] = set()
+
+    for name, loaded_weight in weights:
+        if "rotary_emb.inv_freq" in name:
+            continue
+
+        spec_layer = get_spec_layer_idx_from_weight_name(model.config, name)
+        if spec_layer is not None:
+            continue
+
+        for (param_name, weight_name, shard_id) in stacked_params_mapping:
+            if weight_name not in name:
+                continue
+            if (("mlp.experts." in name) and name not in params_dict):
+                continue
+            name = name.replace(weight_name, param_name)
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+
+            if is_pp_missing_parameter(name, model):
+                continue
+
+            param = params_dict[name]
+            weight_loader = param.weight_loader
+            weight_loader(param, loaded_weight, shard_id)
+            break
+        else:
+            for mapping in expert_params_mapping:
+                param_name, weight_name, expert_id, shard_id = mapping
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+
+                if is_pp_missing_parameter(name, model):
+                    continue
+                param = params_dict[name]
+
+                # custom weight_loader
+                layer_idx = get_layer_index(name)
+                weight_loader = model.model.layers[layer_idx].mlp.experts.weight_loader
+                # replace
+                # weight_loader = param.weight_loader
+
+                weight_loader(param,
+                            loaded_weight,
+                            name,
+                            shard_id=shard_id,
+                            expert_id=expert_id)
+                break
+            else:
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+
+                if is_pp_missing_parameter(name, model):
+                    continue
+
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+    return loaded_params


### PR DESCRIPTION
This is a solution to an error that occurs when vLLM 0.8.2 loads models in the ds_v3 MoE format. For MoE models, directly calling vLLM's `load_weights· function will result in an error, primarily because the model params lose the related methods of the `FusedMoe` class. Therefore, it is necessary to identify and call the specific parameter loading method based on the model parameter names at runtime. However, the current version is a dirty implementation because, in reality, if invasive changes were made to vLLM, it would only require modifying 2 lines of code and adding a new function to identify the layer count (I have already marked comments in the code). I’m not sure if there’s a better implementation and would like some suggestions.