### PR TITLE
feat: add gradient checkpointing in megatron backend

### DIFF
--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -23,6 +23,14 @@ actor_rollout_ref:
     external_lib: null
     override_config: {}
     enable_gradient_checkpointing: False
+    gradient_checkpointing_kwargs:
+      ## Activation Checkpointing
+      activations_checkpoint_method: null # 'uniform', 'block'; not used with 'selective'
+      # 'uniform' divides the total number of transformer layers and checkpoints the input activation of each chunk
+      # 'block' checkpoints the specified number of layers per pipeline stage at the specified granularity
+      activations_checkpoint_granularity: null # 'selective' or 'full'
+      # 'full' will checkpoint the entire transformer layer and 'selective' only checkpoints memory intensive part of attention
+      activations_checkpoint_num_layers: null # not used with 'selective'
   actor:
     strategy: megatron  # This is for backward-compatibility
     ppo_mini_batch_size: 256
@@ -128,6 +136,11 @@ critic:
     override_config: {}
     external_lib: ${actor_rollout_ref.model.external_lib}
     enable_gradient_checkpointing: False
+    gradient_checkpointing_kwargs:
+      ## Activation Checkpointing
+      activations_checkpoint_method: null
+      activations_checkpoint_granularity: null
+      activations_checkpoint_num_layers: null
   megatron:
     tensor_model_parallel_size: 4
     pipeline_model_parallel_size: 1


### PR DESCRIPTION
### Changes 

Add gradient checkpointing (aka `activation recomputation`) config and support from Megatron core (https://github.com/NVIDIA/Megatron-LM/blob/b7ec711cf66cf500b98d8783f2c7f3c3a7d5ba31/megatron/core/transformer/transformer_config.py#L208-L233) to make activation checkpointing more efficient for LLMs with 20B+ parameters.

```
 gradient_checkpointing_kwargs:
     activations_checkpoint_method: null
     activations_checkpoint_granularity: null
     activations_checkpoint_num_layers: null
```

### Test 
Tested on loading Qwen7b/32b of 16k input prompts and bypass the OOM issues after adding gradient checkpointing. 

### Next Step

Add one `ppo_trainer for megatron` doc to explain the config details in  https://verl.readthedocs.io/en/latest/examples/config.html
