### PR TITLE
refactor: use 'from e' for exception stack trace

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -41,7 +41,7 @@ def get_custom_reward_fn(config):
         sys.modules["custom_module"] = module
         spec.loader.exec_module(module)
     except Exception as e:
-        raise RuntimeError(f"Error loading module from '{file_path}': {e}")
+        raise RuntimeError(f"Error loading module from '{file_path}': {e}") from e
 
     function_name = reward_fn_config.get("name")
     if not hasattr(module, function_name):


### PR DESCRIPTION
Use the 'from e' inside the try-except statement to keep the stack trace of the error