### PR TITLE
fix args for prime reward manager

### DIFF
--- a/verl/workers/reward_manager/prime.py
+++ b/verl/workers/reward_manager/prime.py
@@ -86,7 +86,7 @@ class PrimeRewardManager:
     The Reward Manager used in https://github.com/PRIME-RL/PRIME
     """
 
-    def __init__(self, tokenizer, num_examine, compute_score=None) -> None:
+    def __init__(self, tokenizer, num_examine, compute_score=None, **kwargs) -> None:
         self.tokenizer = tokenizer
         self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
         self.compute_score = compute_score or _default_compute_score


### PR DESCRIPTION
Fix error as follows
```
verl/trainer/main_ppo.py", line 164, in run
    reward_fn = reward_manager_cls(tokenizer=tokenizer,
TypeError: PrimeRewardManager.__init__() got an unexpected keyword argument 'reward_fn_key'
```
when prime manager is called due to `reward_fn_key`

