### PR TITLE
[feat] add file level weighted sampling for rl_dataset

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -30,7 +30,7 @@ import numpy as np
 import ray
 from codetiming import Timer
 from omegaconf import OmegaConf, open_dict
-from torch.utils.data import Dataset, RandomSampler, SequentialSampler
+from torch.utils.data import Dataset, RandomSampler, SequentialSampler, WeightedRandomSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
@@ -451,6 +451,32 @@ class RayPPOTrainer:
 
         print("[validate_config] All configuration checks passed successfully!")
 
+    def _create_train_sampler(self):
+        # `data.shuffle` is False, use deterministic sampling
+        if not self.config.data.shuffle:
+            print('Using SequentialSampler')
+            return SequentialSampler(data_source=self.train_dataset)
+
+        # `data.shuffle` is True, can be various probabilistic samplings
+
+        train_dataloader_generator = torch.Generator()
+        train_dataloader_generator.manual_seed(self.config.data.get('seed', 1))
+
+        dataframe_weights = None if not hasattr(self.train_dataset, 'dataframe_weights') \
+                            else self.train_dataset.dataframe_weights
+        # `train_dataset.dataframe_weights` not exists, use plain uniform random sampling
+        if dataframe_weights is None:
+            print('Using RandomSampler')
+            return RandomSampler(data_source=self.train_dataset, generator=train_dataloader_generator)
+
+        # `train_dataset.dataframe_weights` does exist, use weighted sampling
+        assert len(dataframe_weights) == len(self.train_dataset), \
+            f'the sampling weights {len(dataframe_weights)=} must have the same length as the dataset {len(self.train_dataset)=}'
+        print('Using WeightedRandomSampler')
+        return WeightedRandomSampler(weights=dataframe_weights,
+                                     num_samples=len(self.train_dataset),
+                                     generator=train_dataloader_generator)
+
     def _create_dataloader(self):
         # TODO: we have to make sure the batch size is divisible by the dp size
         from verl.utils.import_utils import load_extern_type
@@ -467,26 +493,22 @@ class RayPPOTrainer:
 
         self.train_dataset = dataset_cls(
             data_files=self.config.data.train_files,
+            data_file_weights=self.config.data.get('train_file_weights', None),
             tokenizer=self.tokenizer,
             processor=self.processor,
             config=self.config.data,
         )
 
         # use sampler for better ckpt resume
