### PR TITLE
[feat] video inputs

### DIFF
--- a/recipe/dapo/src/config/dapo_trainer.yaml
+++ b/recipe/dapo/src/config/dapo_trainer.yaml
@@ -15,6 +15,7 @@ data:
   filter_overlong_prompts: False # for large-scale dataset, filtering overlong prompts could be timeconsuming. You should disable this and set `truncation='left'
   truncation: error
   image_key: images
+  video_key: videos
   custom_cls:
       path: null
       name: null
@@ -175,7 +176,7 @@ reward_model:
   use_dynamic_bsz: ${critic.use_dynamic_bsz}
   forward_max_token_len_per_gpu: ${critic.forward_max_token_len_per_gpu}
   reward_manager: naive
-  overlong_buffer: 
+  overlong_buffer:
     enable: False # We try to avoid forgetting to set enable
     len: 0
     penalty_factor: 0.0

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -15,6 +15,7 @@ data:
   filter_overlong_prompts_workers: 1
   truncation: error
   image_key: images
+  video_key: videos
   custom_cls:
       path: null
       name: null

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -223,7 +223,7 @@ class RLHFDataset(Dataset):
                                                             left_pad=True,
                                                             truncation=self.truncation)
 
-        if self.is_multimodal:
+        if self.processor_type.startswith("qwen2"):
             from verl.models.transformers.qwen2_vl import get_rope_index
 
             position_ids = [

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -172,12 +172,7 @@ class RLHFDataset(Dataset):
                 videos = [process_video(video) for video in row_dict.pop(self.video_key)]
                 multi_modal_data["video"] = [video.numpy() for video in videos]
 
-            model_inputs = self.processor(
-                text=[raw_prompt],
-                images=images,
-                videos=videos,
-                return_tensors="pt"
-            )
+            model_inputs = self.processor(text=[raw_prompt], images=images, videos=videos, return_tensors="pt")
 
             input_ids = model_inputs.pop("input_ids")
             attention_mask = model_inputs.pop("attention_mask")

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -176,9 +176,9 @@ class RLHFDataset(Dataset):
         model_inputs = {}
 
         if self.is_multimodal:
+            # This is kinda hard coded for qwen2 vl
             from verl.utils.dataset.vision_utils import process_image, process_video
 
-            # For Qwen2 VL, we should use mrope even for text inputs.
             raw_prompt = self.processor.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
             multi_modal_data = {}
 
@@ -189,7 +189,7 @@ class RLHFDataset(Dataset):
 
             videos = None
             if self.video_key in row_dict:
-                videos = [process_video(video) for video in row_dict.pop(self.image_key)]
+                videos = [process_video(video) for video in row_dict.pop(self.video_key)]
                 multi_modal_data["video"] = [video.numpy() for video in videos]
 
             model_inputs = self.processor(

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -25,7 +25,6 @@ from torch.utils.data import Dataset
 from transformers import PreTrainedTokenizer, ProcessorMixin
 from omegaconf import ListConfig, DictConfig
 
-from verl.utils.dataset.vision_utils import process_image, process_video
 from verl.utils.model import compute_position_id_with_mask
 import verl.utils.torch_functional as verl_F
 
@@ -177,6 +176,8 @@ class RLHFDataset(Dataset):
         model_inputs = {}
 
         if self.is_multimodal:
+            from verl.utils.dataset.vision_utils import process_image, process_video
+
             # For Qwen2 VL, we should use mrope even for text inputs.
             raw_prompt = self.processor.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
             multi_modal_data = {}

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -89,10 +89,6 @@ class RLHFDataset(Dataset):
         self._download()
         self._read_files_and_tokenize()
 
-    @property
-    def is_multimodal(self) -> bool:
-        return self.processor is not None
-
     def _download(self, use_origin_parquet=False):
         from verl.utils.fs import copy_to_local
         data_files = self.data_files if not use_origin_parquet else self.original_data_files

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -189,10 +189,8 @@ class RLHFDataset(Dataset):
             row_dict["multi_modal_data"] = multi_modal_data
             row_dict["multi_modal_inputs"] = dict(model_inputs)
 
-            # second_per_grid_ts isn't used for training, just for rope
-            # calculations
-            if "second_per_grid_ts" in row_dict["multi_modal_inputs"]:
-                row_dict["multi_modal_inputs"].pop("second_per_grid_ts")
+            # second_per_grid_ts isn't used for training, just for mrope
+            row_dict["multi_modal_inputs"].pop("second_per_grid_ts", None)
 
         else:
             raw_prompt = self.tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)

--- a/verl/utils/dataset/vision_utils.py
+++ b/verl/utils/dataset/vision_utils.py
@@ -17,6 +17,34 @@ def process_image(image: Union[dict, Image.Image]) -> Image.Image:
     return fetch_image(image)
 
 
+VIDEO_FORMAT_HELP = """Currently, we only support the video formats introduced in qwen2-vl.
+Refer to https://github.com/QwenLM/Qwen2.5-VL?tab=readme-ov-file#using---transformers-to-chat.
+
+eg.
+{
+    "type": "video",
+    "video": [
+        "file:///path/to/frame1.jpg",
+        "file:///path/to/frame2.jpg"
+    ]
+}
+
+{
+    "type": "video",
+    "video": "file:///path/to/video.mp4"
+}
+# Defaults to fps=2, min_frames=4, max_frames=768
+
+{
+    "type": "video",
+    "video": "file:///path/to/video.mp4",
+    "fps": 2,
+    "min_frames": 1,
+    "max_frames": 32
+}
+"""
+
+
 def process_video(
     video: dict,
     nframes: Optional[int] = None,
@@ -30,7 +58,7 @@ def process_video(
     """
 
     if not isinstance(video, dict) or "video" not in video:
-        raise NotImplementedError("Currently we only support qwen2-vl format")
+        raise NotImplementedError(VIDEO_FORMAT_HELP)
     assert nframes is None or fps is None, "Can't use both `nframes` or `fps`"
 
     # Shallow copy... since we might want to add some keys
@@ -43,8 +71,8 @@ def process_video(
         elif fps is not None:
             video["fps"] = fps
             if fps_min_frames is not None:
-                video["fps_min_frames"] = fps_min_frames
+                video["min_frames"] = fps_min_frames
             if fps_max_frames is not None:
-                video["fps_max_frames"] = fps_max_frames
+                video["max_frames"] = fps_max_frames
 
     return fetch_video(video)

--- a/verl/utils/dataset/vision_utils.py
+++ b/verl/utils/dataset/vision_utils.py
@@ -1,0 +1,50 @@
+from io import BytesIO
+from typing import Optional, Union
+
+import torch
+from PIL import Image
+from qwen_vl_utils import fetch_image, fetch_video
+
+
+def process_image(image: Union[dict, Image.Image]) -> Image.Image:
+    if isinstance(image, Image.Image):
+        return image.convert("RGB")
+
+    if "bytes" in image:
+        assert "image" not in image, "Cannot have both `bytes` and `image`"
+        image["image"] = BytesIO(image["bytes"])
+
+    return fetch_image(image)
+
+
+def process_video(
+    video: dict,
+    nframes: Optional[int] = None,
+    fps: Optional[float] = None,
+    fps_min_frames: Optional[int] = None,
+    fps_max_frames: Optional[int] = None,
+) -> torch.Tensor:
+    """Converts a video dict into a [n_frames, 3, H, W] tensor
+
+    Add video sample FPS in a future MR
+    """
+
+    if not isinstance(video, dict) or "video" not in video:
+        raise NotImplementedError("Currently we only support qwen2-vl format")
+    assert nframes is None or fps is None, "Can't use both `nframes` or `fps`"
+
+    # Shallow copy... since we might want to add some keys
+    video = dict(video)
+
+    contains_sampling_rules = "nframes" in video or "fps" in video
+    if not contains_sampling_rules:
+        if nframes is not None:
+            video["nframes"] = nframes
+        elif fps is not None:
+            video["fps"] = fps
+            if fps_min_frames is not None:
+                video["fps_min_frames"] = fps_min_frames
+            if fps_max_frames is not None:
+                video["fps_max_frames"] = fps_max_frames
+
+    return fetch_video(video)

--- a/verl/utils/dataset/vision_utils.py
+++ b/verl/utils/dataset/vision_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from io import BytesIO
 from typing import Optional, Union
 

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -276,7 +276,7 @@ class vLLMRollout(BaseRollout):
         # prompt: left pad + response: right pad
         # attention_mask: [0,0,0,0,1,1,1,1, | 1,1,1,0,0,0,0,0]
         # position_ids:   [0,0,0,0,0,1,2,3, | 4,5,6,7,8,9,10,11]
-        response_position_ids = position_ids[:, -1:] + delta_position_id
+        response_position_ids = position_ids[..., -1:] + delta_position_id
         position_ids = torch.cat([position_ids, response_position_ids], dim=-1)
         response_attention_mask = get_response_mask(response_id=response,
                                                     eos_token=eos_token_id,


### PR DESCRIPTION
## What does this MR do?
Adds video input support for qwen2 vl models

## Changes
- process_image function is moved to vision_utils.py
- switch process_image & process_video to both use fetch_image and fetch_video functions from qwen-vl-utils
- fixed a mrope bug in vllm rollout