### PR TITLE
feat: support custom training metrics

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -176,6 +176,12 @@ custom_reward_function:
   path: null
   name: compute_score
 
+custom_metric_function:
+  path: null
+  name: "compute_custom_metrics"
+  # metric_kwargs:
+  #   track_every_n_steps: 10
+
 algorithm:
   gamma: 1.0
   lam: 1.0


### PR DESCRIPTION
## Description
This PR adds support for user-defined custom training metrics. Users can now define their own metric calculation functions in separate Python files and load them during training, similar to the existing custom reward function mechanism.

## Implementation Details
- Custom metric functions can be specified in the configuration file
- The functions receive the training batch and global step as inputs
- Additional parameters can be passed through the configuration
- Custom metrics are logged alongside standard training metrics

## Example Usage
Users can define custom metrics in a separate Python file:

```python
def compute_custom_metrics(batch, global_step, **kwargs):
    custom_metrics = {}
    # Calculate custom metrics based on batch data
    custom_metrics['custom/my_metric'] = some_calculation(batch)
    return custom_metrics
```

And specify it in the configuration:

```yaml
custom_metric_function:
  path: "/path/to/custom_metrics.py"
  name: "compute_custom_metrics"
  metric_kwargs:
    param1: value1
```

## Future Work
- Reuse reward module loading logic (we can define a flexible shared function)