-        if self.config.data.shuffle:
-            train_dataloader_generator = torch.Generator()
-            train_dataloader_generator.manual_seed(self.config.data.get("seed", 1))
-            sampler = RandomSampler(data_source=self.train_dataset, generator=train_dataloader_generator)
-        else:
-            sampler = SequentialSampler(data_source=self.train_dataset)
+        train_sampler = self._create_train_sampler()
 
         self.train_dataloader = StatefulDataLoader(
             dataset=self.train_dataset,
-            batch_size=self.config.data.get("gen_batch_size", self.config.data.train_batch_size),
+            batch_size=self.config.data.get('gen_batch_size', self.config.data.train_batch_size),
             num_workers=8,
             drop_last=True,
             collate_fn=collate_fn,
-            sampler=sampler,
+            sampler=train_sampler
         )
 
         self.val_dataset = dataset_cls(

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -454,28 +454,30 @@ class RayPPOTrainer:
     def _create_train_sampler(self):
         # `data.shuffle` is False, use deterministic sampling
         if not self.config.data.shuffle:
-            print('Using SequentialSampler')
+            print("Using SequentialSampler")
             return SequentialSampler(data_source=self.train_dataset)
 
         # `data.shuffle` is True, can be various probabilistic samplings
 
         train_dataloader_generator = torch.Generator()
-        train_dataloader_generator.manual_seed(self.config.data.get('seed', 1))
+        train_dataloader_generator.manual_seed(self.config.data.get("seed", 1))
 
-        dataframe_weights = None if not hasattr(self.train_dataset, 'dataframe_weights') \
-                            else self.train_dataset.dataframe_weights
+        dataframe_weights = (
+            None if not hasattr(self.train_dataset, "dataframe_weights") else self.train_dataset.dataframe_weights
+        )
         # `train_dataset.dataframe_weights` not exists, use plain uniform random sampling
         if dataframe_weights is None:
-            print('Using RandomSampler')
+            print("Using RandomSampler")
             return RandomSampler(data_source=self.train_dataset, generator=train_dataloader_generator)
 
         # `train_dataset.dataframe_weights` does exist, use weighted sampling
-        assert len(dataframe_weights) == len(self.train_dataset), \
-            f'the sampling weights {len(dataframe_weights)=} must have the same length as the dataset {len(self.train_dataset)=}'
-        print('Using WeightedRandomSampler')
-        return WeightedRandomSampler(weights=dataframe_weights,
-                                     num_samples=len(self.train_dataset),
-                                     generator=train_dataloader_generator)
+        assert len(dataframe_weights) == len(self.train_dataset), (
+            f"the sampling weights {len(dataframe_weights)=} must have the same length as the dataset {len(self.train_dataset)=}"
+        )
+        print("Using WeightedRandomSampler")
+        return WeightedRandomSampler(
+            weights=dataframe_weights, num_samples=len(self.train_dataset), generator=train_dataloader_generator
+        )
 
     def _create_dataloader(self):
         # TODO: we have to make sure the batch size is divisible by the dp size
@@ -493,7 +495,7 @@ class RayPPOTrainer:
 
         self.train_dataset = dataset_cls(
             data_files=self.config.data.train_files,
-            data_file_weights=self.config.data.get('train_file_weights', None),
+            data_file_weights=self.config.data.get("train_file_weights", None),
             tokenizer=self.tokenizer,
             processor=self.processor,
             config=self.config.data,
@@ -504,11 +506,11 @@ class RayPPOTrainer:
 
         self.train_dataloader = StatefulDataLoader(
             dataset=self.train_dataset,
-            batch_size=self.config.data.get('gen_batch_size', self.config.data.train_batch_size),
+            batch_size=self.config.data.get("gen_batch_size", self.config.data.train_batch_size),
             num_workers=8,
             drop_last=True,
             collate_fn=collate_fn,
-            sampler=train_sampler
+            sampler=train_sampler,
         )
 
         self.val_dataset = dataset_cls(

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -55,13 +55,15 @@ class RLHFDataset(Dataset):
     We assume the dataset contains a column that contains prompts and other information
     """
 
-    def __init__(self,
-                 data_files: Union[str, List[str]],
-                 tokenizer: PreTrainedTokenizer,
-                 config: DictConfig,
-                 processor: Optional[ProcessorMixin] = None,
-                 data_file_weights: List[float] = None,
-                 **kwargs):
+    def __init__(
+        self,
+        data_files: Union[str, List[str]],
+        tokenizer: PreTrainedTokenizer,
+        config: DictConfig,
+        processor: Optional[ProcessorMixin] = None,
+        data_file_weights: List[float] = None,
+        **kwargs,
+    ):
         if not isinstance(data_files, (List, ListConfig)):
             data_files = [data_files]
 
@@ -73,11 +75,13 @@ class RLHFDataset(Dataset):
 
         self.data_file_weights = data_file_weights
         if self.data_file_weights is not None:
-            assert isinstance(self.data_file_weights, Sized), \
-                f'data_file_weights must be Sized, but {type(self.data_file_weights)=}'
-            assert len(self.data_file_weights) == len(self.data_files), \
-                f'{len(self.data_file_weights)=} not equal to {len(self.data_files)=}'
-            print(f'Using data_file_weights: {self.data_file_weights}')
+            assert isinstance(self.data_file_weights, Sized), (
+                f"data_file_weights must be Sized, but {type(self.data_file_weights)=}"
+            )
+            assert len(self.data_file_weights) == len(self.data_files), (
+                f"{len(self.data_file_weights)=} not equal to {len(self.data_files)=}"
+            )
+            print(f"Using data_file_weights: {self.data_file_weights}")
 
         self.cache_dir = os.path.expanduser(config.get("cache_dir", "~/.cache/verl/rlhf"))
         self.prompt_key = config.get("prompt_key", "prompt")


### PR DESCRIPTION
Allow weighted sampling for multiple dataset files during RL training.

Suppose you have two datasets `GSM8K` (\~= 8K instances) and `BFG10K` (\~= 10K instances) in RL, and you want to mix in balanced data from these two datasets when making a mini batch at each iteration, then you can specify the data file weights by a list of numbers like this:
```
...
 data.train_files="['/path/to/gsm8k.parquet','/path/to/bfg10k.parquet']" \
 data.shuffle=True \
 +data.train_file_weights="[10,8]" \
...
```
as this ensures that the "total unnormalized probability mass (= num instances * weight)" equalizes for the two datasets: 8K * 10 = 10K * 8. 

Of course, other weights and other length of list can be set. Note also that the underlying torch `WeightedRandomSampler` accepts unnormalized weights as input.

One can get back to the conventional random shuffling (uniformly random sampling):
```
data.train_files="['/path/to/gsm8k.parquet','/path/to/bfg10k.parquet']" \
data.shuffle=True \
```
or sequential iterating (deterministic sampling):
```
data.train_files="['/path/to/gsm8k.parquet','/path/to/bfg10k.parquet']" \
data.shuffle=False \
```
by NOT setting the `data.train_file_weights` argument.
 