### PR TITLE
Modify train_batch_size assertion based on sequence_parallel factor

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -357,13 +357,13 @@ class RayPPOTrainer(object):
                                      "reward_model")
 
         # Actor
-        # check if train_batch_size is larger than ppo_mini_batch_size
+        # check if train_batch_size is larger than ppo_mini_batch_size * sp_size
         # if NOT dynamic_bsz, we must ensure:
         #    ppo_mini_batch_size is divisible by ppo_micro_batch_size
         #    ppo_micro_batch_size * sequence_parallel_size >= n_gpus
         if not config.actor_rollout_ref.actor.use_dynamic_bsz:
-            assert config.data.train_batch_size >= config.actor_rollout_ref.actor.ppo_mini_batch_size
             sp_size = config.actor_rollout_ref.actor.get('ulysses_sequence_parallel_size', 1)
+            assert config.data.train_batch_size >= config.actor_rollout_ref.actor.ppo_mini_batch_size * sp_size
             if config.actor_rollout_ref.actor.ppo_micro_batch_size is not None:
                 assert config.actor_rollout_ref.actor.ppo_mini_batch_size % config.actor_rollout_ref.actor.ppo_micro_batch_size == 0
                 assert config.actor_rollout_ref.actor.ppo_micro_batch_size * sp_size >= n_gpus


### PR DESCRIPTION
Current assertion effectively avoid the mismatching between gradient accumulation steps and number of micro batches. But it doesn't take into account sequence parallel size, which is also used when normalizing the ppo_mini_batch_size.

Below is a **concrete “edge‑case” configuration** where  
`train_batch_size == ppo_mini_batch_size`, first with **sequence‑parallel (SP) = 1** (works perfectly), then with **SP = 2** (old assert lets it run but silently halves the gradient; the new assert blocks it).

---

## Configuration (common parts)

| Item | Value | Note |
|------|-------|------|
| `train_batch_size` (`T`) | **32** prompts |
| `ppo_mini_batch_size` (`P`) | **32** prompts |
| `rollout.n` (`R`) | 8 |
| GPUs (`world_size = DP`) | 8 ( 1 node × 8 cards ) |
| `ppo_micro_batch_size_per_gpu` | 4 |
| Dataset length divisible ⇒ dataloader never drops |

---

## 1 . SP = 1  — **Everything aligns**

| Calculation | Result |
|-------------|--------|
| **Real on‑policy samples** | `T × R = 32 × 8 = 256` |
| Per‑GPU real | `256 ÷ 8 = 32` |
| **Normalized mini (per GPU)** | `(P × R) ÷ DP = (32 × 8) ÷ 8 = 32` |
| Mini‑batch count / GPU | `32 ÷ 32 = 1` |
| **Micro‑batch count** | `32 ÷ 4 = 8` |
| `gradient_accumulation` | `32 ÷ 4 = 8` |

Flow per GPU:

```
zero_grad
  ├─ backward × 8   # each loss /= 8
step()              # 1 parameter update
```

No mismatch, full gradient applied.

---

## 2 . SP = 2  — **Gradient silently halved**

1. **Worker’s normalisation**

$$
\text{mini}_{\text{rank}} = \frac{P × R × S}{DP}
                          = \frac{32 × 8 × 2}{8}
                          = 64\; \text{samples}
$$

2. **But each rank only has 32 samples** (real batch unchanged).

3. Code path:

```python
mini_batch = torch.split(batch, 64)    # returns ONE chunk of 32!
gradient_accumulation = 64 // 4 = 16
micro_batches = mini_batch.split(4)    # 32/4 = 8 chunks
```

- We run **8 × (loss / 16).backward()**  
- ⇒ overall gradient scaled by 8 / 16 = **½**  
- Training still “runs,” but effective learning rate and update magnitude are cut in half.

4. **Old assert** (`T ≥ P`) : **passes**  
   ```
   32 ≥ 32   ✓
   ```
   …thus lets this flawed setup proceed.

5. **Proposed assert** (`T ≥ P × S`) : **fails**  
   ```
   32 ≥ 32 × 2   ✗
   ```
   …blocks the configuration before silent under‑training occurs.

---

## Take‑away

| Assert version | SP = 1 (good) | SP = 2 (bad) |
|----------------|--------------|-------------|
| **Old** `T ≥ P` | ✅ | **Allows** → ½‑gradient |
| **New** `T ≥ P × S` | ✅ | **Stops** before damage |

Hence the refined check is *precise enough*: it preserves working cases while catching exactly the scenario where gradient scaling would break once sequence parallelism is enabled.