### PR TITLE
data: use hf template for vlm models

### DIFF
--- a/.github/workflows/dataset.yml
+++ b/.github/workflows/dataset.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Running dataset tests
         run: |
           [ ! -d "$HOME/verl-data" ] && git clone --depth 1 https://github.com/eric-haibin-lin/verl-data ~/verl-data
+          python3 examples/data_preprocess/geo3k.py
           pytest -s -x tests/verl/utils/dataset/test_rl_dataset.py
           pytest -s -x tests/verl/utils/dataset/test_sft_dataset.py
           pytest -s -x tests/verl/utils/test_import_utils.py

--- a/tests/rollout/test_vllm_spmd.py
+++ b/tests/rollout/test_vllm_spmd.py
@@ -150,7 +150,7 @@ def test_vllm_spmd():
         skip_tokenizer_init=False,
         enable_prefix_caching=True,
         trust_remote_code=True,
-        seed=0,
+        seed=1,
     )
 
     outputs = llm.generate(preencode_prompts, sampling_params=sampling_params, use_tqdm=False)

--- a/tests/rollout/test_vllm_spmd.py
+++ b/tests/rollout/test_vllm_spmd.py
@@ -150,7 +150,7 @@ def test_vllm_spmd():
         skip_tokenizer_init=False,
         enable_prefix_caching=True,
         trust_remote_code=True,
-        seed=int(os.getenv("RANK", "0")) // tensor_parallel_size,
+        seed=0,
     )
 
     outputs = llm.generate(preencode_prompts, sampling_params=sampling_params, use_tqdm=False)

--- a/tests/verl/utils/dataset/test_rl_dataset.py
+++ b/tests/verl/utils/dataset/test_rl_dataset.py
@@ -56,6 +56,49 @@ def test_rl_dataset():
             non_tensors[key] = val
 
     data_proto = DataProto.from_dict(tensors=tensors, non_tensors=non_tensors)
+    assert 'input_ids' in data_proto.batch
+
+    data = dataset[0]['input_ids']
+    output = tokenizer.batch_decode([data])[0]
+    print(f'type: type{output}')
+    print(f'\n\noutput: {output}')
+
+
+def test_image_rl_data():
+    from verl.utils.dataset.rl_dataset import RLHFDataset, collate_fn
+    from verl.utils import hf_tokenizer, hf_processor
+    tokenizer = hf_tokenizer('Qwen/Qwen2-VL-2B-Instruct')
+    processor = hf_processor('Qwen/Qwen2-VL-2B-Instruct')
+    config = OmegaConf.create({
+        "prompt_key": "prompt",
+        "max_prompt_length": 1024,
+        "filter_overlong_prompts": True,
+        "filter_overlong_prompts_workers": 2,
+    })
+    dataset = RLHFDataset(data_files=os.path.expanduser("~/data/geo3k/train.parquet"),
+                          tokenizer=tokenizer,
+                          config=config,
+                          processor=processor)
+
+    dataloader = DataLoader(dataset=dataset, batch_size=16, shuffle=True, drop_last=True, collate_fn=collate_fn)
+
+    a = next(iter(dataloader))
+
+    from verl import DataProto
+
+    tensors = {}
+    non_tensors = {}
+
+    for key, val in a.items():
+        if isinstance(val, torch.Tensor):
+            tensors[key] = val
+        else:
+            non_tensors[key] = val
+
+    data_proto = DataProto.from_dict(tensors=tensors, non_tensors=non_tensors)
+
+    assert 'multi_modal_data' in data_proto.non_tensor_batch
+    assert 'multi_modal_inputs' in data_proto.non_tensor_batch
 
     data = dataset[0]['input_ids']
     output = tokenizer.batch_decode([data])[0]

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -226,7 +226,7 @@ class RLHFDataset(Dataset):
         row_dict['raw_prompt_ids'] = raw_prompt_ids
         # encode prompts without chat template
         if self.return_raw_chat:
-            row_dict['raw_prompt'] = raw_prompt
+            row_dict['raw_prompt'] = messages
 
         # add index for each prompt
         index = row_dict.get("extra_info", {}).get("index", 0)

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -151,68 +151,82 @@ class RLHFDataset(Dataset):
     def __len__(self):
         return len(self.dataframe)
 
