### PR TITLE
[mcore] refactor

### DIFF
--- a/verl/models/mcore/__init__.py
+++ b/verl/models/mcore/__init__.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .gpt_model import gptmodel_forward
-from .registry import init_mcore_model, hf_to_mcore_config
+from .registry import init_mcore_model, hf_to_mcore_config, get_mcore_forward_fn
 
-__all__ = ['init_mcore_model', 'hf_to_mcore_config', 'gptmodel_forward']
+__all__ = ['init_mcore_model', 'hf_to_mcore_config', 'get_mcore_forward_fn']

--- a/verl/models/mcore/__init__.py
+++ b/verl/models/mcore/__init__.py
@@ -14,3 +14,6 @@
 # limitations under the License.
 
 from .gpt_model import gptmodel_forward
+from .registry import init_mcore_model, hf_to_mcore_config
+
+__all__ = ['init_mcore_model', 'hf_to_mcore_config', 'gptmodel_forward']

--- a/verl/models/mcore/config_converter.py
+++ b/verl/models/mcore/config_converter.py
@@ -19,7 +19,7 @@ from transformers import PretrainedConfig
 from megatron.core.transformer import TransformerConfig
 import torch
 import torch.nn.functional as F
-from megatron.core.enums import AttnBackend
+from megatron.core.transformer.enums import AttnBackend
 
 
 def hf_to_mcore_config_dense(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:

--- a/verl/models/mcore/config_converter.py
+++ b/verl/models/mcore/config_converter.py
@@ -1,0 +1,84 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# convert huggingface config to mcore transformer config
+
+from transformers import PretrainedConfig
+from megatron.core.transformer import TransformerConfig
+import torch
+import torch.nn.functional as F
+from megatron.core.enums import AttnBackend
+
+
+def hf_to_mcore_config_dense(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
+    # for LlamaForCausalLM or Qwen2ForCausalLM
+    from megatron.core import parallel_state as mpu
+    if "Qwen2ForCausalLM" in hf_config.architectures:
+        qkv_bias = True
+    else:
+        qkv_bias = getattr(hf_config, 'attention_bias', False)
+    overlap_p2p_comm = mpu.get_virtual_pipeline_model_parallel_world_size(
+    ) is not None and mpu.get_virtual_pipeline_model_parallel_world_size() > 1
+    batch_p2p_comm = False
+    transformer_config = TransformerConfig(
+        num_layers=hf_config.num_hidden_layers,
+        hidden_size=hf_config.hidden_size,
+        num_attention_heads=hf_config.num_attention_heads,
+        num_query_groups=hf_config.num_key_value_heads,
+        ffn_hidden_size=hf_config.intermediate_size,
+        activation_func=F.silu,
+        normalization='RMSNorm',
+        gated_linear_unit=True,
+        use_cpu_initialization=True,
+        add_bias_linear=False,
+        tensor_model_parallel_size=mpu.get_tensor_model_parallel_world_size(),
+        pipeline_model_parallel_size=mpu.get_pipeline_model_parallel_world_size(),
+        virtual_pipeline_model_parallel_size=mpu.get_virtual_pipeline_model_parallel_world_size(),
+        context_parallel_size=mpu.get_context_parallel_world_size(),
+        overlap_p2p_comm=overlap_p2p_comm,
+        batch_p2p_comm=batch_p2p_comm,
+        pipeline_dtype=dtype,
+        params_dtype=dtype,
+        sequence_parallel=mpu.get_tensor_model_parallel_world_size() > 1,
+        variable_seq_lengths=True,
+        masked_softmax_fusion=True,
+        moe_token_dispatcher_type="alltoall",
+        attention_dropout=hf_config.attention_dropout,
+        hidden_dropout=getattr(hf_config, 'hidden_dropout', 0.0),
+        add_qkv_bias=qkv_bias,
+        attention_backend=AttnBackend.flash,
+        bf16=dtype is torch.bfloat16)
+
+    return transformer_config
+
+
+def hf_to_mcore_config_qwen2moe(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
+    # Qwen2MoeForCausalLM
+    raise NotImplementedError("Qwen2MoeForCausalLM is not supported yet")
+
+
+def hf_to_mcore_config_dpskv3(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
+    # DeepseekV3ForCausalLM
+    raise NotImplementedError("DeepseekV3ForCausalLM is not supported yet")
+
+
+def hf_to_mcore_config_qwen2_5_vl(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
+    # Qwen2_5_VLForConditionalGeneration
+    raise NotImplementedError("Qwen2_5_VLForConditionalGeneration is not supported yet")
+
+
+def hf_to_mcore_config_llama4(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
+    # Llama4ForConditionalGeneration
+    raise NotImplementedError("Llama4ForConditionalGeneration is not supported yet")

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -1,0 +1,107 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from verl.utils.megatron import sequence_parallel as sp_utils
+from verl.utils.megatron import tensor_parallel as tp_utils
+import torch
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core import parallel_state as mpu
+from verl.utils.megatron_utils import unwrap_model
+from .util import preprocess_packed_seqs, postprocess_packed_seqs, remove_left_padding, recover_left_padding
+
+
+def gptmodel_forward_dense(model,
+                           input_ids,
+                           attention_mask,
+                           position_ids,
+                           sequence_parallel,
+                           value_model=False,
+                           pack_seqs=True):
+    pre_process = unwrap_model(model).pre_process
+    post_process = unwrap_model(model).post_process
+    if pack_seqs:
+        batch_size, seq_len = attention_mask.shape[:2]
+        input_ids_rmpad, packed_seq_params = preprocess_packed_seqs(input_ids, attention_mask, pre_process=pre_process)
+        input_ids_rmpad = input_ids_rmpad.contiguous()
+        output_orig = model(input_ids=input_ids_rmpad,
+                            attention_mask=None,
+                            position_ids=position_ids,
+                            packed_seq_params=packed_seq_params)
+
+        output = postprocess_packed_seqs(output_orig,
+                                         packed_seq_params,
+                                         attention_mask,
+                                         batch_size,
+                                         seq_len,
+                                         post_process=post_process)
+    else:
+        batch_size, sequence_length = attention_mask.shape
+        new_input_ids, new_attention_mask, new_position_ids = remove_left_padding(input_ids,
+                                                                                  attention_mask,
+                                                                                  position_ids,
+                                                                                  sequence_parallel,
+                                                                                  pre_process=pre_process)
+        output = model(input_ids=new_input_ids, attention_mask=new_attention_mask, position_ids=new_position_ids)
+        output = recover_left_padding(output,
+                                      new_attention_mask,
+                                      attention_mask,
+                                      sequence_length,
+                                      post_process=post_process)
+    if value_model and post_process:
+        output = output[..., 0]
+    return output
+
+
+def gptmodel_forward_qwen2_moe(model,
+                               input_ids,
+                               attention_mask,
+                               position_ids,
+                               sequence_parallel,
+                               value_model=False,
+                               pack_seqs=True):
+    return gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model,
+                                  pack_seqs)
+
+
+def gptmodel_forward_llama4(model,
+                            input_ids,
+                            attention_mask,
+                            position_ids,
+                            sequence_parallel,
+                            value_model=False,
+                            pack_seqs=True):
+    return gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model,
+                                  pack_seqs)
+
+
+def gptmodel_forward_dpskv3(model,
+                            input_ids,
+                            attention_mask,
+                            position_ids,
+                            sequence_parallel,
+                            value_model=False,
+                            pack_seqs=True):
+    return gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model,
+                                  pack_seqs)
+
+
+def gptmodel_forward_qwen2_5_vl(model,
+                                input_ids,
+                                attention_mask,
+                                position_ids,
+                                sequence_parallel,
+                                value_model=False,
+                                pack_seqs=True):
+    raise NotImplementedError("VLM is not supported yet")

--- a/verl/models/mcore/model_initializer.py
+++ b/verl/models/mcore/model_initializer.py
@@ -1,0 +1,88 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# use mcore transformer config to initialize the model
+
+
+def init_mcore_model_dense(tfconfig,
+                           hf_config,
+                           pre_process=None,
+                           post_process=None,
+                           share_embeddings_and_output_weights=False,
+                           value=False):
+    # for LlamaForCausalLM, Qwen2ForCausalLM
+    from megatron.core.models.gpt.gpt_model import GPTModel
+    from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+    use_te = True
+    assert tfconfig.normalization == "RMSNorm", 'only RMSNorm is supported for now'
+    transformer_layer_spec = get_gpt_decoder_block_spec(tfconfig, use_transformer_engine=use_te)
+    rope_scaling_args = {}
+    if hf_config.rope_scaling is not None:
+        assert hf_config.rope_scaling['type'] == 'linear', "only linear scaling is supported for now"
+        rope_scaling_args['seq_len_interpolation_factor'] = hf_config.rope_scaling['factor']
+    model = GPTModel(config=tfconfig,
+                     transformer_layer_spec=transformer_layer_spec,
+                     vocab_size=hf_config.vocab_size,
+                     max_sequence_length=hf_config.max_position_embeddings,
+                     pre_process=pre_process,
+                     post_process=post_process,
+                     share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+                     position_embedding_type='rope',
+                     rotary_base=hf_config.rope_theta,
+                     **rope_scaling_args)
+    if post_process and value:
+        from verl.models.llama.megatron.layers.parallel_linear import LinearForLastLayer
+        model.output_layer = LinearForLastLayer(input_size=tfconfig.hidden_size, output_size=1, config=tfconfig)
+    return model
+
+
+def init_mcore_model_qwen2_moe(tfconfig,
+                               hf_config,
+                               pre_process=None,
+                               post_process=None,
+                               share_embeddings_and_output_weights=False,
+                               value=False):
+    return init_mcore_model_dense(tfconfig, hf_config, pre_process, post_process, share_embeddings_and_output_weights,
+                                  value)
+
+
+def init_mcore_model_llama4(tfconfig,
+                            hf_config,
+                            pre_process=None,
+                            post_process=None,
+                            share_embeddings_and_output_weights=False,
+                            value=False):
+    return init_mcore_model_dense(tfconfig, hf_config, pre_process, post_process, share_embeddings_and_output_weights,
+                                  value)
+
+
+def init_mcore_model_dpskv3(tfconfig,
+                            hf_config,
+                            pre_process=None,
+                            post_process=None,
+                            share_embeddings_and_output_weights=False,
+                            value=False):
+    return init_mcore_model_dense(tfconfig, hf_config, pre_process, post_process, share_embeddings_and_output_weights,
+                                  value)
+
+
+def init_mcore_model_qwen2_5_vl(tfconfig,
+                                hf_config,
+                                pre_process=None,
+                                post_process=None,
+                                share_embeddings_and_output_weights=False,
+                                value=False):
+    # Qwen2_5_VLForConditionalGeneration
+    raise NotImplementedError("VLM is not supported yet")

--- a/verl/models/mcore/registry.py
+++ b/verl/models/mcore/registry.py
@@ -63,3 +63,23 @@ def init_mcore_model(
                          f"Supported architectures: {MODEL_INITIALIZER_REGISTRY.keys()}")
     return MODEL_INITIALIZER_REGISTRY[arch](tfconfig, hf_config, pre_process, post_process,
                                             share_embeddings_and_output_weights, value, **extra_kwargs)
+
+
+from .model_forward import gptmodel_forward_dense, gptmodel_forward_qwen2_moe, gptmodel_forward_llama4, gptmodel_forward_dpskv3, gptmodel_forward_qwen2_5_vl
+
+
+def get_mcore_forward_fn(hf_config: PretrainedConfig):
+    MODEL_FORWARD_REGISTRY = {
+        "LlamaForCausalLM": gptmodel_forward_dense,
+        "Qwen2ForCausalLM": gptmodel_forward_dense,
+        "Qwen2MoeForCausalLM": gptmodel_forward_qwen2_moe,
+        "DeepseekV3ForCausalLM": gptmodel_forward_dpskv3,
+        "Qwen2_5_VLForConditionalGeneration": gptmodel_forward_qwen2_5_vl,
+        "Llama4ForConditionalGeneration": gptmodel_forward_llama4,
+    }
+    assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
+    arch = hf_config.architectures[0]
+    if arch not in MODEL_FORWARD_REGISTRY:
+        raise ValueError(f"Model architectures {arch} forward function are not supported for now. "
+                         f"Supported architectures: {MODEL_FORWARD_REGISTRY.keys()}")
+    return MODEL_FORWARD_REGISTRY[arch]

--- a/verl/models/mcore/registry.py
+++ b/verl/models/mcore/registry.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_converter import hf_to_mcore_config_dense, hf_to_mcore_config_qwen2moe, hf_to_mcore_config_dpskv3, hf_to_mcore_config_qwen2_5_vl, hf_to_mcore_config_llama4
+from .config_converter import PretrainedConfig, TransformerConfig
+import torch
+import torch.nn as nn
+
+
+def hf_to_mcore_config(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
+    MODEL_CONFIG_CONVERTER_REGISTRY = {
+        "LlamaForCausalLM": hf_to_mcore_config_dense,
+        "Qwen2ForCausalLM": hf_to_mcore_config_dense,
+        "Qwen2MoeForCausalLM": hf_to_mcore_config_qwen2moe,
+        "DeepseekV3ForCausalLM": hf_to_mcore_config_dpskv3,
+        "Qwen2_5_VLForConditionalGeneration": hf_to_mcore_config_qwen2_5_vl,
+        "Llama4ForConditionalGeneration": hf_to_mcore_config_llama4,
+    }
+    assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
+    arch = hf_config.architectures[0]
+    if arch not in MODEL_CONFIG_CONVERTER_REGISTRY:
+        raise ValueError(f"Model architectures {arch} converter are not supported for now. "
+                         f"Supported architectures: {MODEL_CONFIG_CONVERTER_REGISTRY.keys()}")
+    return MODEL_CONFIG_CONVERTER_REGISTRY[arch](hf_config, dtype)
+
+
+from .model_initializer import init_mcore_model_dense, init_mcore_model_qwen2_moe, init_mcore_model_dpskv3, init_mcore_model_qwen2_5_vl, init_mcore_model_llama4
+
+
+def init_mcore_model(
+        tfconfig,
+        hf_config,
+        pre_process=None,
+        post_process=None,
+        share_embeddings_and_output_weights=False,
+        value=False,
+        **extra_kwargs  # may be used for vlm
+) -> nn.Module:
+    MODEL_INITIALIZER_REGISTRY = {
+        "LlamaForCausalLM": init_mcore_model_dense,
+        "Qwen2ForCausalLM": init_mcore_model_dense,
+        "Qwen2MoeForCausalLM": init_mcore_model_qwen2_moe,
+        "DeepseekV3ForCausalLM": init_mcore_model_dpskv3,
+        "Qwen2_5_VLForConditionalGeneration": init_mcore_model_qwen2_5_vl,
+        "Llama4ForConditionalGeneration": init_mcore_model_llama4,
+    }
+    assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
+    arch = hf_config.architectures[0]
+    if arch not in MODEL_INITIALIZER_REGISTRY:
+        raise ValueError(f"Model architectures {arch} initializer are not supported for now. "
+                         f"Supported architectures: {MODEL_INITIALIZER_REGISTRY.keys()}")
+    return MODEL_INITIALIZER_REGISTRY[arch](tfconfig, hf_config, pre_process, post_process,
+                                            share_embeddings_and_output_weights, value, **extra_kwargs)

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -21,48 +21,6 @@ from megatron.core import parallel_state as mpu
 from verl.utils.megatron_utils import unwrap_model
 
 
-def gptmodel_forward(model,
-                     input_ids,
-                     attention_mask,
-                     position_ids,
-                     sequence_parallel,
-                     value_model=False,
-                     pack_seqs=True):
-    pre_process = unwrap_model(model).pre_process
-    post_process = unwrap_model(model).post_process
-    if pack_seqs:
-        batch_size, seq_len = attention_mask.shape[:2]
-        input_ids_rmpad, packed_seq_params = preprocess_packed_seqs(input_ids, attention_mask, pre_process=pre_process)
-        input_ids_rmpad = input_ids_rmpad.contiguous()
-        output_orig = model(input_ids=input_ids_rmpad,
-                            attention_mask=None,
-                            position_ids=position_ids,
-                            packed_seq_params=packed_seq_params)
-
-        output = postprocess_packed_seqs(output_orig,
-                                         packed_seq_params,
-                                         attention_mask,
-                                         batch_size,
-                                         seq_len,
-                                         post_process=post_process)
-    else:
-        batch_size, sequence_length = attention_mask.shape
-        new_input_ids, new_attention_mask, new_position_ids = remove_left_padding(input_ids,
-                                                                                  attention_mask,
-                                                                                  position_ids,
-                                                                                  sequence_parallel,
-                                                                                  pre_process=pre_process)
-        output = model(input_ids=new_input_ids, attention_mask=new_attention_mask, position_ids=new_position_ids)
-        output = recover_left_padding(output,
-                                      new_attention_mask,
-                                      attention_mask,
-                                      sequence_length,
-                                      post_process=post_process)
-    if value_model and post_process:
-        output = output[..., 0]
-    return output
-
-
 def preprocess_packed_seqs(input_ids: torch.Tensor,
                            attention_mask: torch.Tensor,
                            pre_process: bool = True) -> tuple[torch.Tensor, PackedSeqParams]:

--- a/verl/single_controller/base/megatron/worker.py
+++ b/verl/single_controller/base/megatron/worker.py
@@ -37,3 +37,48 @@ class MegatronWorker(Worker):
         cp_rank = mpu.get_context_parallel_rank()
         info = DistRankInfo(tp_rank=tp_rank, dp_rank=dp_rank, pp_rank=pp_rank, cp_rank=cp_rank)
         return info
+
+    def _init_hf_config_and_tf_config(self, 
+                                      model_path,
+                                      dtype,
+                                      override_model_config):
+        from verl.utils.model import print_model_size, update_model_config
+        from verl.utils.fs import copy_to_local
+        from verl.utils import hf_tokenizer
+        from transformers import AutoConfig
+        from verl.models.mcore import hf_to_mcore_config
+
+        # Step 1: initialize the tokenizer
+        self.local_path = copy_to_local(model_path)
+        self.tokenizer = hf_tokenizer(self.local_path)
+
+        # Step 2: get the hf
+        hf_config = AutoConfig.from_pretrained(self.local_path)
+
+        # Step 3: override the hf config
+        override_config_kwargs = {
+            'bos_token_id': self.tokenizer.bos_token_id,
+            'eos_token_id': self.tokenizer.eos_token_id,
+            'pad_token_id': self.tokenizer.pad_token_id,
+        }
+        override_config_kwargs.update(override_model_config)
+        self.share_embeddings_and_output_weights = getattr(hf_config, "tie_word_embeddings", False)
+        update_model_config(hf_config, override_config_kwargs=override_config_kwargs)
+        self.architectures = getattr(hf_config, "architectures", None)
+        if self.rank == 0:
+            print(f'Model config after override: {hf_config}')
+        tf_config = hf_to_mcore_config(hf_config, dtype)
+
+        def add_optimization_config_to_tf_config(tf_config, verl_model_config):
+            # add optimization config to tf_config, e.g. checkpointing
+            if verl_model_config.get('enable_gradient_checkpointing', False):
+                gradient_checkpointing_cfg = dict(verl_model_config.get('gradient_checkpointing_kwargs', dict()))
+                tf_config.recompute_method = gradient_checkpointing_cfg.get('activations_checkpoint_method', 'full')
+                tf_config.recompute_granularity = gradient_checkpointing_cfg.get('activations_checkpoint_granularity', 'full')
+                tf_config.recompute_num_layers = gradient_checkpointing_cfg.get('activations_checkpoint_num_layers', -1)
+
+        add_optimization_config_to_tf_config(tf_config, self.config.model)
+
+        print(f'TF config: {tf_config}')
+        self.hf_config = hf_config
+        self.tf_config = tf_config

--- a/verl/single_controller/base/megatron/worker.py
+++ b/verl/single_controller/base/megatron/worker.py
@@ -38,10 +38,7 @@ class MegatronWorker(Worker):
         info = DistRankInfo(tp_rank=tp_rank, dp_rank=dp_rank, pp_rank=pp_rank, cp_rank=cp_rank)
         return info
 
-    def _init_hf_config_and_tf_config(self, 
-                                      model_path,
-                                      dtype,
-                                      override_model_config):
+    def _init_hf_config_and_tf_config(self, model_path, dtype, override_model_config):
         from verl.utils.model import print_model_size, update_model_config
         from verl.utils.fs import copy_to_local
         from verl.utils import hf_tokenizer
@@ -74,7 +71,8 @@ class MegatronWorker(Worker):
             if verl_model_config.get('enable_gradient_checkpointing', False):
                 gradient_checkpointing_cfg = dict(verl_model_config.get('gradient_checkpointing_kwargs', dict()))
                 tf_config.recompute_method = gradient_checkpointing_cfg.get('activations_checkpoint_method', 'full')
-                tf_config.recompute_granularity = gradient_checkpointing_cfg.get('activations_checkpoint_granularity', 'full')
+                tf_config.recompute_granularity = gradient_checkpointing_cfg.get('activations_checkpoint_granularity',
+                                                                                 'full')
                 tf_config.recompute_num_layers = gradient_checkpointing_cfg.get('activations_checkpoint_num_layers', -1)
 
         add_optimization_config_to_tf_config(tf_config, self.config.model)

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -217,6 +217,11 @@ def mcore_model_parallel_config(
     sequence_parallel: bool,
     params_dtype: torch.dtype,
 ) -> ModelParallelConfig:
+    # WARNING: Code should not reach this point. This function is deprecated and will be removed.
+    # Please use hf_to_mcore_config_dense() from verl.models.mcore.config_converter instead.
+    warnings.warn("Code should not reach this point. This function is deprecated and will be removed. "
+                 "Please use hf_to_mcore_config_dense() from verl.models.mcore.config_converter instead.",
+                 DeprecationWarning, stacklevel=2)
     return ModelParallelConfig(
         tensor_model_parallel_size=mpu.get_tensor_model_parallel_world_size(),
         pipeline_model_parallel_size=mpu.get_pipeline_model_parallel_world_size(),

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -219,9 +219,11 @@ def mcore_model_parallel_config(
 ) -> ModelParallelConfig:
     # WARNING: Code should not reach this point. This function is deprecated and will be removed.
     # Please use hf_to_mcore_config_dense() from verl.models.mcore.config_converter instead.
-    warnings.warn("Code should not reach this point. This function is deprecated and will be removed. "
-                 "Please use hf_to_mcore_config_dense() from verl.models.mcore.config_converter instead.",
-                 DeprecationWarning, stacklevel=2)
+    warnings.warn(
+        "Code should not reach this point. This function is deprecated and will be removed. "
+        "Please use hf_to_mcore_config_dense() from verl.models.mcore.config_converter instead.",
+        DeprecationWarning,
+        stacklevel=2)
     return ModelParallelConfig(
         tensor_model_parallel_size=mpu.get_tensor_model_parallel_world_size(),
         pipeline_model_parallel_size=mpu.get_pipeline_model_parallel_world_size(),

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -53,7 +53,7 @@ __all__ = ['MegatronPPOActor']
 class MegatronPPOActor(BasePPOActor):
 
     def __init__(self, config, model_config, hf_config, tf_config, actor_module: nn.ModuleList,
-                 actor_optimizer: DistributedOptimizer, actor_optimizer_config: OptimizerConfig):
+                 actor_optimizer: DistributedOptimizer):
         """MeagtronPPOActor class. This class implements the simple PPO logics when the model is built with Megatron.
 
         Args:
@@ -107,7 +107,6 @@ class MegatronPPOActor(BasePPOActor):
         self.tf_config = tf_config
         self.actor_module = actor_module
         self.actor_optimizer: DistributedOptimizer = actor_optimizer
-        self.actor_optimizer_config = actor_optimizer_config
 
         self.optimizer_step_args = OmegaConf.create({
             'skip_grad': None,

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -52,7 +52,7 @@ __all__ = ['MegatronPPOActor']
 
 class MegatronPPOActor(BasePPOActor):
 
-    def __init__(self, config, model_config, megatron_config: ModelParallelConfig, actor_module: nn.ModuleList,
+    def __init__(self, config, model_config, hf_config, tf_config, actor_module: nn.ModuleList,
                  actor_optimizer: DistributedOptimizer, actor_optimizer_config: OptimizerConfig):
         """MeagtronPPOActor class. This class implements the simple PPO logics when the model is built with Megatron.
 
@@ -72,13 +72,8 @@ class MegatronPPOActor(BasePPOActor):
                 ``entropy_coeff``: entropy coefficient of the PPO loss. See https://arxiv.org/abs/1707.06347.
             model_config (OmegaConf): model configuration. It must contains ``model_config.vocab_size`` and
                 ``model_config.hidden_size``
-            megatron_config (OmegaConf): megatron configuration. It must contains
-
-                ``sequence_parallel_enabled``: whether the sequence parallel is enabled.
-
-                ``param_dtype``: the dtype of the parameters.
-
-                ``virtual_pipeline_model_parallel_size``: virtual pipeline model parallel size. a.k.a number of chunks in each pp stage.
+            hf_config (PretrainedConfig): huggingface config
+            tf_config (TransformerConfig): mcore transformer config
             actor_module (nn.ModuleList): actor module is a ModuleList that contains a list of nn.Module in this pp stage.
                 each nn.Module in this rank holds a vpp module chunk. See https://arxiv.org/pdf/2104.04473.pdf for more details.
                 The actor module has some constraints to follow in order to use the updating logics implemented here
@@ -93,13 +88,6 @@ class MegatronPPOActor(BasePPOActor):
             actor_optimizer (DistributedOptimizer): currently, we only support DistributedOptimizer in Megatron. It implements
                 zero1 optimizer that shards the optimizer state across dp ranks.
 
-        >>> def megatron_actor_model_provider(pre_process, post_process):
-        >>>     vpp_rank = mpu.get_virtual_pipeline_model_parallel_rank()
-        >>>     parallel_model = ParallelMistralForCausalLMRmPadPP(config=actor_model_config,
-        >>>                                                        megatron_config=megatron_config,
-        >>>                                                        pre_process=pre_process,
-        >>>                                                        post_process=post_process).cuda()
-        >>>     return parallel_model
         >>> from megatron.training import get_model
         >>> from megatron.optimizer import get_megatron_optimizer
         >>> actor_module = get_model(megatron_actor_model_provider, wrap_with_ddp=True)
@@ -107,14 +95,16 @@ class MegatronPPOActor(BasePPOActor):
         >>> actor_optimizer = get_megatron_optimizer(actor_module)
         >>> actor = MegatronPPOActor(config=config,
         >>>                          model_config=actor_model_config,
-        >>>                          megatron_config=megatron_config,
+        >>>                          hf_config=hf_config,
+        >>>                          tf_config=tf_config,
         >>>                          actor_module=actor_module,
         >>>                          actor_optimizer=actor_optimizer)
         """
         super().__init__(config)
         self._validate_config(config)
         self.model_config = model_config
-        self.megatron_config = megatron_config
+        self.hf_config = hf_config
+        self.tf_config = tf_config
         self.actor_module = actor_module
         self.actor_optimizer: DistributedOptimizer = actor_optimizer
         self.actor_optimizer_config = actor_optimizer_config
@@ -124,7 +114,7 @@ class MegatronPPOActor(BasePPOActor):
             'overlap_dp_param_comm': False,
             'overlap_dp_grad_comm': False,
             'gradient_accumulation_steps': 1,
-            'sequence_parallel': self.megatron_config.sequence_parallel,
+            'sequence_parallel': self.tf_config.sequence_parallel,
             'DDP_impl': 'local',
             'layernorm_allreduce_bucket_threshold': 0,
             'pipeline_model_parallel_split_rank': None,
@@ -253,7 +243,7 @@ class MegatronPPOActor(BasePPOActor):
         input_shapes = compute_transformers_input_shapes(
             batches,
             meta_info={
-                'sequence_parallel': self.megatron_config.sequence_parallel,
+                'sequence_parallel': self.tf_config.sequence_parallel,
                 'hidden_size': self.model_config.hidden_size
             })
         n_micro_batch = len(batches)
@@ -334,7 +324,7 @@ class MegatronPPOActor(BasePPOActor):
                                       input_ids,
                                       attention_mask,
                                       position_ids,
-                                      sequence_parallel=self.megatron_config.sequence_parallel)
+                                      sequence_parallel=self.tf_config.sequence_parallel)
             if forward_only:
                 meta_info = None
             else:

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -37,7 +37,6 @@ from verl.utils.debug import log_gpu_memory_usage
 from verl.utils.model import load_megatron_model_weights, load_megatron_gptmodel_weights, load_mcore_dist_weights
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.checkpoint.megatron_checkpoint_manager import MegatronCheckpointManager
-from verl.utils.megatron_utils import mcore_model_parallel_config
 from verl.utils.megatron_utils import offload_megatron_param_and_grad, load_megatron_param_and_grad
 from verl.utils import hf_tokenizer
 
@@ -136,54 +135,21 @@ class ActorRolloutRefWorker(MegatronWorker):
 
     def _build_model_optimizer(self,
                                model_path,
-                               dtype,
                                optim_config,
-                               override_model_config,
-                               enable_gradient_checkpointing=False):
+                               override_model_config):
         from verl.utils.megatron.optimizer import get_megatron_optimizer
         from megatron.core.models.gpt.gpt_model import ModelType
-        from verl.utils.model import print_model_size, update_model_config, get_generation_config
+        from verl.utils.model import print_model_size, get_generation_config
         from verl.utils.megatron_utils import get_model, init_megatron_optim_config
-        from verl.models.mcore import hf_to_mcore_config
-        from transformers import AutoConfig
 
-        # Step 1: initialize the tokenizer
-        local_path = copy_to_local(model_path)
-        self.tokenizer = hf_tokenizer(local_path)
-
-        # Step 2: get the actor_model_config
-        actor_model_config = AutoConfig.from_pretrained(local_path)
-
-        self.generation_config = get_generation_config(local_path)
-
-        override_config_kwargs = {
-            'bos_token_id': self.tokenizer.bos_token_id,
-            'eos_token_id': self.tokenizer.eos_token_id,
-            'pad_token_id': self.tokenizer.pad_token_id,
-        }
-        override_config_kwargs.update(override_model_config)
-        update_model_config(actor_model_config, override_config_kwargs=override_config_kwargs)
-
-        if self.rank == 0:
-            print(f'Model config after override: {actor_model_config}')
-
-        self.share_embeddings_and_output_weights = getattr(actor_model_config, "tie_word_embeddings", False)
-        self.architectures = getattr(actor_model_config, "architectures", None)
-
-        tf_config = hf_to_mcore_config(actor_model_config, dtype)
-        if enable_gradient_checkpointing:
-            gradient_checkpointing_cfg = dict(self.config.model.get('gradient_checkpointing_kwargs', dict()))
-            tf_config.recompute_method = gradient_checkpointing_cfg['activations_checkpoint_method']
-            tf_config.recompute_granularity = gradient_checkpointing_cfg['activations_checkpoint_granularity']
-            tf_config.recompute_num_layers = gradient_checkpointing_cfg['activations_checkpoint_num_layers']
-        print(f'TF config: {tf_config}')
-        self.hf_config = actor_model_config
+        self._init_hf_config_and_tf_config(model_path, self.dtype, override_model_config)
+        self.generation_config = get_generation_config(self.local_path)
 
         def megatron_actor_model_provider(pre_process, post_process):
             from verl.models.mcore import init_mcore_model
             parallel_model = init_mcore_model(
-                tf_config,
-                actor_model_config,
+                self.tf_config,
+                self.hf_config,
                 pre_process,
                 post_process,
                 share_embeddings_and_output_weights=self.share_embeddings_and_output_weights,
@@ -212,9 +178,9 @@ class ActorRolloutRefWorker(MegatronWorker):
                                             is_value_model=False)
                 else:
                     load_megatron_gptmodel_weights(self.config,
-                                                   actor_model_config,
+                                                   self.hf_config,
                                                    actor_module,
-                                                   params_dtype=dtype,
+                                                   params_dtype=self.dtype,
                                                    is_value_model=False)
 
             if self.rank == 0:
@@ -237,12 +203,12 @@ class ActorRolloutRefWorker(MegatronWorker):
                                             is_value_model=False)
                 else:
                     load_megatron_gptmodel_weights(self.config,
-                                                   actor_model_config,
+                                                   self.hf_config,
                                                    ref_module,
-                                                   params_dtype=dtype,
+                                                   params_dtype=self.dtype,
                                                    is_value_model=False)
             log_gpu_memory_usage('After ref module init', logger=logger)
-            return ref_module, actor_model_config
+            return ref_module, self.hf_config
 
         # TODO: add more optimizer args into config
         if self._is_actor:
@@ -254,7 +220,7 @@ class ActorRolloutRefWorker(MegatronWorker):
 
         log_gpu_memory_usage('After actor optimizer init', logger=logger)
 
-        return actor_module, hybrid_engine, actor_optimizer, actor_model_config, optim_config
+        return actor_module, hybrid_engine, actor_optimizer, self.hf_config, optim_config
 
     def _build_rollout(self):
         if self.config.rollout.name == 'vllm':
@@ -319,12 +285,10 @@ class ActorRolloutRefWorker(MegatronWorker):
             else:
                 optim_config = None
             self.actor_module, self.hybrid_engine, self.actor_optimizer, \
-            self.actor_model_config, self.actor_optim_config = self._build_model_optimizer(
+            self.actor_model_config, self.actor_hf_config = self._build_model_optimizer(
                 model_path=self.config.model.path,
-                dtype=self.dtype,
                 optim_config=optim_config,
-                override_model_config=override_model_config,
-                enable_gradient_checkpointing=self.config.model.get('enable_gradient_checkpointing', False)
+                override_model_config=override_model_config
             )
 
         if self._is_actor:
@@ -334,7 +298,7 @@ class ActorRolloutRefWorker(MegatronWorker):
                                           tf_config=self.tf_config,
                                           actor_module=self.actor_module,
                                           actor_optimizer=self.actor_optimizer,
-                                          actor_optimizer_config=self.actor_optim_config)
+                                          )
 
         if self._is_rollout:
             self.rollout, self.sharding_manager = self._build_rollout()
@@ -342,17 +306,14 @@ class ActorRolloutRefWorker(MegatronWorker):
         if self._is_ref:
             self.ref_module, self.ref_model_config = self._build_model_optimizer(
                 model_path=self.config.model.path,
-                dtype=self.dtype,
                 optim_config=None,
-                override_model_config=override_model_config,
-                enable_gradient_checkpointing=self.config.model.get('enable_gradient_checkpointing', False))
+                override_model_config=override_model_config,)
             self.ref_policy = MegatronPPOActor(config=self.config.ref,
                                                model_config=self.ref_model_config,
                                                hf_config=self.hf_config,
                                                tf_config=self.tf_config,
                                                actor_module=self.ref_module,
-                                               actor_optimizer=None,
-                                               actor_optimizer_config=None)
+                                               actor_optimizer=None)
 
         if self._is_actor:
             self.flops_counter = FlopsCounter(self.actor_model_config)
@@ -524,49 +485,19 @@ class CriticWorker(MegatronWorker):
 
     def _build_critic_model_optimizer(self,
                                       model_path,
-                                      dtype,
                                       optim_config,
-                                      override_model_config,
-                                      enable_gradient_checkpointing=False):
+                                      override_model_config):
         from megatron.core.models.gpt.gpt_model import ModelType
-        from verl.utils.model import print_model_size, update_model_config
+        from verl.utils.model import print_model_size
         from verl.utils.megatron.optimizer import get_megatron_optimizer
         from verl.utils.megatron_utils import get_model, init_megatron_optim_config
-        from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
-        from verl.models.mcore import hf_to_mcore_config
 
-        # Step 1: initialize the tokenizer
-        local_path = copy_to_local(model_path)
-        self.tokenizer = hf_tokenizer(local_path)
-
-        # Step 2: get the critic_model_config
-        critic_model_config = AutoConfig.from_pretrained(local_path)
-
-        override_config_kwargs = {
-            'bos_token_id': self.tokenizer.bos_token_id,
-            'eos_token_id': self.tokenizer.eos_token_id,
-            'pad_token_id': self.tokenizer.pad_token_id,
-        }
-        override_config_kwargs.update(override_model_config)
-        self.share_embeddings_and_output_weights = getattr(critic_model_config, "tie_word_embeddings", False)
-        update_model_config(critic_model_config, override_config_kwargs=override_config_kwargs)
-        self.architectures = getattr(critic_model_config, "architectures", None)
-        if self.rank == 0:
-            print(f'Model config after override: {critic_model_config}')
-        tf_config = hf_to_mcore_config(critic_model_config, dtype)
-        if enable_gradient_checkpointing:
-            gradient_checkpointing_cfg = dict(self.config.model.get('gradient_checkpointing_kwargs', dict()))
-            tf_config.recompute_method = gradient_checkpointing_cfg['activations_checkpoint_method']
-            tf_config.recompute_granularity = gradient_checkpointing_cfg['activations_checkpoint_granularity']
-            tf_config.recompute_num_layers = gradient_checkpointing_cfg['activations_checkpoint_num_layers']
-        print(f'Critic TF config: {tf_config}')
-        self.hf_config = critic_model_config
-        self.tf_config = tf_config
+        self._init_hf_config_and_tf_config(model_path, self.dtype, override_model_config)
 
         def megatron_critic_model_provider(pre_process, post_process):
             from verl.models.mcore import init_mcore_model
-            parallel_model = init_mcore_model(tf_config,
-                                              critic_model_config,
+            parallel_model = init_mcore_model(self.tf_config,
+                                              self.hf_config,
                                               pre_process,
                                               post_process,
                                               share_embeddings_and_output_weights=False,
@@ -591,9 +522,9 @@ class CriticWorker(MegatronWorker):
                                         is_value_model=True)
             else:
                 load_megatron_gptmodel_weights(self.config,
-                                               critic_model_config,
+                                               self.hf_config,
                                                critic_module,
-                                               params_dtype=dtype,
+                                               params_dtype=self.dtype,
                                                is_value_model=True)
             t1 = time.time()
             if torch.distributed.get_rank() == 0:
@@ -605,7 +536,7 @@ class CriticWorker(MegatronWorker):
         optim_config = init_megatron_optim_config(optim_config)
         critic_optimizer = get_megatron_optimizer(model=critic_module, config=optim_config)
         torch.cuda.empty_cache()
-        return critic_module, critic_optimizer, critic_model_config, optim_config
+        return critic_module, critic_optimizer, self.hf_config, optim_config
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
@@ -622,10 +553,8 @@ class CriticWorker(MegatronWorker):
         self.dtype = PrecisionType.to_dtype(self.param_dtype)
         self.critic_module, self.critic_optimizer, self.critic_model_config, critic_optimizer_config = self._build_critic_model_optimizer(
             model_path=self.config.model.path,
-            dtype=self.dtype,
             optim_config=self.config.optim,
-            override_model_config=override_model_config,
-            enable_gradient_checkpointing=self.config.model.get('enable_gradient_checkpointing', False))
+            override_model_config=override_model_config)
         self.critic = MegatronPPOCritic(config=self.config,
                                         model_config=self.critic_model_config,
                                         hf_config=self.hf_config,
@@ -724,45 +653,25 @@ class RewardModelWorker(MegatronWorker):
             self.config.micro_batch_size //= mpu.get_data_parallel_world_size()
             self.config.micro_batch_size_per_gpu = self.config.micro_batch_size
 
-    def _build_rm_model(self, model_path, megatron_config: ModelParallelConfig, override_model_config):
+    def _build_rm_model(self, model_path, override_model_config):
         from megatron.core.models.gpt.gpt_model import ModelType
-        from verl.utils.model import update_model_config
-        from verl.utils.megatron_utils import get_model
-        from transformers import AutoConfig
+        from verl.utils.model import print_model_size
+        from verl.utils.megatron.optimizer import get_megatron_optimizer
+        from verl.utils.megatron_utils import get_model, init_megatron_optim_config
 
-        # Step 1: initialize the tokenizer
-        local_path = copy_to_local(model_path)
-        self.tokenizer = hf_tokenizer(local_path)
-
-        # Step 2: get the actor_model_config
-        rm_model_config = AutoConfig.from_pretrained(local_path)
-
-        override_config_kwargs = {
-            'bos_token_id': self.tokenizer.bos_token_id,
-            'eos_token_id': self.tokenizer.eos_token_id,
-            'pad_token_id': self.tokenizer.pad_token_id,
-        }
-        override_config_kwargs.update(override_model_config)
-        update_model_config(rm_model_config, override_config_kwargs=override_config_kwargs)
-
-        if self.rank == 0:
-            print(f'Model config after override: rm_model_config {rm_model_config}')
+        self._init_hf_config_and_tf_config(model_path, self.dtype, override_model_config)
 
         def megatron_rm_model_provider(pre_process, post_process):
-            from verl.utils.model import get_parallel_model_from_config
-            # vpp is not supported yet because it will hang for some reason. Need debugging
-            vpp_rank = mpu.get_virtual_pipeline_model_parallel_rank()  # this will be set inside get_model
-            # this_megatron_config = copy.deepcopy(megatron_config)
-            # this_megatron_config.virtual_pipeline_model_parallel_rank = vpp_rank
-            parallel_model = get_parallel_model_from_config(config=rm_model_config,
-                                                            megatron_config=megatron_config,
-                                                            pre_process=pre_process,
-                                                            post_process=post_process,
-                                                            share_embeddings_and_output_weights=False,
-                                                            value=True)
+            from verl.models.mcore import init_mcore_model
+            parallel_model = init_mcore_model(self.tf_config,
+                                              self.hf_config,
+                                              pre_process,
+                                              post_process,
+                                              share_embeddings_and_output_weights=False,
+                                              value=True)
             parallel_model.cuda()
             return parallel_model
-
+        
         # Step 3: initialize the megatron model
         reward_model = get_model(model_provider_func=megatron_rm_model_provider,
                                  model_type=ModelType.encoder_or_decoder,
@@ -773,15 +682,20 @@ class RewardModelWorker(MegatronWorker):
         # reward_model = nn.ModuleList(reward_model)
 
         if self.config.load_weight:
-            load_megatron_model_weights(self.config,
-                                        rm_model_config,
-                                        reward_model,
-                                        params_dtype=megatron_config.params_dtype,
+            if self.config.megatron.use_dist_checkpointing:
+                load_mcore_dist_weights(reward_model,
+                                        self.config.megatron.dist_checkpointing_path,
                                         is_value_model=True)
+            else:
+                load_megatron_gptmodel_weights(self.config,
+                                               self.hf_config,
+                                               reward_model,
+                                               params_dtype=self.dtype,
+                                               is_value_model=True)
 
         # TODO: add more optimizer args into config
         torch.cuda.empty_cache()
-        return reward_model, rm_model_config
+        return reward_model, self.hf_config
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
@@ -804,14 +718,10 @@ class RewardModelWorker(MegatronWorker):
             rm_tokenizer = hf_tokenizer(rm_tokenizer_local_path)
 
         self.param_dtype = torch.bfloat16
-
-        megatron_config = mcore_model_parallel_config(sequence_parallel=self.config.megatron.get(
-            'sequence_parallel', True),
-                                                      params_dtype=PrecisionType.to_dtype(self.param_dtype))
+        self.dtype = PrecisionType.to_dtype(self.param_dtype)
 
         reward_model_module, reward_model_config = self._build_rm_model(
             model_path=self.config.model.path,
-            megatron_config=megatron_config,
             override_model_config=override_model_config,
         )
         # FIXME(sgm): reward model param offload is implemented in MegatronRewardModel
@@ -819,7 +729,8 @@ class RewardModelWorker(MegatronWorker):
         self.rm = MegatronRewardModel(config=self.config,
                                       reward_model_module=reward_model_module,
                                       model_config=reward_model_config,
-                                      megatron_config=megatron_config,
+                                      hf_config=self.hf_config,
+                                      tf_config=self.tf_config,
                                       sft_tokenizer=sft_tokenizer,
                                       rm_tokenizer=rm_tokenizer)
 

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -133,10 +133,7 @@ class ActorRolloutRefWorker(MegatronWorker):
                 self.config.ref.ppo_micro_batch_size_per_gpu = self.config.ref.ppo_micro_batch_size
             self._is_offload_param = self.config.ref.get('param_offload', False)
 
-    def _build_model_optimizer(self,
-                               model_path,
-                               optim_config,
-                               override_model_config):
+    def _build_model_optimizer(self, model_path, optim_config, override_model_config):
         from verl.utils.megatron.optimizer import get_megatron_optimizer
         from megatron.core.models.gpt.gpt_model import ModelType
         from verl.utils.model import print_model_size, get_generation_config
@@ -292,13 +289,14 @@ class ActorRolloutRefWorker(MegatronWorker):
             )
 
         if self._is_actor:
-            self.actor = MegatronPPOActor(config=self.config.actor,
-                                          model_config=self.actor_model_config,
-                                          hf_config=self.hf_config,
-                                          tf_config=self.tf_config,
-                                          actor_module=self.actor_module,
-                                          actor_optimizer=self.actor_optimizer,
-                                          )
+            self.actor = MegatronPPOActor(
+                config=self.config.actor,
+                model_config=self.actor_model_config,
+                hf_config=self.hf_config,
+                tf_config=self.tf_config,
+                actor_module=self.actor_module,
+                actor_optimizer=self.actor_optimizer,
+            )
 
         if self._is_rollout:
             self.rollout, self.sharding_manager = self._build_rollout()
@@ -307,7 +305,8 @@ class ActorRolloutRefWorker(MegatronWorker):
             self.ref_module, self.ref_model_config = self._build_model_optimizer(
                 model_path=self.config.model.path,
                 optim_config=None,
-                override_model_config=override_model_config,)
+                override_model_config=override_model_config,
+            )
             self.ref_policy = MegatronPPOActor(config=self.config.ref,
                                                model_config=self.ref_model_config,
                                                hf_config=self.hf_config,
@@ -483,10 +482,7 @@ class CriticWorker(MegatronWorker):
 
         # TODO(sgm): support critic model offload
 
-    def _build_critic_model_optimizer(self,
-                                      model_path,
-                                      optim_config,
-                                      override_model_config):
+    def _build_critic_model_optimizer(self, model_path, optim_config, override_model_config):
         from megatron.core.models.gpt.gpt_model import ModelType
         from verl.utils.model import print_model_size
         from verl.utils.megatron.optimizer import get_megatron_optimizer
@@ -671,7 +667,7 @@ class RewardModelWorker(MegatronWorker):
                                               value=True)
             parallel_model.cuda()
             return parallel_model
-        
+
         # Step 3: initialize the megatron model
         reward_model = get_model(model_provider_func=megatron_rm_model_provider,
                                  model_type=ModelType.encoder_or_decoder,
@@ -683,9 +679,7 @@ class RewardModelWorker(MegatronWorker):
 
         if self.config.load_weight:
             if self.config.megatron.use_dist_checkpointing:
-                load_mcore_dist_weights(reward_model,
-                                        self.config.megatron.dist_checkpointing_path,
-                                        is_value_model=True)
+                load_mcore_dist_weights(reward_model, self.config.megatron.dist_checkpointing_path, is_value_model=True)
             else:
                 load_megatron_gptmodel_weights(self.config,
                                                self.hf_config,

--- a/verl/workers/reward_model/megatron/reward_model.py
+++ b/verl/workers/reward_model/megatron/reward_model.py
@@ -35,12 +35,14 @@ class MegatronRewardModel(BasePPORewardModel):
                  config,
                  model_config,
                  reward_model_module: torch.nn.ModuleList,
-                 megatron_config,
+                 hf_config,
+                 tf_config,
                  sft_tokenizer=None,
                  rm_tokenizer=None):
         self.config = config
         self.reward_model_module = reward_model_module
-        self.megatron_config = megatron_config
+        self.hf_config = hf_config
+        self.tf_config = tf_config
         self.model_config = model_config
         self.device = 'cuda'
         self.sft_tokenizer = sft_tokenizer
@@ -133,7 +135,7 @@ class MegatronRewardModel(BasePPORewardModel):
         with torch.no_grad():
             output = self.forward_batch(data)
             if mpu.is_pipeline_last_stage(ignore_virtual=True):
-                logits = torch.cat([o['logits'] for o in output], dim=0)
+                logits = torch.cat([output], dim=0)
             else:
                 logits = torch.empty(
                     (input_ids.shape[0], input_ids.shape[1]),
@@ -205,21 +207,27 @@ class MegatronRewardModel(BasePPORewardModel):
         input_shapes = compute_transformers_input_shapes(
             batches,
             meta_info={
-                'sequence_parallel': self.megatron_config.sequence_parallel,
+                'sequence_parallel': self.tf_config.sequence_parallel,
                 'hidden_size': self.model_config.hidden_size
             })
         # compute input shapes for pp stages
         forward_backward_func = get_forward_backward_func()
 
         def loss_func(output):
-            return 1., {'logits': output.logits}
+            return 1., {'logits': output}
 
         def forward_step(batch_iter, model):
             batch = next(batch_iter)
             input_ids = batch['input_ids']
             attention_mask = batch['attention_mask']
             position_ids = batch['position_ids']
-            output = model(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids)
+            from verl.models.mcore import gptmodel_forward
+
+            output = gptmodel_forward(model,
+                                      input_ids,
+                                      attention_mask,
+                                      position_ids,
+                                      sequence_parallel=self.tf_config.sequence_parallel)
             return output, loss_func
 
         # batch should be a list of batches inside micro-batches


### PR DESCRIPTION
refactor the mcore code, add registry for extensibility for more types of model such as MoE or VLM.
clean some deprecated code such as megatron_config.
reward model worker uses GPTModel api now.