### PR TITLE
[log] fix: val-core pattern

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -593,8 +593,9 @@ class RayPPOTrainer(object):
             for var_name, metric2val in var2metric2val.items():
                 n_max = max([int(name.split("@")[-1].split("/")[0]) for name in metric2val.keys()])
                 for metric_name, metric_val in metric2val.items():
-                    if var_name == core_var and any(metric_name.startswith(pfx)
-                                                    for pfx in ["mean", "maj", "best"]) and f"@{n_max}" in metric_name:
+                    if (var_name == core_var) and any(
+                            metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"]) and (f"@{n_max}"
+                                                                                                 in metric_name):
                         metric_sec = "val-core"
                     else:
                         metric_sec = "val-aux"

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -595,7 +595,7 @@ class RayPPOTrainer(object):
                 for metric_name, metric_val in metric2val.items():
                     if var_name == core_var and any(
                             metric_name.startswith(pfx)
-                            for pfx in ["mean", "std", "maj", "best"]) and f"@{n_max}/" in metric_name:
+                            for pfx in ["mean", "std", "maj", "best"]) and f"@{n_max}" in metric_name:
                         metric_sec = "val-core"
                     else:
                         metric_sec = "val-aux"

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -593,9 +593,8 @@ class RayPPOTrainer(object):
             for var_name, metric2val in var2metric2val.items():
                 n_max = max([int(name.split("@")[-1].split("/")[0]) for name in metric2val.keys()])
                 for metric_name, metric_val in metric2val.items():
-                    if var_name == core_var and any(
-                            metric_name.startswith(pfx)
-                            for pfx in ["mean", "std", "maj", "best"]) and f"@{n_max}" in metric_name:
+                    if var_name == core_var and any(metric_name.startswith(pfx)
+                                                    for pfx in ["mean", "maj", "best"]) and f"@{n_max}" in metric_name:
                         metric_sec = "val-core"
                     else:
                         metric_sec = "val-aux"


### PR DESCRIPTION
This PR

1. fixes the problem that important metrics like `"mean@{n}"` can not be recognized as `val-core` due to lack to `/...` at the end
2. removes `"std@{n}"` from `val-core`