### PR TITLE
fix checkpoint rng_states confliction

### DIFF
--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -301,9 +301,9 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             torch.distributed.barrier()
 
             rng_state_path = get_rng_states_checkpoint_path(local_path)
-            rng_state = self.get_rng_state()
-            torch.save(rng_state, rng_state_path)
-            if self.rank == 0:
-                print(f"saving rng states to {rng_state_path}")
+            if self.rank % torch.cuda.device_count() == 0:
+                rng_state = self.get_rng_state()
+                torch.save(rng_state, rng_state_path)
+                print(f"Rank {self.rank} saving rng states to {rng_state_path}")
 
         self.previous_saved_paths.append(local_path)

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -173,7 +173,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         self.optimizer.load_parameter_state(optimizer_path)
 
     def load_rng_states(self, ckpt_path, data_parallel_random_init=False, use_dist_ckpt=False):
-        rng_state_path = get_rng_states_checkpoint_path(ckpt_path)
+        rng_state_path = get_rng_states_checkpoint_path(ckpt_path, only_rank0_save=False)
         print(f"Loading rng states from {rng_state_path}")
         rng_state = torch.load(rng_state_path)
         # access rng_state for data parallel rank
@@ -300,10 +300,9 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         if 'extra' in self.checkpoint_contents:
             torch.distributed.barrier()
 
-            rng_state_path = get_rng_states_checkpoint_path(local_path)
-            if self.rank % torch.cuda.device_count() == 0:
-                rng_state = self.get_rng_state()
-                torch.save(rng_state, rng_state_path)
-                print(f"Rank {self.rank} saving rng states to {rng_state_path}")
+            rng_state_path = get_rng_states_checkpoint_path(local_path, only_rank0_save=False)
+            rng_state = self.get_rng_state()
+            torch.save(rng_state, rng_state_path)
+            print(f"Rank {self.rank} saving rng states to {rng_state_path}")
 
         self.previous_saved_paths.append(local_path)

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -291,9 +291,14 @@ def get_optimizer_checkpoint_path(checkpoint_path, use_distributed_optimizer=Tru
     return os.path.join(checkpoint_path, f"optim", f"distrib_optim_pp{pp_rank}_tp{tp_rank}_cp{cp_rank}_dp{dp_rank}.pt")
 
 
-def get_rng_states_checkpoint_path(checkpoint_path, data_parallel_random_init=False):
+def get_rng_states_checkpoint_path(checkpoint_path, only_rank0_save=True):
+    # save rng states cause interrupts
     os.makedirs(os.path.join(checkpoint_path, "rng_states"), exist_ok=True)
-    if not data_parallel_random_init:
+    if only_rank0_save:
         return os.path.join(checkpoint_path, f'rng_states', "rng_states.pt")
     dp_rank = mpu.get_data_parallel_rank()
-    return os.path.join(checkpoint_path, f'rng_states', f"rng_states_{dp_rank}.pt")
+    pp_rank = mpu.get_pipeline_model_parallel_rank()
+    tp_rank = mpu.get_tensor_model_parallel_rank()
+    cp_rank = mpu.get_context_parallel_rank()
+    return os.path.join(checkpoint_path, f'rng_states',
+                        f"rng_states_pp{pp_rank}_tp{tp_rank}_cp{cp_rank}_dp{dp_rank}.pt")


### PR DESCRIPTION
Only 1 node in a machine save rng_states to avoid conflicts and read properly

New version of torch.save can cause races here.

FSDP also split the rng_states in extra states