### PR TITLE
change deepspeedai url site.

### DIFF
--- a/verl/utils/ulysses.py
+++ b/verl/utils/ulysses.py
@@ -14,7 +14,7 @@
 """
 Utilities for DeepSpeed Ulysses Sequence Parallelism.
 DeepSpeed Ulysses Paper: https://arxiv.org/abs/2309.14509
-Inspired from: https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/sequence/layer.py
+Inspired from: https://github.com/deepspeedai/DeepSpeed/blob/master/deepspeed/sequence/layer.py
 """
 
 from typing import Any, Optional, Tuple


### PR DESCRIPTION
DeepSpeed has moved to `deepspeedai` repo.