### PR TITLE
fix: wrong pg_clipfrac_lower

### DIFF
--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -394,7 +394,7 @@ def compute_policy_loss(old_log_prob,
     pg_losses3 = -advantages * clip_ratio_c
     clip_pg_losses2 = torch.min(pg_losses3, clip_pg_losses1)
     pg_clipfrac_lower = verl_F.masked_mean(
-        torch.gt(clip_pg_losses2, pg_losses3) * (advantages < 0).float(), response_mask)
+        torch.gt(clip_pg_losses1, pg_losses3) * (advantages < 0).float(), response_mask)
 
     pg_losses = torch.where(advantages < 0, clip_pg_losses2, clip_pg_losses1)
     pg_loss = agg_loss(loss_mat=pg_losses, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)


### PR DESCRIPTION
Currently, `pg_clipfrac_lower` is always 0 by mistake.