### PR TITLE
fix: loading HF model in rank0 for mcore megatron model

### DIFF
--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -277,12 +277,8 @@ def _get_parallel_model_architecture_from_config(config: PretrainedConfig, value
                      f"Supported architectures: {ModelRegistry.get_supported_archs()}")
 
 
-def load_megatron_model_weights(config,
-                                model_config,
-                                parallel_model,
-                                params_dtype,
-                                is_value_model=False,
-                                local_cache_path='~/.cache/verl/rlhf'):
+def _load_hf_model(config, model_config, is_value_model, local_cache_path):
+    """Helper function containing the loading hf model logic"""
     assert hasattr(model_config, "architectures"), "architectures cannot be empty when load weight!"
     architectures = getattr(model_config, "architectures", [])
     local_cache_path = os.path.expanduser(local_cache_path)
@@ -303,31 +299,75 @@ def load_megatron_model_weights(config,
         warnings.simplefilter("ignore")
         if 'mistral7b-rm' in config.model.path:
             model = MistralForSequenceClassification.from_pretrained(
-                local_model_path, device_map="auto", low_cpu_mem_usage=True)  # use score head instead of lm_head
+                local_model_path,
+                torch_dtype="auto",
+                # device_map="auto",  # disable auto device_map, the HF weight is only loaded to CPU in root rank
+                # low_cpu_mem_usage=True
+            )  # use score head instead of lm_head
             state_dict = model.state_dict()
             state_dict['lm_head.weight'] = state_dict['score.weight']
             state_dict['model.embed_tokens.weight'] = state_dict[
                 'model.embed_tokens.weight'][:32000]  # workaround, 32001 -> 32000
             is_value_model = True
         else:
-            model = AutoModelForCausalLM.from_pretrained(local_model_path,
-                                                         torch_dtype="auto",
-                                                         device_map="auto",
-                                                         low_cpu_mem_usage=True)
+            model = AutoModelForCausalLM.from_pretrained(
+                local_model_path,
+                torch_dtype="auto",
+                # device_map="auto", # disable auto device_map, the HF weight is only loaded to CPU in root rank
+                # low_cpu_mem_usage=True
+            )
             state_dict = model.state_dict()
+
+    return architectures, model, state_dict, is_value_model
+
+
+def load_megatron_model_weights(config,
+                               model_config,
+                               parallel_model,
+                               params_dtype,
+                               is_value_model=False,
+                               local_cache_path='~/.cache/verl/rlhf'):
+    """Load weights for verl customized model."""
+    architectures, model, state_dict, is_value_model = _load_hf_model(
+        config, model_config, is_value_model, local_cache_path
+    )
 
     from verl.models.weight_loader_registry import get_weight_loader
     print(f'before weight loader: architectures = {architectures}...')
     for arch in architectures:
         print(f'call weight loader arch = {arch}, model config = {model.config}')
         weight_loader = get_weight_loader(arch)
-        weight_loader(state_dict=state_dict,
-                      wrapped_models=parallel_model,
-                      config=model.config,
-                      params_dtype=params_dtype,
-                      is_value_model=is_value_model,
-                      tie_word_embeddings=model_config.tie_word_embeddings)
+        weight_loader(
+            state_dict=state_dict,
+            wrapped_models=parallel_model,
+            config=model.config,
+            params_dtype=params_dtype,
+            is_value_model=is_value_model,
+            tie_word_embeddings=model_config.tie_word_embeddings
+        )
     return model.config
+
+
+def load_megatron_gptmodel_weights(config,
+                                   model_config,
+                                   parallel_model,
+                                   params_dtype,
+                                   is_value_model=False,
+                                   local_cache_path='~/.cache/verl/rlhf'):
+    """Load weights for mcore GPT model."""
+    _, model, state_dict, is_value_model = _load_hf_model(
+        config, model_config, is_value_model, local_cache_path
+    )
+
+    from verl.models.mcore.loader import load_state_dict_to_megatron_gptmodel
+    load_state_dict_to_megatron_gptmodel(
+        state_dict=state_dict,
+        wrapped_models=parallel_model,
+        config=model.config,
+        params_dtype=params_dtype,
+        is_value_model=is_value_model
+    )
+    del state_dict, model
 
 
 # pad input_ids_rmpad, cu_seqlens and max_seqlen_in_batch to be divisible by tp
@@ -366,47 +406,6 @@ def pad_packed_inputs(unpad_tokens: torch.Tensor, cu_seqlens, max_seqlen_in_batc
 
     return unpad_tokens, cu_seqlens, max_seqlen_in_batch
 
-
-def load_megatron_gptmodel_weights(config,
-                                   model_config,
-                                   parallel_model,
-                                   params_dtype,
-                                   is_value_model=False,
-                                   local_cache_path='~/.cache/verl/rlhf'):
-    assert hasattr(model_config, "architectures"), "architectures cannot be empty when load weight!"
-    architectures = getattr(model_config, "architectures", [])
-    local_cache_path = os.path.expanduser(local_cache_path)
-
-    if config.model.path.startswith("hdfs:"):
-        from verl.utils.fs import copy_to_local
-        print(f'start download from {config.model.path}')
-        local_model_path = copy_to_local(src=config.model.path, cache_dir=local_cache_path)
-        print('finish download')
-    else:
-        print(f"load from local dir {config.model.path}")
-        local_model_path = config.model.path
-
-    # TODO: to find a better way to load mistral7b-rm lm_head
-    if 'mistral7b-rm' in config.model.path:
-        model = MistralForSequenceClassification.from_pretrained(local_model_path)  # use score head instead of lm_head
-        state_dict = model.state_dict()
-        state_dict['lm_head.weight'] = state_dict['score.weight']
-        state_dict['model.embed_tokens.weight'] = state_dict[
-            'model.embed_tokens.weight'][:32000]  # workaround, 32001 -> 32000
-        is_value_model = True
-    else:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-        model = AutoModelForCausalLM.from_pretrained(local_model_path)
-        state_dict = model.state_dict()
-
-    from verl.models.mcore.loader import load_state_dict_to_megatron_gptmodel
-    load_state_dict_to_megatron_gptmodel(state_dict=state_dict,
-                                         wrapped_models=parallel_model,
-                                         config=model.config,
-                                         params_dtype=params_dtype,
-                                         is_value_model=is_value_model)
-    del state_dict, model
 
 
 def get_parallel_gptmodel_from_config(tfconfig,


### PR DESCRIPTION
[bug fix] Loading 72B Qwen model for mcore megatron is causing OOM. 
Extracted out the HF loading logic to a helper function (and disable `device_map=auto`), and refactored the legacy function `load_megatron_model_weights` and the new function `load_megatron_gptmodel_weights`.  `load_megatron_model_weights` should be deprecated once the the class RewardModelWorker is also migrated to Mcore.