### PR TITLE
[vllm] fix oom when vllm wakeup (vllm >=0.8.3)

### DIFF
--- a/scripts/model_merger.py
+++ b/scripts/model_merger.py
@@ -28,7 +28,6 @@ try:
 except ImportError:
     from torch.distributed._tensor import DTensor
 
-
 parser = argparse.ArgumentParser()
 parser.add_argument('--backend', type=str, required=True, help="The backend of the model", choices=["fsdp", "megatron"])
 parser.add_argument('--tie-word-embedding', action='store_true', help="Whether to tie word embedding weights")


### PR DESCRIPTION
This is a memory optimization method implemented based on this [fix](https://github.com/vllm-project/vllm/pull/15500). I just successfully ran a 72B model on 8*H800 cards. Before the fix, I would encounter an OOM issue. Please note that this fix is only effective for vLLM >= 0.8.3.