### PR TITLE
Add bool-type index selection for DataProto

### DIFF
--- a/tests/utility/test_tensor_dict_utilities.py
+++ b/tests/utility/test_tensor_dict_utilities.py
@@ -297,3 +297,67 @@ def test_seqlen_balancing():
     reverse_idx_map = torch.tensor(reverse_idx_map)
     new_batch = batch[reverse_idx_map]
     torch.testing.assert_close(new_batch, dataproto.batch)
+
+
+def test_dataproto_index():
+    data_len = 100
+    idx_num = 10
+
+    obs = torch.randn(data_len, 10)
+    labels = [random.choice(["abc", "cde"]) for _ in range(data_len)]
+    data = DataProto.from_dict(tensors={"obs": obs}, non_tensors={"labels": labels})
+    labels_np = np.array(labels)
+
+    idx_np_int = np.random.randint(0, data_len, size=(idx_num,))
+    result_np_int = data[idx_np_int]
+    assert result_np_int.batch.keys() == data.batch.keys()
+    assert result_np_int.non_tensor_batch.keys() == data.non_tensor_batch.keys()
+    assert result_np_int.batch["obs"].shape[0] == idx_num
+    assert result_np_int.non_tensor_batch["labels"].shape[0] == idx_num
+    assert np.array_equal(result_np_int.batch["obs"].cpu().numpy(), obs[idx_np_int].numpy())
+    assert np.array_equal(result_np_int.non_tensor_batch["labels"], labels_np[idx_np_int])
+
+    idx_torch_int = torch.randint(0, data_len, size=(idx_num,))
+    result_torch_int = data[idx_torch_int]
+    assert result_torch_int.batch.keys() == data.batch.keys()
+    assert result_torch_int.non_tensor_batch.keys() == data.non_tensor_batch.keys()
+    assert result_torch_int.batch["obs"].shape[0] == idx_num
+    assert result_torch_int.non_tensor_batch["labels"].shape[0] == idx_num
+    assert np.array_equal(result_torch_int.batch["obs"].cpu().numpy(), obs[idx_torch_int].cpu().numpy())
+    assert np.array_equal(result_torch_int.non_tensor_batch["labels"], labels_np[idx_torch_int.cpu().numpy()])
+
+    idx_list_int = [np.random.randint(0, data_len) for _ in range(idx_num)]
+    result_list_int = data[idx_list_int]
+    assert result_list_int.batch.keys() == data.batch.keys()
+    assert result_list_int.non_tensor_batch.keys() == data.non_tensor_batch.keys()
+    assert result_list_int.batch["obs"].shape[0] == idx_num
+    assert result_list_int.non_tensor_batch["labels"].shape[0] == idx_num
+    assert np.array_equal(result_list_int.batch["obs"].cpu().numpy(), obs[idx_list_int].cpu().numpy())
+    assert np.array_equal(result_list_int.non_tensor_batch["labels"], labels_np[idx_list_int])
+
+    idx_np_bool = np.random.randint(0, 2, size=(data_len,), dtype=bool)
+    result_np_bool = data[idx_np_bool]
+    assert result_np_bool.batch.keys() == data.batch.keys()
+    assert result_np_bool.non_tensor_batch.keys() == data.non_tensor_batch.keys()
+    assert result_np_bool.batch["obs"].shape[0] == idx_np_bool.sum()
+    assert result_np_bool.non_tensor_batch["labels"].shape[0] == idx_np_bool.sum()
+    assert np.array_equal(result_np_bool.batch["obs"].cpu().numpy(), obs[idx_np_bool].cpu().numpy())
+    assert np.array_equal(result_np_bool.non_tensor_batch["labels"], labels_np[idx_np_bool])
+
+    idx_torch_bool = torch.randint(0, 2, size=(data_len,), dtype=torch.bool)
+    result_torch_bool = data[idx_torch_bool]
+    assert result_torch_bool.batch.keys() == data.batch.keys()
+    assert result_torch_bool.non_tensor_batch.keys() == data.non_tensor_batch.keys()
+    assert result_torch_bool.batch["obs"].shape[0] == idx_torch_bool.sum().item()
+    assert result_torch_bool.non_tensor_batch["labels"].shape[0] == idx_torch_bool.sum().item()
+    assert np.array_equal(result_torch_bool.batch["obs"].cpu().numpy(), obs[idx_torch_bool].cpu().numpy())
+    assert np.array_equal(result_torch_bool.non_tensor_batch["labels"], labels_np[idx_torch_bool])
+
+    idx_list_bool = [np.random.randint(0, 2, dtype=bool) for _ in range(data_len)]
+    result_list_bool = data[idx_list_bool]
+    assert result_list_bool.batch.keys() == data.batch.keys()
+    assert result_list_bool.non_tensor_batch.keys() == data.non_tensor_batch.keys()
+    assert result_list_bool.batch["obs"].shape[0] == sum(idx_list_bool)
+    assert result_list_bool.non_tensor_batch["labels"].shape[0] == sum(idx_list_bool)
+    assert np.array_equal(result_list_bool.batch["obs"].cpu().numpy(), obs[idx_list_bool].cpu().numpy())
+    assert np.array_equal(result_list_bool.non_tensor_batch["labels"], labels_np[idx_list_bool])

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -418,7 +418,9 @@ class DataProto:
             DataProto: A new DataProto containing only the selected indices
         """
         if isinstance(idxs, list):
-            idxs = torch.tensor(idxs, dtype=torch.int32)
+            idxs = torch.tensor(idxs)
+            if idxs.dtype != torch.bool:
+                idxs = idxs.type(torch.int32)
 
         if isinstance(idxs, np.ndarray):
             idxs_np = idxs
@@ -431,10 +433,9 @@ class DataProto:
 
         if self.batch is not None:
             # Use TensorDict's built-in indexing capabilities
-            selected_batch = TensorDict(source={
-                key: tensor[idxs_torch] for key, tensor in self.batch.items()
-            },
-                                        batch_size=(batch_size,))
+            selected_batch = TensorDict(
+                source={key: tensor[idxs_torch] for key, tensor in self.batch.items()}, batch_size=(batch_size,)
+            )
         else:
             selected_batch = None
 

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -427,12 +427,14 @@ class DataProto:
             idxs_torch = idxs
             idxs_np = idxs.detach().cpu().numpy()
 
+        batch_size = idxs_np.sum() if idxs_np.dtype == bool else idxs_np.shape[0]
+
         if self.batch is not None:
             # Use TensorDict's built-in indexing capabilities
-            selected_batch = TensorDict(
-                source={key: tensor[idxs_torch] for key, tensor in self.batch.items()},
-                batch_size=(idxs_torch.shape[0],),
-            )
+            selected_batch = TensorDict(source={
+                key: tensor[idxs_torch] for key, tensor in self.batch.items()
+            },
+                                        batch_size=(batch_size,))
         else:
             selected_batch = None
 


### PR DESCRIPTION
After the last change, current DataProto cannot use bool-type index due to hard-coded batch_size equal to idxs.shape[0]. 

This patch changes the new batch_size for bool-type idx to idxs.sum(). It's useful when users filter the batch with bool-type masks.
