### PR TITLE
fix: gpu memory report in vllm sleep mode

### DIFF
--- a/verl/utils/debug/performance.py
+++ b/verl/utils/debug/performance.py
@@ -19,8 +19,10 @@ import logging
 
 def log_gpu_memory_usage(head: str, logger: logging.Logger = None, level=logging.DEBUG, rank: int = 0):
     if (not dist.is_initialized()) or (rank is None) or (dist.get_rank() == rank):
-        memory_allocated = torch.cuda.memory_allocated() / 1024**3
-        memory_reserved = torch.cuda.memory_reserved() / 1024**3
+        free_mem, total_mem = torch.cuda.mem_get_info()
+        vllm_sleep_mem = torch.cuda.memory_reserved() - (total_mem - free_mem)
+        memory_allocated = (torch.cuda.memory_allocated() - vllm_sleep_mem) / 1024**3
+        memory_reserved = (torch.cuda.memory_reserved() - vllm_sleep_mem) / 1024**3
 
         message = f'{head}, memory allocated (GB): {memory_allocated}, memory reserved (GB): {memory_reserved}'
 


### PR DESCRIPTION
## What does this PR do?

When we use vLLM's sleep mode, we can no longer obtain the GPU memory statistics from the PyTorch API because vLLM uses cuMem to manage the memory space. We compute the freed memory of vLLM offloading to estimate the memory correctly.

see https://github.com/vllm-project/vllm/pull/11743#issuecomment-2754338119

Before:
![image](https://github.com/user-attachments/assets/40879b65-97b6-4fc1-be1d-00a89f536a66)

After:
![image](https://github.com/user-attachments/assets/63522605-5f3b-4d2a-9d45-c02bf614448d)


## Who can review?

@vermouth1992 @tongyx361 @BearBiscuit05 
