### PR TITLE
[SGLang] Add support for IPv6

### DIFF
--- a/verl/utils/net_utils.py
+++ b/verl/utils/net_utils.py
@@ -1,0 +1,33 @@
+import ipaddress
+
+def is_ipv4(ip_str: str) -> bool:
+    """
+    Check if the given string is an IPv4 address
+    
+    Args:
+        ip_str: The IP address string to check
+        
+    Returns:
+        bool: Returns True if it's an IPv4 address, False otherwise
+    """
+    try:
+        ipaddress.IPv4Address(ip_str)
+        return True
+    except ipaddress.AddressValueError:
+        return False
+
+def is_ipv6(ip_str: str) -> bool:
+    """
+    Check if the given string is an IPv6 address
+    
+    Args:
+        ip_str: The IP address string to check
+        
+    Returns:
+        bool: Returns True if it's an IPv6 address, False otherwise
+    """
+    try:
+        ipaddress.IPv6Address(ip_str)
+        return True
+    except ipaddress.AddressValueError:
+        return False

--- a/verl/utils/net_utils.py
+++ b/verl/utils/net_utils.py
@@ -1,3 +1,29 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import ipaddress
 
 def is_ipv4(ip_str: str) -> bool:

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -45,6 +45,7 @@ from torch.nn.utils.rnn import pad_sequence
 from verl import DataProto
 from verl.third_party.sglang import parallel_state as sglang_ps
 from verl.utils.torch_functional import get_response_mask, pad_sequence_to_length
+from verl.utils.net_utils import is_ipv6
 from verl.workers.rollout.base import BaseRollout
 
 if TYPE_CHECKING:
@@ -161,7 +162,7 @@ class SGLangRollout(BaseRollout):
             dist_group=device_mesh_cpu.get_group("tp"),
             src=device_mesh_cpu["tp"].mesh[0].item(),
         )
-        dist_init_addr = f"{ip}:{port_args.nccl_port}"
+        dist_init_addr = f"[{ip}]:{port_args.nccl_port}" if is_ipv6(ip) else f"{ip}:{port_args.nccl_port}"
         load_format = "dummy" if config.load_format.startswith("dummy") else config.load_format
         self.inference_engine = VerlEngine(
             model_path=actor_module,


### PR DESCRIPTION
## Motivation
In the current usage of SGLang, if verl is under an IPv6 network, it will cause an address construction error, leading to a failure. This is because we need to handle the address based on IP network judgment.