### PR TITLE
add rollout config swap_space for vllm_rollout

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -157,6 +157,8 @@ Actor/Rollout/Reference Policy
       log_prob_max_token_len_per_gpu: ${actor_rollout_ref.actor.ppo_max_token_len_per_gpu}
       # for hf rollout
       do_sample: True
+      engine_kwargs: # inference engine parameters
+        swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
       # number of responses (i.e. num sample times)
       n: 1 # > 1 for grpo, rloo
 
@@ -280,6 +282,10 @@ Reference model will be enabled when ``actor.use_kl_loss`` or/and ``algorithm.us
 - ``do_sample``: Whether to sample. If set to False, the rollout model
   will perform greedy sampling. We disable ``do_sample`` during
   validation.
+
+- ``actor_rollout_ref.rollout.engine_kwargs.swap_space``: swap space in GB used by the inference engine.
+  - ``null``: means not setting and using the engine default value (usually, e.g., 4 GB for vLLM)
+  - Positive integer, e.g., ``32 `` means 32 GB.
 
 - ``actor_rollout_ref.rollout.ignore_eos``: Whether to ignore the EOS
   token and continue generating tokens after the EOS token is generated.

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -111,6 +111,8 @@ actor_rollout_ref:
       gate_proj_layer_name: gate_up
     # number of responses (i.e. num sample times)
     n: 1
+    engine_kwargs: # inference engine parameters
+      swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
     val_kwargs:
       # sampling parameters for validation
       top_k: -1 # 0 for hf rollout, -1 for vllm rollout

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -103,6 +103,8 @@ actor_rollout_ref:
     do_sample: True
     # number of responses (i.e. num sample times)
     n: 1 # > 1 for grpo
+    engine_kwargs: # inference engine parameters
+      swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
     val_kwargs:
       # sampling parameters for validation
       top_k: -1 # 0 for hf rollout, -1 for vllm rollout

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -100,7 +100,7 @@ class vLLMRollout(BaseRollout):
                              please increase max_num_batched_tokens or disable chunked prefill')
 
         # copy it to avoid secretly modifying the engine config
-        engine_kwargs = OmegaConf.to_container(deepcopy(config.engine_kwargs))
+        engine_kwargs = {} if 'engine_kwargs' not in config else OmegaConf.to_container(deepcopy(config.engine_kwargs))
         # For each vLLM engine parameter, 
         # - `None` means not setting it, so we pop it, and leave it to vLLM default value 
         #    (which can vary across different vLLM versions);

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -102,9 +102,9 @@ class vLLMRollout(BaseRollout):
         # copy it to avoid secretly modifying the engine config
         engine_kwargs = OmegaConf.to_container(deepcopy(config.engine_kwargs))
         if engine_kwargs.get('swap_space', None) is None:
