### PR TITLE
fix: replace '@' with '_at_' in metric names to comply with MLflow naming constraints

### DIFF
--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -139,6 +139,7 @@ class _MlflowLoggingAdapter:
 
     def log(self, data, step):
         import mlflow
+        results = {k.replace('@', '_at_'): v for k, v in data.items()}
         mlflow.log_metrics(metrics=data, step=step)
 
 


### PR DESCRIPTION
Fix MLflow metric name errors by replacing '@' with '_at_' during MLflow logging

MLflow rejects metric names with '@' as below

`mlflow.exceptions.RestException: INVALID_PARAMETER_VALUE: Invalid metric name: 'val-aux/semantic_matching/reward/mean@1'. Names may only contain alphanumerics, underscores (_), dashes (-), periods (.), spaces ( ), and slashes (/).`



