### PR TITLE
fix: support non-DTensor when converting fsdp checkpoints to hf model

### DIFF
--- a/scripts/model_merger.py
+++ b/scripts/model_merger.py
@@ -17,6 +17,7 @@ import re
 import os
 import torch
 import argparse
+import numpy as np
 from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForTokenClassification, AutoModelForVision2Seq
 from concurrent.futures import ThreadPoolExecutor
 from torch.distributed._tensor import DTensor, Shard, Placement
@@ -85,11 +86,16 @@ def convert_fsdp_checkpoints_to_hfmodels():
                             map_location='cpu')
     pivot_key = sorted(list(state_dict.keys()))[0]
     weight = state_dict[pivot_key]
-    assert isinstance(weight, torch.distributed._tensor.DTensor)
-    # get sharding info
-    device_mesh = weight.device_mesh
-    mesh = device_mesh.mesh
-    mesh_dim_names = device_mesh.mesh_dim_names
+
+    if isinstance(weight, torch.distributed._tensor.DTensor):
+        # get sharding info
+        device_mesh = weight.device_mesh
+        mesh = device_mesh.mesh
+        mesh_dim_names = device_mesh.mesh_dim_names
+    else:
+        # for non-DTensor
+        mesh = np.array([int(world_size)], dtype=np.int64)
+        mesh_dim_names = ('fsdp',)
 
     print(f'Got device mesh {mesh}, mesh_dim_names {mesh_dim_names}')
 
@@ -130,7 +136,7 @@ def convert_fsdp_checkpoints_to_hfmodels():
             except:
                 print("-" * 30)
                 print(model_state_dict)
-            if isinstance(tensor, DTensor):
+            if isinstance(tensor, torch.distributed._tensor.DTensor):
                 state_dict[key].append(tensor._local_tensor.bfloat16())
                 placements = tuple(tensor.placements)
                 # replicated placement at dp dimension can be discarded
@@ -141,7 +147,7 @@ def convert_fsdp_checkpoints_to_hfmodels():
                 else:
                     assert param_placements[key] == placements
             else:
-                state_dict[key] = tensor.bfloat16()
+                state_dict[key].append(tensor.bfloat16())
 
     del model_state_dict_lst
 
@@ -149,16 +155,19 @@ def convert_fsdp_checkpoints_to_hfmodels():
         if not isinstance(state_dict[key], list):
             print(f"No need to merge key {key}")
             continue
-        # merge shards
-        placements: Tuple[Shard] = param_placements[key]
-        if len(mesh_shape) == 1:
-            # 1-D list, FSDP without TP
-            assert len(placements) == 1
-            shards = state_dict[key]
-            state_dict[key] = merge_by_placement(shards, placements[0])
+        if key in param_placements:
+            # merge shards
+            placements: Tuple[Shard] = param_placements[key]
+            if len(mesh_shape) == 1:
+                # 1-D list, FSDP without TP
+                assert len(placements) == 1
+                shards = state_dict[key]
+                state_dict[key] = merge_by_placement(shards, placements[0])
+            else:
+                # 2-D list, FSDP + TP
+                raise NotImplementedError("FSDP + TP is not supported yet")
         else:
-            # 2-D list, FSDP + TP
-            raise NotImplementedError("FSDP + TP is not supported yet")
+            state_dict[key] = torch.cat(state_dict[key], dim=0)
 
     print('Writing to local disk')
     if args.target_dir is None:
@@ -212,7 +221,7 @@ def check_megatron_checkpoint_path(model_path):
     return sharded_dirs, tp_size, pp_size
 
 
-def convert_megatron_checkpoints_to_hfmodes():
+def convert_megatron_checkpoints_to_hfmodels():
     local_path = args.local_dir
 
     model_ckpt_path = get_model_checkpoint_path(local_path)
@@ -422,6 +431,6 @@ if __name__ == '__main__':
     if args.backend == "fsdp":
         convert_fsdp_checkpoints_to_hfmodels()
     elif args.backend == "megatron":
-        convert_megatron_checkpoints_to_hfmodes()
+        convert_megatron_checkpoints_to_hfmodels()
     else:
         raise NotImplementedError(f"{args.backend} not supported")


### PR DESCRIPTION
As mentioned in https://github.com/volcengine/verl/issues/903, the model_merger script has some problem when dealing with saved fsdp checkpoint trained with `trainer.n_gpus_per_node=1`.  The loaded `weight` is of type `Tensor` instead of `DTensor`. This PR supported this situation.