+    def _build_messages(self, example: dict):
+        messages: list = example.pop(self.prompt_key)
+        if self.image_key in example:
+            # https://huggingface.co/docs/transformers/en/tasks/image_text_to_text
+            content_list = []
+            last_user_message: str = messages.pop(-1)['content']
+            for i, content in enumerate(last_user_message.split("<image>")):
+                if i != 0:
+                    content_list.append({"type": "image"})
+
+                if content:
+                    content_list.append({"type": "text", "text": content})
+
+            messages.append({"role": "user", "content": content_list})
+
+        return messages
+
     def __getitem__(self, item):
         """
         Note that we also return the raw_input_ids so that it can be combined with other chat template
         """
         row_dict: dict = self.dataframe[item]
+        messages = self._build_messages(row_dict)
 
-        chat = row_dict.pop(self.prompt_key)
-
-        prompt_with_chat_template = self.tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=False)
-
-        is_multi_modal = self.image_key in row_dict
-        if is_multi_modal:  # expand image token
-            raw_prompt = prompt_with_chat_template.replace('<image>', '<|vision_start|><|image_pad|><|vision_end|>')
-            row_dict['multi_modal_data'] = {'image': [process_image(image) for image in row_dict.pop(self.image_key)]}
-            image_inputs = self.processor.image_processor(row_dict['multi_modal_data']['image'], return_tensors='pt')
-            image_grid_thw = image_inputs['image_grid_thw']
-            row_dict['multi_modal_inputs'] = {key: val for key, val in image_inputs.items()}
-
-            if image_grid_thw is not None:
-                merge_length = self.processor.image_processor.merge_size**2
-                index = 0
-                while '<image>' in prompt_with_chat_template:
-                    prompt_with_chat_template = prompt_with_chat_template.replace(
-                        '<image>',
-                        '<|vision_start|>' + '<|placeholder|>' * (image_grid_thw[index].prod() // merge_length) +
-                        '<|vision_end|>',
-                        1,
-                    )
-                    index += 1
-
-                prompt_with_chat_template = prompt_with_chat_template.replace('<|placeholder|>',
-                                                                              self.processor.image_token)
+        if self.image_key in row_dict:  # process multimodal data
+            raw_prompt = self.processor.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+            images = [process_image(image) for image in row_dict.pop(self.image_key)]
+            model_inputs = self.processor(images, [raw_prompt], return_tensors="pt", add_special_tokens=False)
+            input_ids = model_inputs.pop('input_ids')
+            attention_mask = model_inputs.pop('attention_mask')
+            row_dict["multi_modal_data"] = {"image": images}
+            row_dict["multi_modal_inputs"] = dict(model_inputs)
         else:
-            raw_prompt = prompt_with_chat_template
+            raw_prompt = self.tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+            model_inputs = self.tokenizer(raw_prompt, return_tensors='pt', add_special_tokens=False)
+            input_ids = model_inputs.pop('input_ids')
+            attention_mask = model_inputs.pop('attention_mask')
 
-        input_ids, attention_mask = verl_F.tokenize_and_postprocess_data(prompt=prompt_with_chat_template,
-                                                                         tokenizer=self.tokenizer,
-                                                                         max_length=self.max_prompt_length,
-                                                                         pad_token_id=self.tokenizer.pad_token_id,
-                                                                         left_pad=True,
-                                                                         truncation=self.truncation)
+        input_ids, attention_mask = verl_F.postprocess_data(input_ids=input_ids,
+                                                            attention_mask=attention_mask,
+                                                            max_length=self.max_prompt_length,
+                                                            pad_token_id=self.tokenizer.pad_token_id,
+                                                            left_pad=True,
+                                                            truncation=self.truncation)
 
-        if is_multi_modal:
+        if self.processor is not None and self.processor.image_processor.__class__.__name__ == "Qwen2VLImageProcessor":
             from verl.models.transformers.qwen2_vl import get_rope_index
 
-            position_ids = get_rope_index(
-                self.processor,
-                input_ids=input_ids[0],
-                image_grid_thw=image_grid_thw,
-                attention_mask=attention_mask[0],
-            )  # (3, seq_len)
+            position_ids = [
+                get_rope_index(
+                    self.processor,
+                    input_ids=input_ids[0],
+                    image_grid_thw=model_inputs.get("image_grid_thw"),
+                    attention_mask=attention_mask[0],
+                )
+            ]  # (1, 3, seq_len)
         else:
             position_ids = compute_position_id_with_mask(attention_mask)
 
         row_dict['input_ids'] = input_ids[0]
         row_dict['attention_mask'] = attention_mask[0]
         row_dict['position_ids'] = position_ids[0]
-        row_dict['raw_prompt_ids'] = self.tokenizer.encode(raw_prompt, add_special_tokens=False)
 
+        raw_prompt_ids = self.tokenizer.encode(raw_prompt, add_special_tokens=False)
+        if len(raw_prompt_ids) > self.max_prompt_length:
+            if self.truncation == "left":
+                raw_prompt_ids = raw_prompt_ids[-self.max_prompt_length:]
+            elif self.truncation == "right":
+                raw_prompt_ids = raw_prompt_ids[:self.max_prompt_length]
+            elif self.truncation == "error":
+                raise RuntimeError(f"Prompt length {len(raw_prompt_ids)} is longer than {self.max_prompt_length}.")
+
+        row_dict['raw_prompt_ids'] = raw_prompt_ids
         # encode prompts without chat template
         if self.return_raw_chat:
-            row_dict['raw_prompt'] = chat
+            row_dict['raw_prompt'] = raw_prompt
 
         # add index for each prompt
         index = row_dict.get("extra_info", {}).get("index", 0)
@@ -227,4 +241,5 @@ class RLHFDataset(Dataset):
             if 'dataframe' in state:
                 del state['dataframe']
             return state
+
         return self.__dict__.copy()

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -255,25 +255,16 @@ def pad_sequence_to_length(tensors, max_seq_len, pad_token_id, left_pad=False):
     return F.pad(tensors, pad_tuple, 'constant', pad_token_id)
 
 
-from transformers import PreTrainedTokenizer
-
-
-def tokenize_and_postprocess_data(prompt: str,
-                                  tokenizer: PreTrainedTokenizer,
-                                  max_length: int,
-                                  pad_token_id: int,
-                                  left_pad=True,
-                                  truncation='error'):
+def postprocess_data(input_ids: torch.Tensor,
+                     attention_mask: torch.Tensor,
+                     max_length: int,
+                     pad_token_id: int,
+                     left_pad=True,
+                     truncation='error'):
     """
     input_data is the output from tokenizer.
     """
     assert truncation in ['left', 'right', 'error']
-
-    input_data = tokenizer(prompt, return_tensors='pt', add_special_tokens=False)
-
-    input_ids = input_data['input_ids']
-    attention_mask = input_data['attention_mask']
-
     assert input_ids.ndim == 2
 
     sequence_length = input_ids.shape[-1]

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -1125,9 +1125,11 @@ class RewardModelWorker(Worker):
             max_length = self.config.get('max_length', src_max_length)
             if max_length is None:
                 max_length = src_max_length
-            input_ids, attention_mask = verl_F.tokenize_and_postprocess_data(
-                prompt=prompt_with_chat_template,
-                tokenizer=target_tokenizer,
+
+            model_inputs = target_tokenizer(prompt_with_chat_template, return_tensors='pt', add_special_tokens=False)
+            input_ids, attention_mask = verl_F.postprocess_data(
+                input_ids=model_inputs['input_ids'],
+                attention_mask=model_inputs['attention_mask'],
                 max_length=max_length,
                 pad_token_id=target_tokenizer.pad_token_id,
                 left_pad=False,  # right padding


### PR DESCRIPTION
## What does this PR do?

In this PR, we use huggingface's chat template (i.e., `processor.apply_chat_template`) to compute input ids for VLMs, it could be generalized to more model architectures compared with the earlier implementation.

## Who can review?

@vermouth1992 @eric-haibin-lin 