-            # vLLM has its own default `swap_space` value, which can change in the future versions.
-            # Not setting it means leave it to vLLM default value, 
-            # while setting it explicitly in config means the swap space in GB you want.
+            # Not setting it means leave it to vLLM default value (Note that vLLM has its own default `swap_space` value, 
+            # which can, however, change in the future versions);
+            # Setting it explicitly in config means the swap space in GB you want.
             engine_kwargs.pop('swap_space')
         self.inference_engine = LLM(
             actor_module,

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -101,11 +101,11 @@ class vLLMRollout(BaseRollout):
 
         # copy it to avoid secretly modifying the engine config
         engine_kwargs = OmegaConf.to_container(deepcopy(config.engine_kwargs))
-        if engine_kwargs.get('swap_space', None) is None:
-            # Not setting it means leave it to vLLM default value (Note that vLLM has its own default `swap_space` value, 
-            # which can, however, change in the future versions);
-            # Setting it explicitly in config means the swap space in GB you want.
-            engine_kwargs.pop('swap_space')
+        # For each vLLM engine parameter, 
+        # - `None` means not setting it, so we pop it, and leave it to vLLM default value 
+        #    (which can vary across different vLLM versions);
+        # - Otherwise it's the desired value we want to explicitly set.
+        engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
         self.inference_engine = LLM(
             actor_module,
             tokenizer=tokenizer,

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -101,27 +101,25 @@ class vLLMRollout(BaseRollout):
 
         # copy it to avoid secretly modifying the engine config
         engine_kwargs = {} if 'engine_kwargs' not in config else OmegaConf.to_container(deepcopy(config.engine_kwargs))
-        # For each vLLM engine parameter, 
-        # - `None` means not setting it, so we pop it, and leave it to vLLM default value 
+        # For each vLLM engine parameter,
+        # - `None` means not setting it, so we pop it, and leave it to vLLM default value
         #    (which can vary across different vLLM versions);
         # - Otherwise it's the desired value we want to explicitly set.
         engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
-        self.inference_engine = LLM(
-            actor_module,
-            tokenizer=tokenizer,
-            model_hf_config=model_hf_config,
-            tensor_parallel_size=tensor_parallel_size,
-            dtype=config.dtype,
-            enforce_eager=config.enforce_eager,
-            gpu_memory_utilization=config.gpu_memory_utilization,
-            skip_tokenizer_init=False,
-            max_model_len=max_model_len,
-            load_format=config.load_format,
-            disable_log_stats=config.disable_log_stats,
-            max_num_batched_tokens=max_num_batched_tokens,
-            enable_chunked_prefill=config.enable_chunked_prefill,
-            **engine_kwargs
-        )
+        self.inference_engine = LLM(actor_module,
+                                    tokenizer=tokenizer,
+                                    model_hf_config=model_hf_config,
+                                    tensor_parallel_size=tensor_parallel_size,
+                                    dtype=config.dtype,
+                                    enforce_eager=config.enforce_eager,
+                                    gpu_memory_utilization=config.gpu_memory_utilization,
+                                    skip_tokenizer_init=False,
+                                    max_model_len=max_model_len,
+                                    load_format=config.load_format,
+                                    disable_log_stats=config.disable_log_stats,
+                                    max_num_batched_tokens=max_num_batched_tokens,
+                                    enable_chunked_prefill=config.enable_chunked_prefill,
+                                    **engine_kwargs)
 
         # Offload vllm model to reduce peak memory usage
         self.inference_engine.offload_model_weights()

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -98,6 +98,12 @@ class vLLMRollout(BaseRollout):
             raise ValueError('Enable chunked prefill, max_num_batched_tokens is smaller than max_model_len, \
                              please increase max_num_batched_tokens or disable chunked prefill')
 
+        vllm_kwargs = {}
+        if config.get('swap_space', None) is not None:
+            # vLLM has its own default swap_space value, which can change in the future versions.
+            # So let's leave the defalut value to vLLM by not setting it, or just explicitly set it via config.
+            vllm_kwargs['swap_space'] = config.get('swap_space')
+
         self.inference_engine = LLM(
             actor_module,
             tokenizer=tokenizer,
@@ -112,6 +118,7 @@ class vLLMRollout(BaseRollout):
             disable_log_stats=config.disable_log_stats,
             max_num_batched_tokens=max_num_batched_tokens,
             enable_chunked_prefill=config.enable_chunked_prefill,
+            **vllm_kwargs
         )
 
         # Offload vllm model to reduce peak memory usage


### PR DESCRIPTION
 When training big model and/or super-long seq len using vLLM rollout, you may encounter the error
```
...
in _swap_out raise RuntimeError( RuntimeError: Aborted due to the lack of CPU swap space. Please increase the swap space to avoid this error
``` 


(updated)This can be fixed by setting bigger `swap_space` for vLLM.  E.g., in your training bash you can do the
```
...
actor_rollout_ref.rollout.engine_kwargs.swap_space=32 \
...
```
which sets the swap_space to 32GB. Note in most vLLM releases the default value is 4GB.