### PR TITLE
[Enhancement] Make `register_center` named actor waiting time configurable & providing better error info

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -420,6 +420,7 @@ Trainer
      resume_from_path: null
      remove_previous_ckpt_in_save: False
      del_local_ckpt_after_load: False
+     ray_wait_register_center_timeout: 300
 
 - ``trainer.total_epochs``: Number of epochs in training.
 - ``trainer.project_name``: For wandb, swanlab, mlflow
@@ -445,6 +446,8 @@ Trainer
   checkpoints in the save directory. Default is False.
 - ``trainer.del_local_ckpt_after_load``: Whether to delete local
   checkpoints after loading them. Default is False.
+- ``trainer.ray_wait_register_center_timeout``: The timeout for waiting
+  for the ray register center to be ready. Default is 300 seconds.
 
 
 evaluation.yaml

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import time
-from typing import Dict, List, Any, Tuple
+from typing import Dict, List, Any, Tuple, Optional
 
 import ray
 from ray.util import list_named_actors
@@ -202,10 +203,13 @@ class RayWorkerGroup(WorkerGroup):
                  name_prefix: str = None,
                  detached=False,
                  worker_names=None,
+                 ray_wait_register_center_timeout: Optional[int] = None,
                  **kwargs) -> None:
         super().__init__(resource_pool=resource_pool, **kwargs)
         self.ray_cls_with_init = ray_cls_with_init
         self.name_prefix = get_random_string(length=6) if name_prefix is None else name_prefix
+        # Set the default timeout to wait for the register center actor to be ready as 300s.
+        self._ray_wait_register_center_timeout = ray_wait_register_center_timeout or 300
 
         if worker_names is not None:
             assert self._is_init_with_detached_workers
@@ -285,13 +289,30 @@ class RayWorkerGroup(WorkerGroup):
 
                 if rank == 0:
                     register_center_actor = None
-                    for _ in range(120):
-                        if f"{self.name_prefix}_register_center" not in list_named_actors():
-                            time.sleep(1)
-                        else:
-                            register_center_actor = ray.get_actor(f"{self.name_prefix}_register_center")
+                    actor_name = f"{self.name_prefix}_register_center"
+                    start_time = time.time()
+
+                    while time.time() - start_time < self._ray_wait_register_center_timeout:
+                        if actor_name in list_named_actors():
+                            register_center_actor = ray.get_actor(actor_name)
                             break
-                    assert register_center_actor is not None, f"failed to get register_center_actor: {self.name_prefix}_register_center in {list_named_actors(all_namespaces=True)}"
+
+                        elapsed = int(time.time() - start_time)
+                        if elapsed % 30 == 0:
+                            logging.warning(
+                                f"Waiting for register center actor {actor_name} to be ready. "
+                                f"Elapsed time: {elapsed} seconds out of {self._ray_wait_register_center_timeout} seconds."
+                            )
+                        time.sleep(1)
+
+                    if register_center_actor is None:
+                        raise TimeoutError(
+                            f"Failed to get register_center_actor {actor_name} in {list_named_actors(all_namespaces=True)} "
+                            f"for {self._ray_wait_register_center_timeout} seconds. "
+                            "Ensure that any lingering Ray resources from previous runs are cleaned up (e.g., by restarting the Ray cluster), "
+                            "or adjust the waiting time by modifying the config `trainer.ray_wait_register_center_timeout`."
+                        )
+
                     rank_zero_info = ray.get(register_center_actor.get_rank_zero_info.remote())
                     self._master_addr, self._master_port = rank_zero_info['MASTER_ADDR'], rank_zero_info['MASTER_PORT']
                     # print(f"rank_zero_info: {rank_zero_info}")

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -203,13 +203,12 @@ class RayWorkerGroup(WorkerGroup):
                  name_prefix: str = None,
                  detached=False,
                  worker_names=None,
