### PR TITLE
[math-verify] fix: TimeoutException

### DIFF
--- a/verl/utils/reward_score/math_verify.py
+++ b/verl/utils/reward_score/math_verify.py
@@ -15,11 +15,12 @@
 try:
     from math_verify.metric import math_metric
     from math_verify.parser import LatexExtractionConfig, ExprExtractionConfig
+    from math_verify.errors import TimeoutException
 except ImportError:
     print("To use Math-Verify, please install it first by running `pip install math-verify`.")
 
 
-def compute_score(model_output: str, ground_truth: str) -> bool:
+def compute_score(model_output: str, ground_truth: str, timeout_score: float = 0) -> bool:
     verify_func = math_metric(
         gold_extraction_target=(LatexExtractionConfig(),),
         pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig()),
@@ -32,5 +33,7 @@ def compute_score(model_output: str, ground_truth: str) -> bool:
         ret_score, _ = verify_func([ground_truth_boxed], [model_output])
     except Exception as e:
         pass
+    except TimeoutException:
+        ret_score = timeout_score
 
     return ret_score


### PR DESCRIPTION
`math_verify.errors.TimeoutException` can not be caught as `Exception`.

```python
In [1]: import math_verify

In [2]: issubclass(math_verify.errors.TimeoutException, Exception)
False

In [3]: issubclass(math_verify.errors.TimeoutException, BaseException)
True
```