### PR TITLE
[dev] fix: instructions about merging from before using ruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,8 @@ Contributions from the community are welcome! Please check out our [project road
 > [!WARNING]
 > We are [immigrating to `ruff` as the linter and formatter and `pre-commit` as the managing tool](https://github.com/volcengine/verl/pull/1010).
 >
-> If your branch is based on a previous commit using `yapf` and `pylint`,
-> please try applying `ruff check --fix` and `ruff format` before merging
-> to minimize the linting errors.
+> You are only expected to fix the linting errors in the files you changed.
+> Our pre-commit hook and CI action only checks the files you changed for now.
 
 We use pre-commit to help improve code quality. To initialize pre-commit, run:
 

--- a/README.md
+++ b/README.md
@@ -207,14 +207,9 @@ Contributions from the community are welcome! Please check out our [project road
 > [!WARNING]
 > We are [immigrating to `ruff` as the linter and formatter and `pre-commit` as the managing tool](https://github.com/volcengine/verl/pull/1010).
 >
-> If your branch is based on a previous commit using `yapf` and `pylint`, simply merging might trigger overwhelming linting errors, while **you are only expected to resolve ones in the files related to your PR**.
->
-> To resolve this issue, please try the following workaround to only include the files you **really changed** in the PR:
->
-> 1. In your branch, fix linting and format with `ruff`: `ruff check --fix && ruff-format`
-> 2. Squash into a new single commit: `git reset --soft $(git merge-base main HEAD) && git add -A && git commit -m "feat: ..."`
-> 3. Merge with the latest main: `git merge origin/main`
-> 4. Force push to your branch: `git push --force`
+> If your branch is based on a previous commit using `yapf` and `pylint`,
+> please try applying `ruff check --fix` and `ruff format` before merging
+> to minimize the linting errors.
 
 We use pre-commit to help improve code quality. To initialize pre-commit, run:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,9 +121,8 @@ Code Linting and Formatting
 .. warning::
    We are `immigrating to ``ruff`` as the linter and formatter and ``pre-commit`` as the managing tool <https://github.com/volcengine/verl/pull/1010>`_.
 
-   If your branch is based on a previous commit using `yapf` and `pylint`,
-   please try applying `ruff check --fix` and `ruff format` before merging
-   to minimize the linting errors.
+   You are only expected to fix the linting errors in the files you changed.
+   Our pre-commit hook and CI action only checks the files you changed for now.
 
 We use pre-commit to help improve code quality. To initialize pre-commit, run:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,14 +121,9 @@ Code Linting and Formatting
 .. warning::
    We are `immigrating to ``ruff`` as the linter and formatter and ``pre-commit`` as the managing tool <https://github.com/volcengine/verl/pull/1010>`_.
 
-   If your branch is based on a previous commit using ``yapf`` and ``pylint``, simply merging might trigger overwhelming linting errors, while **you are only expected to resolve ones in the files related to your PR**.
-   
-   To resolve this issue, please try the following workaround to only include the files you **really changed** in the PR:
-   
-   1. In your branch, fix linting and format with ``ruff``: ``ruff check --fix && ruff-format``
-   2. Squash into a new single commit: ``git reset --soft $(git merge-base main HEAD) && git add -A && git commit -m "feat: ..."``
-   3. Merge with the latest main: ``git merge origin/main``
-   4. Force push to your branch: ``git push --force``
+   If your branch is based on a previous commit using `yapf` and `pylint`,
+   please try applying `ruff check --fix` and `ruff format` before merging
+   to minimize the linting errors.
 
 We use pre-commit to help improve code quality. To initialize pre-commit, run:
 

--- a/examples/split_placement/split_monkey_patch.py
+++ b/examples/split_placement/split_monkey_patch.py
@@ -37,7 +37,8 @@ from verl.trainer.ppo.ray_trainer import (
 def fit(self):
     """
     The training loop of PPO.
-    The driver process only need to call the compute functions of the worker group through RPC to construct the PPO dataflow.
+    The driver process only need to call the compute functions of the worker group through RPC
+    to construct the PPO dataflow.
     The light-weight advantage computation is done on the driver process.
     """
     from omegaconf import OmegaConf
@@ -156,13 +157,15 @@ def fit(self):
                         batch.batch["token_level_rewards"] = batch.batch["token_level_scores"]
 
                     # compute advantages, executed on the driver process
-                    norm_adv_by_std_in_grpo = self.config.algorithm.get('norm_adv_by_std_in_grpo', True)
-                    batch = compute_advantage(batch,
-                                              adv_estimator=self.config.algorithm.adv_estimator,
-                                              gamma=self.config.algorithm.gamma,
-                                              lam=self.config.algorithm.lam,
-                                              num_repeat=self.config.actor_rollout_ref.rollout.n,
-                                              norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo)
+                    norm_adv_by_std_in_grpo = self.config.algorithm.get("norm_adv_by_std_in_grpo", True)
+                    batch = compute_advantage(
+                        batch,
+                        adv_estimator=self.config.algorithm.adv_estimator,
+                        gamma=self.config.algorithm.gamma,
+                        lam=self.config.algorithm.lam,
+                        num_repeat=self.config.actor_rollout_ref.rollout.n,
+                        norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+                    )
 
                 # update critic
                 if self.use_critic:

--- a/recipe/dapo/src/dapo_ray_trainer.py
+++ b/recipe/dapo/src/dapo_ray_trainer.py
@@ -43,7 +43,8 @@ class RayDAPOTrainer(RayPPOTrainer):
     def fit(self):
         """
         The training loop of PPO.
-        The driver process only need to call the compute functions of the worker group through RPC to construct the PPO dataflow.
+        The driver process only need to call the compute functions of the worker group through RPC
+        to construct the PPO dataflow.
         The light-weight advantage computation is done on the driver process.
         """
         from omegaconf import OmegaConf
@@ -171,7 +172,8 @@ class RayDAPOTrainer(RayPPOTrainer):
 
                     if not self.config.algorithm.filter_groups.enable:
                         batch = new_batch
-                    else:  # NOTE: When prompts after filtering is less than train batch size, we skip to the next generation batch
+                    else:  # NOTE: When prompts after filtering is less than train batch size,
+                        # we skip to the next generation batch
                         metric_name = self.config.algorithm.filter_groups.metric
                         if metric_name == "seq_final_reward":
                             # Turn to numpy for easier filtering
@@ -218,7 +220,9 @@ class RayDAPOTrainer(RayPPOTrainer):
                                 continue
                             else:
                                 raise ValueError(
-                                    f"{num_gen_batches=} >= {max_num_gen_batches=}. Generated too many. Please check your data."
+                                    f"{num_gen_batches=} >= {max_num_gen_batches=}."
+                                    + " Generated too many. Please check if your data are too difficult."
+                                    + " You could also try set max_num_gen_batches=0 to enable endless trials."
                                 )
                         else:
                             # Align the batch
@@ -253,13 +257,15 @@ class RayDAPOTrainer(RayPPOTrainer):
 
                     with _timer("adv", timing_raw):
                         # compute advantages, executed on the driver process
-                        norm_adv_by_std_in_grpo = self.config.algorithm.get('norm_adv_by_std_in_grpo', True)
-                        batch = compute_advantage(batch,
-                                                  adv_estimator=self.config.algorithm.adv_estimator,
-                                                  gamma=self.config.algorithm.gamma,
-                                                  lam=self.config.algorithm.lam,
-                                                  num_repeat=self.config.actor_rollout_ref.rollout.n,
-                                                  norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo)
+                        norm_adv_by_std_in_grpo = self.config.algorithm.get("norm_adv_by_std_in_grpo", True)
+                        batch = compute_advantage(
+                            batch,
+                            adv_estimator=self.config.algorithm.adv_estimator,
+                            gamma=self.config.algorithm.gamma,
+                            lam=self.config.algorithm.lam,
+                            num_repeat=self.config.actor_rollout_ref.rollout.n,
+                            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+                        )
 
                     # update critic
                     if self.use_critic:

--- a/verl/models/mcore/model_initializer.py
+++ b/verl/models/mcore/model_initializer.py
@@ -28,6 +28,7 @@ def init_mcore_model_dense(
     # for LlamaForCausalLM, Qwen2ForCausalLM
     from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
     from megatron.core.models.gpt.gpt_model import GPTModel
+
     use_te = True
     assert tfconfig.normalization == "RMSNorm", "only RMSNorm is supported for now"
     transformer_layer_spec = get_gpt_decoder_block_spec(tfconfig, use_transformer_engine=use_te)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -110,11 +110,13 @@ def compute_gae_advantage_return(
 
 
 # NOTE(sgm): this implementation only consider outcome supervision, where the reward is a scalar.
-def compute_grpo_outcome_advantage(token_level_rewards: torch.Tensor,
-                                   response_mask: torch.Tensor,
-                                   index: np.ndarray,
-                                   epsilon: float = 1e-6,
-                                   norm_adv_by_std_in_grpo: str = True):
+def compute_grpo_outcome_advantage(
+    token_level_rewards: torch.Tensor,
+    response_mask: torch.Tensor,
+    index: np.ndarray,
+    epsilon: float = 1e-6,
+    norm_adv_by_std_in_grpo: str = True,
+):
     """
     Compute advantage for GRPO, operating only on Outcome reward
     (with only one scalar reward for each response).
@@ -124,10 +126,10 @@ def compute_grpo_outcome_advantage(token_level_rewards: torch.Tensor,
         response_mask: `(torch.Tensor)`
             shape: (bs, response_length)
         norm_adv_by_std_in_grpo: (bool)
-            whether to scale the GRPO advantage. 
+            whether to scale the GRPO advantage.
             If True, the advantage is scaled by the std, as in the original GRPO.
             If False, the advantage is not scaled, as in Dr.GRPO (https://arxiv.org/abs/2503.20783).
-    
+
     Returns:
         advantages: `(torch.Tensor)`
             shape: (bs, response_length)
@@ -157,7 +159,7 @@ def compute_grpo_outcome_advantage(token_level_rewards: torch.Tensor,
             if norm_adv_by_std_in_grpo:
                 scores[i] = (scores[i] - id2mean[index[i]]) / (id2std[index[i]] + epsilon)
             else:
-                scores[i] = (scores[i] - id2mean[index[i]])
+                scores[i] = scores[i] - id2mean[index[i]]
         scores = scores.unsqueeze(-1) * response_mask
 
     return scores, scores
@@ -329,9 +331,9 @@ def agg_loss(loss_mat: torch.Tensor, loss_mask: torch.Tensor, loss_agg_mode: str
             shape: (bs, response_length)
         loss_mask: `(torch.Tensor)`
             shape: (bs, response_length)
-        loss_agg_mode: (str) choices: "token-mean" / 
+        loss_agg_mode: (str) choices: "token-mean" /
                                       "seq-mean-token-sum" /
-                                      "seq-mean-token-mean" / 
+                                      "seq-mean-token-mean" /
                                       "seq-mean-token-sum-norm" /
             "token-mean" is the default behavior
     Returns:
@@ -388,11 +390,11 @@ def compute_policy_loss(
             The higher clip range used in PPO.
         clip_ratio_c: (float) default: 3.0
             The lower bound of the ratio for dual-clip PPO, See https://arxiv.org/pdf/1912.09729
-        loss_agg_mode: (str) choices: "token-mean" / 
-                                      "seq-mean-token-sum" / 
+        loss_agg_mode: (str) choices: "token-mean" /
+                                      "seq-mean-token-sum" /
                                       "seq-mean-token-mean" /
                                       "seq-mean-token-sum-norm" /
-            "token-mean" is the default behavior        
+            "token-mean" is the default behavior
 
     Returns:
         pg_loss: `a scalar torch.Tensor`
@@ -405,7 +407,8 @@ def compute_policy_loss(
             the fraction of policy gradient loss being clipped when the advantage is negative
     """
     assert clip_ratio_c > 1.0, (
-        f"The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0, but get the value: {clip_ratio_c}."
+        "The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0,"
+        + f" but get the value: {clip_ratio_c}."
     )
 
     negative_approx_kl = log_prob - old_log_prob

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -203,12 +203,13 @@ def compute_advantage(data: DataProto, adv_estimator, gamma=1.0, lam=1.0, num_re
         data.batch["returns"] = returns
     elif adv_estimator == AdvantageEstimator.GRPO:
         advantages, returns = core_algos.compute_grpo_outcome_advantage(
-            token_level_rewards=data.batch['token_level_rewards'],
-            response_mask=data.batch['response_mask'],
-            index=data.non_tensor_batch['uid'],
-            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo)
-        data.batch['advantages'] = advantages
-        data.batch['returns'] = returns
+            token_level_rewards=data.batch["token_level_rewards"],
+            response_mask=data.batch["response_mask"],
+            index=data.non_tensor_batch["uid"],
+            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+        )
+        data.batch["advantages"] = advantages
+        data.batch["returns"] = returns
     elif adv_estimator == AdvantageEstimator.REINFORCE_PLUS_PLUS_BASELINE:
         advantages, returns = core_algos.compute_reinforce_plus_plus_baseline_outcome_advantage(
             token_level_rewards=data.batch["token_level_rewards"],
@@ -406,7 +407,10 @@ class RayPPOTrainer:
                 assert config.actor_rollout_ref.actor.ppo_micro_batch_size * sp_size >= n_gpus
 
         assert config.actor_rollout_ref.actor.loss_agg_mode in [
-            "token-mean", "seq-mean-token-sum", "seq-mean-token-mean", "seq-mean-token-sum-norm"
+            "token-mean",
+            "seq-mean-token-sum",
+            "seq-mean-token-mean",
+            "seq-mean-token-sum-norm",
         ], f"Invalid loss_agg_mode: {config.actor_rollout_ref.actor.loss_agg_mode}"
 
         if config.algorithm.use_kl_in_reward and config.actor_rollout_ref.actor.use_kl_loss:
@@ -1018,14 +1022,17 @@ class RayPPOTrainer:
                             batch.batch["token_level_rewards"] = batch.batch["token_level_scores"]
 
                         # compute advantages, executed on the driver process
-                        norm_adv_by_std_in_grpo = self.config.algorithm.get('norm_adv_by_std_in_grpo',
-                                                                            True)  # GRPO adv normalization factor
-                        batch = compute_advantage(batch,
-                                                  adv_estimator=self.config.algorithm.adv_estimator,
-                                                  gamma=self.config.algorithm.gamma,
-                                                  lam=self.config.algorithm.lam,
-                                                  num_repeat=self.config.actor_rollout_ref.rollout.n,
-                                                  norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo)
+                        norm_adv_by_std_in_grpo = self.config.algorithm.get(
+                            "norm_adv_by_std_in_grpo", True
+                        )  # GRPO adv normalization factor
+                        batch = compute_advantage(
+                            batch,
+                            adv_estimator=self.config.algorithm.adv_estimator,
+                            gamma=self.config.algorithm.gamma,
+                            lam=self.config.algorithm.lam,
+                            num_repeat=self.config.actor_rollout_ref.rollout.n,
+                            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+                        )
 
                     # update critic
                     if self.use_critic:

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -30,6 +30,7 @@ from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.module import Float16Module
 from megatron.core.utils import get_attr_wrapped_model
+from transformers import PretrainedConfig
 
 from verl.utils.memory_buffer import build_memory_reference_from_module
 from verl.utils.torch_dtypes import PrecisionType
@@ -157,9 +158,6 @@ def unwrap_model(model, module_instances=ALL_MODULE_WRAPPER_CLASSNAMES):
     return unwrapped_model
 
 
-from transformers import PretrainedConfig
-
-
 def convert_config(hf_config: PretrainedConfig, megatron_config) -> TransformerConfig:
     print(f"megatron config {megatron_config}")
     dt = PrecisionType.to_dtype(megatron_config.params_dtype)
@@ -208,10 +206,10 @@ def convert_config(hf_config: PretrainedConfig, megatron_config) -> TransformerC
 
 def init_megatron_optim_config(optim_config: Dict) -> OptimizerConfig:
     config = OptimizerConfig(
-        optimizer='adam',
-        lr=optim_config.get('lr'),
-        clip_grad=optim_config.get('clip_grad'),
-        weight_decay=optim_config.get('weight_decay'),
+        optimizer="adam",
+        lr=optim_config.get("lr"),
+        clip_grad=optim_config.get("clip_grad"),
+        weight_decay=optim_config.get("weight_decay"),
         bf16=True,
         params_dtype=torch.bfloat16,
         use_distributed_optimizer=True,

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -216,9 +216,10 @@ class ActorRolloutRefWorker(MegatronWorker):
 
     def _build_rollout(self, trust_remote_code=False):
         if self.config.rollout.name == "vllm":
+            from torch.distributed.device_mesh import init_device_mesh
+
             from verl.workers.rollout.vllm_rollout import vllm_mode, vLLMRollout
             from verl.workers.sharding_manager.megatron_vllm import MegatronVLLMShardingManager
-            from torch.distributed.device_mesh import init_device_mesh
 
             # NOTE(sgm): If the QKV and gate_up projection layer are concate together in actor,
             # we will reorganize their weight format when resharding from actor to rollout.


### PR DESCRIPTION
Our pre-commit hook and CI action only check the changes for now.

In this PR,

1. We apply `ruff check --fix` and `ruff format`.
2. We remove the unnecessary pipeline from the immigration warning, since directly merging without applying `ruff`, which might cause extra conflicts, is the best way to avoid introducing extra file changes.