-                 ray_wait_register_center_timeout: Optional[int] = None,
+                 ray_wait_register_center_timeout: int = 300,
                  **kwargs) -> None:
         super().__init__(resource_pool=resource_pool, **kwargs)
         self.ray_cls_with_init = ray_cls_with_init
         self.name_prefix = get_random_string(length=6) if name_prefix is None else name_prefix
-        # Set the default timeout to wait for the register center actor to be ready as 300s.
-        self._ray_wait_register_center_timeout = ray_wait_register_center_timeout or 300
+        self._ray_wait_register_center_timeout = ray_wait_register_center_timeout
 
         if worker_names is not None:
             assert self._is_init_with_detached_workers

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -221,5 +221,5 @@ trainer:
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
   max_actor_ckpt_to_keep: null
   max_critic_ckpt_to_keep: null
-  # The timeout for ray woker group to wait for the register center to be ready
+  # The timeout for ray worker group to wait for the register center to be ready
   ray_wait_register_center_timeout: 300

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -221,3 +221,5 @@ trainer:
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
   max_actor_ckpt_to_keep: null
   max_critic_ckpt_to_keep: null
+  # The timeout for ray woker group to wait for the register center to be ready
+  ray_wait_register_center_timeout: 300

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -210,5 +210,5 @@ trainer:
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
   max_actor_ckpt_to_keep: null
   max_critic_ckpt_to_keep: null
-  # The timeout for ray woker group to wait for the register center to be ready
+  # The timeout for ray worker group to wait for the register center to be ready
   ray_wait_register_center_timeout: 300

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -210,3 +210,5 @@ trainer:
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
   max_actor_ckpt_to_keep: null
   max_critic_ckpt_to_keep: null
+  # The timeout for ray woker group to wait for the register center to be ready
+  ray_wait_register_center_timeout: 300

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -647,12 +647,15 @@ class RayPPOTrainer(object):
         # See https://github.com/volcengine/verl/blob/master/examples/ray/tutorial.ipynb for more information.
         all_wg = {}
         self.wg_dicts = []
+        wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
+        if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
+            wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
+
         for resource_pool, class_dict in self.resource_pool_to_cls.items():
             worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
-            wg_dict = self.ray_worker_group_cls(
-                resource_pool=resource_pool,
-                ray_cls_with_init=worker_dict_cls,
-                ray_wait_register_center_timeout=self.config.trainer.ray_wait_register_center_timeout)
+            wg_dict = self.ray_worker_group_cls(resource_pool=resource_pool,
+                                                ray_cls_with_init=worker_dict_cls,
+                                                **wg_kwargs)
             spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())
             all_wg.update(spawn_wg)
             # keep the referece of WorkerDict to support ray >= 2.31. Ref: https://github.com/ray-project/ray/pull/45699

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -649,7 +649,10 @@ class RayPPOTrainer(object):
         self.wg_dicts = []
         for resource_pool, class_dict in self.resource_pool_to_cls.items():
             worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
-            wg_dict = self.ray_worker_group_cls(resource_pool=resource_pool, ray_cls_with_init=worker_dict_cls)
+            wg_dict = self.ray_worker_group_cls(
+                resource_pool=resource_pool,
+                ray_cls_with_init=worker_dict_cls,
+                ray_wait_register_center_timeout=self.config.trainer.ray_wait_register_center_timeout)
             spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())
             all_wg.update(spawn_wg)
             # keep the referece of WorkerDict to support ray >= 2.31. Ref: https://github.com/ray-project/ray/pull/45699


### PR DESCRIPTION
## Summary

As mentioned in #491, the `register_center` named actor could be `None` after 2mins waiting time and crash the job for some verl users. 

This might be due to (1) uncleaned ray resources from previous runs; or (2) too short waiting time of 120s if the `named_actor` launching task is delayed in the cluster.

This PR makes the `register_cetner` named actor waiting time configurable and longer by default . This PR also provides better error info to help users to self debug the issue.

## Related issues

#491 