### PR TITLE
Change behaviour during raw prompt extraction

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -1096,7 +1096,10 @@ class RewardModelWorker(Worker):
 
         for i in range(data.batch.batch_size[0]):
             # extract raw prompt
-            chat: list = data.non_tensor_batch['raw_prompt'][i].tolist()
+            if isinstance(data.non_tensor_batch['raw_prompt'][i], list):
+                chat: list = data.non_tensor_batch['raw_prompt'][i]
+            else:
+                chat: list = data.non_tensor_batch['raw_prompt'][i].tolist()
 
             # extract response
             response_ids = data.batch['responses'][i]


### PR DESCRIPTION
This PR suggest a fix on a bug that when `_switch_chat_template()` method is called. 

According to
https://github.com/volcengine/verl/blob/main/verl/utils/dataset/rl_dataset.py#L222 
`data.non_tensor_batch['raw_prompt'][i]` is already a list if `data.return_raw_chat=True`.

Calling `.tolist()` again will result an error. Now we check if it is a list before run this method. 
