### PR TITLE
Add scale_grpo_adv option 

### DIFF
--- a/examples/split_placement/split_monkey_patch.py
+++ b/examples/split_placement/split_monkey_patch.py
@@ -141,11 +141,13 @@ def fit(self):
                         batch.batch['token_level_rewards'] = batch.batch['token_level_scores']
 
                     # compute advantages, executed on the driver process
+                    scale_grpo_adv = self.config.algorithm.get('scale_grpo_adv', True)
                     batch = compute_advantage(batch,
                                               adv_estimator=self.config.algorithm.adv_estimator,
                                               gamma=self.config.algorithm.gamma,
                                               lam=self.config.algorithm.lam,
-                                              num_repeat=self.config.actor_rollout_ref.rollout.n)
+                                              num_repeat=self.config.actor_rollout_ref.rollout.n,
+                                              scale_grpo_adv=scale_grpo_adv)
 
                 # update critic
                 if self.use_critic:

--- a/recipe/dapo/src/dapo_ray_trainer.py
+++ b/recipe/dapo/src/dapo_ray_trainer.py
@@ -242,11 +242,13 @@ class RayDAPOTrainer(RayPPOTrainer):
 
                     with _timer('adv', timing_raw):
                         # compute advantages, executed on the driver process
+                        scale_grpo_adv = self.config.algorithm.get('scale_grpo_adv', True)
                         batch = compute_advantage(batch,
                                                   adv_estimator=self.config.algorithm.adv_estimator,
                                                   gamma=self.config.algorithm.gamma,
                                                   lam=self.config.algorithm.lam,
-                                                  num_repeat=self.config.actor_rollout_ref.rollout.n)
+                                                  num_repeat=self.config.actor_rollout_ref.rollout.n,
+                                                  scale_grpo_adv=scale_grpo_adv)
 
                     # update critic
                     if self.use_critic:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -173,7 +173,7 @@ def compute_response_mask(data: DataProto):
     return attention_mask[:, -response_length:]
 
 
-def compute_advantage(data: DataProto, adv_estimator, gamma=1.0, lam=1.0, num_repeat=1):
+def compute_advantage(data: DataProto, adv_estimator, gamma=1.0, lam=1.0, num_repeat=1, scale_grpo_adv=True):
     # Back-compatible with trainers that do not compute response mask in fit
     if "response_mask" not in data.batch.keys():
         data.batch['response_mask'] = compute_response_mask(data)
@@ -193,7 +193,8 @@ def compute_advantage(data: DataProto, adv_estimator, gamma=1.0, lam=1.0, num_re
         advantages, returns = core_algos.compute_grpo_outcome_advantage(
             token_level_rewards=data.batch['token_level_rewards'],
             response_mask=data.batch['response_mask'],
-            index=data.non_tensor_batch['uid'])
+            index=data.non_tensor_batch['uid'],
+            scale_grpo_adv=scale_grpo_adv)
         data.batch['advantages'] = advantages
         data.batch['returns'] = returns
     elif adv_estimator == AdvantageEstimator.REINFORCE_PLUS_PLUS_BASELINE:
@@ -939,11 +940,13 @@ class RayPPOTrainer(object):
                             batch.batch['token_level_rewards'] = batch.batch['token_level_scores']
 
                         # compute advantages, executed on the driver process
+                        scale_grpo_adv = self.config.algorithm.get('scale_grpo_adv', True) # GRPO adv normalization factor
                         batch = compute_advantage(batch,
                                                   adv_estimator=self.config.algorithm.adv_estimator,
                                                   gamma=self.config.algorithm.gamma,
                                                   lam=self.config.algorithm.lam,
-                                                  num_repeat=self.config.actor_rollout_ref.rollout.n)
+                                                  num_repeat=self.config.actor_rollout_ref.rollout.n,
+                                                  scale_grpo_adv=scale_grpo_adv)
 
                     # update critic
                     if self.use_critic:


### PR DESCRIPTION
https://github.com/volcengine/verl/issues/742

- Add an option for disabling standard-deviation normalization of advantages in GRPO.
- This completes one out of two algorithmic changes made by Dr.GRPO to GRPO, the other one being the removal of sequence-length averaging during loss aggregation. 