### PR TITLE
Add WSD (Warmup-Stable-Decay) scheduler for SFT

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -482,3 +482,23 @@ Customized Reward Function
 
 - ``custom_reward_function.path``: The path to the file containing your customized reward function. If not specified, pre-implemented reward functions will be used.
 - ``custom_reward_function.name`` (Optional) : The name of the reward function within the specified file. Default is 'compute_score'.
+
+sft_trainer.yaml for FSDP Backend
+---------------------------------
+
+.. code:: yaml
+
+   optim:
+     lr: 1e-5
+     weight_decay: 0.01
+     warmup_steps_ratio: 0.1
+     clip_grad: 1.0
+     lr_scheduler: cosine
+
+- ``optim.lr``: Learning rate for the optimizer.
+- ``optim.weight_decay``: Weight decay for the optimizer.
+- ``optim.warmup_steps_ratio``: Ratio of warmup steps to total training steps.
+- ``optim.clip_grad``: Gradient clipping value.
+- ``optim.lr_scheduler``: Learning rate scheduler type. Options:
+  - ``cosine``: Cosine learning rate scheduler with warmup (default).
+  - ``wsd``: Warmup-Stable-Decay scheduler that provides a stable learning rate phase between warmup and decay phases.

--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -3,8 +3,8 @@
 Config Explanation
 ===================
 
-ppo_trainer.yaml for FSDP Backend
----------------------------------
+ppo_trainer.yaml for RL FSDP Backend
+-------------------------------------
 
 Data
 ~~~~
@@ -483,8 +483,8 @@ Customized Reward Function
 - ``custom_reward_function.path``: The path to the file containing your customized reward function. If not specified, pre-implemented reward functions will be used.
 - ``custom_reward_function.name`` (Optional) : The name of the reward function within the specified file. Default is 'compute_score'.
 
-sft_trainer.yaml for FSDP Backend
----------------------------------
+sft_trainer.yaml for SFT FSDP Backend
+--------------------------------------
 
 .. code:: yaml
 
@@ -500,5 +500,6 @@ sft_trainer.yaml for FSDP Backend
 - ``optim.warmup_steps_ratio``: Ratio of warmup steps to total training steps.
 - ``optim.clip_grad``: Gradient clipping value.
 - ``optim.lr_scheduler``: Learning rate scheduler type. Options:
+
   - ``cosine``: Cosine learning rate scheduler with warmup (default).
   - ``wsd``: Warmup-Stable-Decay scheduler that provides a stable learning rate phase between warmup and decay phases.

--- a/verl/trainer/config/sft_trainer.yaml
+++ b/verl/trainer/config/sft_trainer.yaml
@@ -38,6 +38,7 @@ optim:
   weight_decay: 0.01
   warmup_steps_ratio: 0.1
   clip_grad: 1.0
+  lr_scheduler: cosine
 ulysses_sequence_parallel_size: 1
 use_remove_padding: False
 trainer:

--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -289,8 +289,8 @@ class FSDPSFTTrainer(object):
                                                                 num_training_steps=self.total_steps)
         elif self.config.optim.lr_scheduler == 'wsd':
             self.lr_scheduler = get_wsd_schedule_with_warmup(optimizer=self.optimizer,
-                                                            num_warmup_steps=num_warmup_steps,
-                                                            num_training_steps=self.total_steps)
+                                                             num_warmup_steps=num_warmup_steps,
+                                                             num_training_steps=self.total_steps)
         else:
             raise ValueError(f'Unknown lr scheduler: {self.config.optim.lr_scheduler}')
 

--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -32,7 +32,7 @@ from torch import nn, optim
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, MixedPrecision, ShardingStrategy, CPUOffload
 from tqdm import tqdm
 from transformers import AutoTokenizer, AutoModelForCausalLM, PreTrainedModel, AutoConfig
-from verl.utils.torch_functional import get_cosine_schedule_with_warmup
+from verl.utils.torch_functional import get_cosine_schedule_with_warmup, get_wsd_schedule_with_warmup
 from tensordict import TensorDict
 from torch.utils.data import DataLoader, DistributedSampler
 from flash_attn.bert_padding import pad_input, unpad_input, rearrange, index_first_axis
@@ -283,9 +283,16 @@ class FSDPSFTTrainer(object):
 
         num_warmup_steps = int(self.total_steps * self.config.optim.warmup_steps_ratio)
 
-        self.lr_scheduler = get_cosine_schedule_with_warmup(optimizer=self.optimizer,
+        if not hasattr(self.config.optim, 'lr_scheduler') or self.config.optim.lr_scheduler == 'cosine':
+            self.lr_scheduler = get_cosine_schedule_with_warmup(optimizer=self.optimizer,
+                                                                num_warmup_steps=num_warmup_steps,
+                                                                num_training_steps=self.total_steps)
+        elif self.config.optim.lr_scheduler == 'wsd':
+            self.lr_scheduler = get_wsd_schedule_with_warmup(optimizer=self.optimizer,
                                                             num_warmup_steps=num_warmup_steps,
                                                             num_training_steps=self.total_steps)
+        else:
+            raise ValueError(f'Unknown lr scheduler: {self.config.optim.lr_scheduler}')
 
     def _compute_loss_and_backward(self, batch, do_backward=True):
         """Compute loss with optional sequence parallelism and remove padding features"""

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -526,3 +526,58 @@ def get_unpad_data(attention_mask):
         cu_seqlens,
         max_seqlen_in_batch,
     )
+
+
+def get_wsd_schedule_with_warmup(
+    optimizer: Optimizer,
+    num_warmup_steps: int,
+    num_training_steps: int,
+    min_lr_ratio: float = 0.0,
+    num_cycles: float = 0.5,
+    last_epoch: int = -1,
+    stable_ratio: float = 0.9,
+):
+    """
+    Create a Warmup-Stable-Decay learning rate scheduler.
+
+    The schedule follows three phases:
+    1. Warmup: Learning rate increases linearly from 0 to the initial LR
+    2. Stable: Learning rate remains constant at the initial LR
+    3. Decay: Learning rate decreases following a cosine curve to min_lr_ratio * initial LR
+
+    Args:
+        optimizer (:class:`~torch.optim.Optimizer`):
+            The optimizer for which to schedule the learning rate.
+        num_warmup_steps (:obj:`int`):
+            The number of steps for the warmup phase.
+        num_training_steps (:obj:`int`):
+            The total number of training steps.
+        min_lr_ratio (:obj:`float`, `optional`, defaults to 0.0):
+            The minimum learning rate ratio w.r.t the initial learning rate.
+        num_cycles (:obj:`float`, `optional`, defaults to 0.5):
+            The number of waves in the cosine schedule during decay phase.
+        last_epoch (:obj:`int`, `optional`, defaults to -1):
+            The index of the last epoch when resuming training.
+        stable_ratio (:obj:`float`, `optional`, defaults to 0.0):
+            The ratio of non-warmup steps that should maintain a constant learning rate.
+            Set to 0.0 to behave exactly like cosine schedule.
+
+    Return:
+        :obj:`torch.optim.lr_scheduler.LambdaLR` with the appropriate schedule.
+    """
+    remaining_steps = max(0, num_training_steps - num_warmup_steps)
+    num_stable_steps = int(remaining_steps * stable_ratio)
+    num_decay_steps = remaining_steps - num_stable_steps
+
+    def lr_lambda(current_step):
+        if current_step < num_warmup_steps:
+            return float(current_step) / float(max(1, num_warmup_steps))
+        if current_step < num_warmup_steps + num_stable_steps:
+            return 1.0
+        if current_step < num_training_steps:
+            progress = float(current_step - num_warmup_steps - num_stable_steps) / float(max(1, num_decay_steps))
+            value = max(0.0, 0.5 * (1.0 + math.cos(math.pi * float(num_cycles) * 2.0 * progress)))
+            return (1.0 - min_lr_ratio) * value + min_lr_ratio
+        return min_lr_ratio
+
+    return LambdaLR(optimizer, lr_lambda, last_epoch)


### PR DESCRIPTION
# Add WSD (Warmup-Stable-Decay) Learning Rate Scheduler

## Overview
This PR adds a new learning rate scheduler called WSD (Warmup-Stable-Decay) that provides more control over the learning rate schedule during training. The WSD scheduler extends the traditional cosine scheduler by adding a stable phase where the learning rate remains constant.

## Features
- **Three-phase schedule**: Warmup → Stable → Decay
- **Configurable stable phase**: Control what percentage of training maintains a constant learning rate
- **Compatible with existing code**: Minimal changes to the trainer infrastructure
- **Default to cosine**: Maintains backward compatibility with existing configurations

## Implementation Details
1. Added `get_wsd_schedule_with_warmup` function to `verl/utils/torch_functional.py`
2. Updated the SFT trainer to support the new scheduler type
3. Added `lr_scheduler: cosine` as the default in the SFT trainer config

Here's the reference implementation: https://github.com/kozistr/pytorch_optimizer/blob/6397d56279ad80b26c4bba7fb4b04852b517fdeb/pytorch_optimizer/lr_scheduler/wsd.py#L8

## Usage
To use the WSD scheduler, set the following in your configuration:
```yaml
optim:
  lr_scheduler: wsd  # Options: 'cosine' (default) or 'wsd'
```

## Benefits
- Better control over learning rate behavior during training
- Potentially improved training stability for certain tasks
- Allows experimentation with different learning rate schedules without code changes

(trying to get this in to make sure my own branch don't end up with huge chunk of git conflict 😓 )