### PR TITLE
Log gpu mem refactor

### DIFF
--- a/recipe/prime/prime_fsdp_workers.py
+++ b/recipe/prime/prime_fsdp_workers.py
@@ -43,7 +43,7 @@ from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManage
 from .prime_core_algos import compute_dpo_abs_accuracy, compute_dpo_accuracy
 
 logger = logging.getLogger(__file__)
-logger.setLevel(os.getenv("VERL_PPO_LOGGING_LEVEL", "WARN"))
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 class PRIMERewardModelWorker(Worker):

--- a/verl/utils/debug/__init__.py
+++ b/verl/utils/debug/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .performance import log_gpu_memory_usage
+from .performance import GPUMemoryLogger, log_gpu_memory_usage

--- a/verl/utils/debug/performance.py
+++ b/verl/utils/debug/performance.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-from functools import wraps
 
 import torch
 import torch.distributed as dist

--- a/verl/utils/debug/performance.py
+++ b/verl/utils/debug/performance.py
@@ -18,7 +18,7 @@ from functools import wraps
 import torch
 import torch.distributed as dist
 
-from verl.utils.logger.aggregate_logger import DecoratorLogger
+from verl.utils.logger.aggregate_logger import DecoratorLoggerBase
 
 
 def log_gpu_memory_usage(head: str, logger: logging.Logger = None, level=logging.DEBUG, rank: int = 0):
@@ -34,7 +34,7 @@ def log_gpu_memory_usage(head: str, logger: logging.Logger = None, level=logging
             logger.log(msg=message, level=level)
 
 
-class GPUMemoryLogger(DecoratorLogger):
+class GPUMemoryLogger(DecoratorLoggerBase):
     """_summary_
     
     Usage:
@@ -67,6 +67,8 @@ class GPUMemoryLogger(DecoratorLogger):
         memory_reserved = torch.cuda.memory_reserved() / 1024**3
 
         message = f"Before {func.__name__}, memory allocated (GB): {memory_allocated}, memory reserved (GB): {memory_reserved}"
-        output = self.logging_function(message, func, *args, **kwargs)
+        self.logging_function(message)
+        output = func(*args, **kwargs)
         message = f"After {func.__name__}, memory allocated (GB): {memory_allocated}, memory reserved (GB): {memory_reserved}"
+        self.logging_function(message)
         return output

--- a/verl/utils/debug/performance.py
+++ b/verl/utils/debug/performance.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import logging
+from functools import wraps
 
 import torch
 import torch.distributed as dist
+
+from verl.utils.logger.aggregate_logger import DecoratorLogger
 
 
 def log_gpu_memory_usage(head: str, logger: logging.Logger = None, level=logging.DEBUG, rank: int = 0):
@@ -29,3 +32,41 @@ def log_gpu_memory_usage(head: str, logger: logging.Logger = None, level=logging
             print(message)
         else:
             logger.log(msg=message, level=level)
+
+
+class GPUMemoryLogger(DecoratorLogger):
+    """_summary_
+    
+    Usage:
+        For example, in actor function, we initialize a GPUMemoryLogger
+        
+        ```
+        from verl.utils.debug.performance import GPUMemoryLogger
+        @GPUMemoryLogger(role="actor")
+        def update_actor(self, batch):
+            # do something
+            return
+        ```
+    
+    """
+    
+    def __init__(self, role: str, logger: logging.Logger = None, level=logging.DEBUG, log_only_rank_0: bool = True):
+        if dist.is_initialized() and dist.get_world_size() > 1:
+            rank = dist.get_rank()
+        else:
+            rank = 0
+        super().__init__(role, logger, level, rank, log_only_rank_0)
+    
+    def __call__(self, decorated_function: callable):
+        def f(*args, **kwargs):
+            return self.log(decorated_function, *args, **kwargs)
+        return f
+    
+    def log(self, func, *args, **kwargs):
+        memory_allocated = torch.cuda.memory_allocated() / 1024**3
+        memory_reserved = torch.cuda.memory_reserved() / 1024**3
+
+        message = f"Before {func.__name__}, memory allocated (GB): {memory_allocated}, memory reserved (GB): {memory_reserved}"
+        output = self.logging_function(message, func, *args, **kwargs)
+        message = f"After {func.__name__}, memory allocated (GB): {memory_allocated}, memory reserved (GB): {memory_reserved}"
+        return output

--- a/verl/utils/logger/aggregate_logger.py
+++ b/verl/utils/logger/aggregate_logger.py
@@ -53,21 +53,13 @@ class DecoratorLoggerBase:
         if logger is None:
             self.logging_function = self.log_by_print
     
-    def log_by_print(self, log_str, decorated_function, *args, **kwargs):
-        if not self.log_only_rank_0 and self.rank == 0:
-            print(f"Before {self.role} {log_str}", flush=True)
-        output = decorated_function(*args, **kwargs)
-        if not self.log_only_rank_0 and self.rank == 0:
-            print(f"After {self.role} {log_str}", flush=True)
-        return output
+    def log_by_print(self, log_str):
+        if not self.log_only_rank_0 or self.rank == 0:
+            print(f"{self.role} {log_str}", flush=True)
     
-    def log_by_logging(self, log_str, decorated_function, *args, **kwargs):
+    def log_by_logging(self, log_str):
         if self.logger is None:
             raise ValueError("Logger is not initialized")
-        if not self.log_only_rank_0 and self.rank == 0:
-            self.logger.log(self.level, f"Before {self.role} {log_str}")
-        output = decorated_function(*args, **kwargs)
-        if not self.log_only_rank_0 and self.rank == 0:
-            self.logger.log(self.level, f"After {self.role} {log_str}")
-        return output
+        if not self.log_only_rank_0 or self.rank == 0:
+            self.logger.log(self.level, f"{self.role} {log_str}")
     

--- a/verl/utils/logger/aggregate_logger.py
+++ b/verl/utils/logger/aggregate_logger.py
@@ -15,6 +15,7 @@
 A Ray logger will receive logging info from different processes.
 """
 
+import logging
 import numbers
 from typing import Dict
 
@@ -40,3 +41,33 @@ class LocalLogger:
     def log(self, data, step):
         if self.print_to_console:
             print(concat_dict_to_str(data, step=step), flush=True)
+
+class DecoratorLoggerBase:
+    def __init__(self, role: str, logger: logging.Logger = None, level=logging.DEBUG, rank: int = 0, log_only_rank_0: bool = True):
+        self.role = role
+        self.logger = logger
+        self.level = level
+        self.rank = rank
+        self.log_only_rank_0 = log_only_rank_0
+        self.logging_function = self.log_by_logging
+        if logger is None:
+            self.logging_function = self.log_by_print
+    
+    def log_by_print(self, log_str, decorated_function, *args, **kwargs):
+        if not self.log_only_rank_0 and self.rank == 0:
+            print(f"Before {self.role} {log_str}", flush=True)
+        output = decorated_function(*args, **kwargs)
+        if not self.log_only_rank_0 and self.rank == 0:
+            print(f"After {self.role} {log_str}", flush=True)
+        return output
+    
+    def log_by_logging(self, log_str, decorated_function, *args, **kwargs):
+        if self.logger is None:
+            raise ValueError("Logger is not initialized")
+        if not self.log_only_rank_0 and self.rank == 0:
+            self.logger.log(self.level, f"Before {self.role} {log_str}")
+        output = decorated_function(*args, **kwargs)
+        if not self.log_only_rank_0 and self.rank == 0:
+            self.logger.log(self.level, f"After {self.role} {log_str}")
+        return output
+    

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -15,9 +15,9 @@
 Single Process Actor
 """
 
+import itertools
 import logging
 import os
-import itertools
 from typing import Tuple
 
 import torch
@@ -28,11 +28,11 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 import verl.utils.torch_functional as verl_F
 from verl import DataProto
 from verl.trainer.ppo.core_algos import agg_loss, compute_policy_loss, kl_penalty
+from verl.utils.debug import GPUMemoryLogger
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.torch_functional import logprobs_from_logits
 from verl.utils.ulysses import gather_outpus_and_unpad, ulysses_pad_and_slice_inputs
-from verl.utils.debug import GPUMemoryLogger
 from verl.workers.actor import BasePPOActor
 
 __all__ = ["DataParallelPPOActor"]

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -19,6 +19,8 @@ In megatron actor, the differences are:
 Note that our model doesn't have to be `MegatronModule` because we don't share embedding in the last layer
 """
 
+import logging
+import os
 from functools import partial
 from typing import Dict, Iterable
 
@@ -40,9 +42,13 @@ from verl.utils.megatron.tensor_parallel import vocab_parallel_entropy, vocab_pa
 from verl.utils.megatron_utils import get_model_config
 from verl.utils.py_functional import append_to_dict
 from verl.utils.torch_functional import broadcast_dict_tensor, split_dict_tensor_into_batches
+from verl.utils.debug import GPUMemoryLogger
 from verl.workers.actor import BasePPOActor
 
 __all__ = ["MegatronPPOActor"]
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 class MegatronPPOActor(BasePPOActor):
@@ -137,6 +143,7 @@ class MegatronPPOActor(BasePPOActor):
             config.megatron.sequence_parallel = False
         self.config = config
 
+    @GPUMemoryLogger(role="megatron actor", logger=logger)
     def compute_log_prob(self, data: DataProto, calculate_entropy=False) -> torch.Tensor:
         """Compute the log probability of the responses given input_ids, attention_mask and position_ids
 
@@ -419,6 +426,7 @@ class MegatronPPOActor(BasePPOActor):
         # loss_reduces contains the stats returned from loss_func
         return losses_reduced
 
+    @GPUMemoryLogger(role="megatron actor", logger=logger)
     def update_policy(self, dataloader: Iterable[DataProto]) -> Dict:
         """Update the policy with an iterator of DataProto
 

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -37,12 +37,12 @@ from torch import nn
 
 from verl import DataProto
 from verl.trainer.ppo.core_algos import agg_loss, compute_policy_loss, kl_penalty
+from verl.utils.debug import GPUMemoryLogger
 from verl.utils.megatron.pipeline_parallel import compute_transformers_input_shapes, make_batch_generator
 from verl.utils.megatron.tensor_parallel import vocab_parallel_entropy, vocab_parallel_log_probs_from_logits
 from verl.utils.megatron_utils import get_model_config
 from verl.utils.py_functional import append_to_dict
 from verl.utils.torch_functional import broadcast_dict_tensor, split_dict_tensor_into_batches
-from verl.utils.debug import GPUMemoryLogger
 from verl.workers.actor import BasePPOActor
 
 __all__ = ["MegatronPPOActor"]

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -15,7 +15,9 @@
 Implement a multiprocess PPOCritic
 """
 
+import logging
 import itertools
+import os
 
 import torch
 import torch.distributed
@@ -25,6 +27,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 from verl import DataProto
 from verl.trainer.ppo import core_algos
+from verl.utils.debug import GPUMemoryLogger
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.torch_functional import masked_mean
@@ -32,6 +35,9 @@ from verl.utils.ulysses import gather_outpus_and_unpad, ulysses_pad_and_slice_in
 from verl.workers.critic import BasePPOCritic
 
 __all__ = ["DataParallelPPOCritic"]
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 class DataParallelPPOCritic(BasePPOCritic):
@@ -133,6 +139,7 @@ class DataParallelPPOCritic(BasePPOCritic):
             self.critic_optimizer.step()
         return grad_norm
 
+    @GPUMemoryLogger(role="dp critic", logger=logger)
     def compute_values(self, data: DataProto) -> torch.Tensor:
         self.critic_module.eval()
         micro_batch_size = data.meta_info["micro_batch_size"]
@@ -174,6 +181,7 @@ class DataParallelPPOCritic(BasePPOCritic):
 
         return values
 
+    @GPUMemoryLogger(role="dp critic", logger=logger)
     def update_critic(self, data: DataProto):
         # make sure we are in training mode
         self.critic_module.train()

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -15,8 +15,8 @@
 Implement a multiprocess PPOCritic
 """
 
-import logging
 import itertools
+import logging
 import os
 
 import torch

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -49,7 +49,7 @@ from verl.utils.model import compute_position_id_with_mask
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
 
 logger = logging.getLogger(__file__)
-logger.setLevel(os.getenv("VERL_PPO_LOGGING_LEVEL", "WARN"))
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 def create_device_mesh(world_size, fsdp_size):
@@ -507,8 +507,6 @@ class ActorRolloutRefWorker(Worker):
         if self._is_offload_optimizer:
             load_fsdp_optimizer(optimizer=self.actor_optimizer, device_id=torch.cuda.current_device())
 
-        log_gpu_memory_usage("Before update policy", logger=logger)
-
         with self.ulysses_sharding_manager:
             data = self.ulysses_sharding_manager.preprocess_data(data=data)
             # perform training
@@ -527,8 +525,6 @@ class ActorRolloutRefWorker(Worker):
             self.actor_lr_scheduler.step()
             lr = self.actor_lr_scheduler.get_last_lr()[0]
             metrics["actor/lr"] = lr
-
-            log_gpu_memory_usage("After update policy", logger=logger)
 
             # TODO: here, we should return all metrics
             output = DataProto(meta_info={"metrics": metrics})
@@ -568,18 +564,14 @@ class ActorRolloutRefWorker(Worker):
             if self._is_offload_optimizer:
                 offload_fsdp_optimizer(optimizer=self.actor_optimizer)
 
-            log_gpu_memory_usage("After entering rollout sharding manager", logger=logger)
-
             prompts = self.rollout_sharding_manager.preprocess_data(prompts)
             output = self.rollout.generate_sequences(prompts=prompts)
-            log_gpu_memory_usage("After rollout generation", logger=logger)
-
             output = self.rollout_sharding_manager.postprocess_data(output)
 
         output = output.to("cpu")
 
         # clear kv cache
-        log_gpu_memory_usage("After generate_sequences", logger=logger)
+        torch.cuda.empty_cache()
         return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
@@ -615,7 +607,6 @@ class ActorRolloutRefWorker(Worker):
         if self._is_offload_param:
             offload_fsdp_model_to_cpu(self.actor_module_fsdp)
 
-        log_gpu_memory_usage("After compute_log_prob", logger=logger)
         return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -43,7 +43,7 @@ from verl.workers.critic.megatron_critic import MegatronPPOCritic
 from verl.workers.reward_model.megatron.reward_model import MegatronRewardModel
 
 logger = logging.getLogger(__file__)
-logger.setLevel(os.getenv("VERL_PPO_LOGGING_LEVEL", "WARN"))
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 def set_random_seed(seed):
@@ -354,8 +354,6 @@ class ActorRolloutRefWorker(MegatronWorker):
 
         data.batch = data.batch.cuda()
 
-        log_gpu_memory_usage("Before update policy", logger=logger)
-
         micro_batch_size = self.config.actor.ppo_micro_batch_size_per_gpu
         data.meta_info["micro_batch_size"] = micro_batch_size
         dataloader = self.actor.make_minibatch_iterator(data=data)
@@ -365,8 +363,6 @@ class ActorRolloutRefWorker(MegatronWorker):
         global_num_tokens = data.meta_info["global_token_num"]
         estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
         metrics["perf/mfu/actor"] = estimated_flops * self.config.actor.ppo_epochs / promised_flops / self.world_size
-
-        log_gpu_memory_usage("After update policy", logger=logger)
 
         # TODO: here, we should return all metrics
         output = DataProto(meta_info={"metrics": metrics})
@@ -389,19 +385,13 @@ class ActorRolloutRefWorker(MegatronWorker):
         }
         prompts.meta_info.update(meta_info)
         with self.sharding_manager:
-            log_gpu_memory_usage("After entering sharding manager", logger=logger)
-
             prompts = self.sharding_manager.preprocess_data(prompts)
             output = self.rollout.generate_sequences(prompts=prompts)
-
-            log_gpu_memory_usage("After rollout generation", logger=logger)
-
             output = self.sharding_manager.postprocess_data(output)
 
         output = output.to("cpu")
         # clear kv cache
         torch.cuda.empty_cache()
-        log_gpu_memory_usage("After generate_sequences", logger=logger)
         return output
 
     @register(dispatch_mode=Dispatch.MEGATRON_COMPUTE_PROTO)
@@ -437,7 +427,6 @@ class ActorRolloutRefWorker(MegatronWorker):
         output = output.to("cpu")
         # clear kv cache
         torch.cuda.empty_cache()
-        log_gpu_memory_usage("After generate_sequences", logger=logger)
         return output
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -27,6 +27,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
@@ -45,10 +46,14 @@ from torch.nn.utils.rnn import pad_sequence
 from verl import DataProto
 from verl.third_party.sglang import parallel_state as sglang_ps
 from verl.utils.torch_functional import get_response_mask, pad_sequence_to_length
+from verl.utils.debug import GPUMemoryLogger
 from verl.workers.rollout.base import BaseRollout
 
 if TYPE_CHECKING:
     from torch import nn
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 # NOTE(sgm): add for verl. We can optimize it by making the dataloader yield List[int] without padding.
@@ -219,6 +224,7 @@ class SGLangRollout(BaseRollout):
         for key, value in old_sampling_params_args.items():
             self.sampling_params[key] = value
 
+    @GPUMemoryLogger(role="sglang rollout", logger=logger)
     @torch.no_grad()
     def generate_sequences(self, prompts: DataProto, **kwargs) -> DataProto:
         # if self.config.free_cache_engine:

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -45,8 +45,8 @@ from torch.nn.utils.rnn import pad_sequence
 
 from verl import DataProto
 from verl.third_party.sglang import parallel_state as sglang_ps
-from verl.utils.torch_functional import get_response_mask, pad_sequence_to_length
 from verl.utils.debug import GPUMemoryLogger
+from verl.utils.torch_functional import get_response_mask, pad_sequence_to_length
 from verl.workers.rollout.base import BaseRollout
 
 if TYPE_CHECKING:

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -25,6 +25,8 @@ When working with Megatron:
 - After inference, all the parameters that doesn't belong to this pp rank is freed.
 """
 
+import logging
+import os
 from contextlib import contextmanager
 from copy import deepcopy
 from typing import List
@@ -40,7 +42,11 @@ from verl import DataProto
 from verl.third_party.vllm import LLM, vllm_version
 from verl.third_party.vllm import parallel_state as vllm_ps
 from verl.utils.torch_functional import get_response_mask, pad_sequence_to_length
+from verl.utils.debug import GPUMemoryLogger
 from verl.workers.rollout.base import BaseRollout
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 # TODO
 # 1. support pp in vllm
@@ -177,6 +183,7 @@ class vLLMRollout(BaseRollout):
         for key, value in old_sampling_params_args.items():
             setattr(self.sampling_params, key, value)
 
+    @GPUMemoryLogger(role="vllm rollout spmd", logger=logger)
     @torch.no_grad()
     def generate_sequences(self, prompts: DataProto, **kwargs) -> DataProto:
         # rebuild vllm cache engine

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -41,8 +41,8 @@ from vllm import SamplingParams
 from verl import DataProto
 from verl.third_party.vllm import LLM, vllm_version
 from verl.third_party.vllm import parallel_state as vllm_ps
-from verl.utils.torch_functional import get_response_mask, pad_sequence_to_length
 from verl.utils.debug import GPUMemoryLogger
+from verl.utils.torch_functional import get_response_mask, pad_sequence_to_length
 from verl.workers.rollout.base import BaseRollout
 
 logger = logging.getLogger(__file__)

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -40,8 +40,8 @@ from vllm.distributed import parallel_state as vllm_ps
 
 from verl import DataProto
 from verl.third_party.vllm import vllm_version
-from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
 from verl.utils.debug import GPUMemoryLogger
+from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
 from verl.workers.rollout.base import BaseRollout
 
 logger = logging.getLogger(__file__)

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -25,6 +25,8 @@ When working with Megatron:
 - After inference, all the parameters that doesn't belong to this pp rank is freed.
 """
 
+import logging
+import os
 from contextlib import contextmanager
 from typing import Any, List, Union
 
@@ -39,7 +41,11 @@ from vllm.distributed import parallel_state as vllm_ps
 from verl import DataProto
 from verl.third_party.vllm import vllm_version
 from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
+from verl.utils.debug import GPUMemoryLogger
 from verl.workers.rollout.base import BaseRollout
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 # TODO
 # 1. support pp in vllm
@@ -184,6 +190,7 @@ class vLLMRollout(BaseRollout):
         for key, value in old_sampling_params_args.items():
             setattr(self.sampling_params, key, value)
 
+    @GPUMemoryLogger(role="vllm rollout spmd", logger=logger)
     @torch.no_grad()
     def generate_sequences(self, prompts: DataProto, **kwargs) -> DataProto:
         # rebuild vllm cache engine

--- a/verl/workers/sharding_manager/fsdp_sglang.py
+++ b/verl/workers/sharding_manager/fsdp_sglang.py
@@ -44,7 +44,7 @@ from .base import BaseShardingManager
 # from vllm.distributed import parallel_state as sglang_ps
 
 logger = logging.getLogger(__file__)
-logger.setLevel(os.getenv("VERL_PPO_LOGGING_LEVEL", "WARN"))
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 class FSDPSGLangShardingManager(BaseShardingManager):

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -25,7 +25,7 @@ from verl import DataProto
 from verl.protocol import all_gather_data_proto
 from verl.third_party.vllm import LLM, vllm_version
 from verl.third_party.vllm import parallel_state as vllm_ps
-from verl.utils.debug import log_gpu_memory_usage, GPUMemoryLogger
+from verl.utils.debug import GPUMemoryLogger, log_gpu_memory_usage
 
 from .base import BaseShardingManager
 from .patch import patched_ds_v3_load_weights, patched_qwen_moe_load_weights

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -25,13 +25,13 @@ from verl import DataProto
 from verl.protocol import all_gather_data_proto
 from verl.third_party.vllm import LLM, vllm_version
 from verl.third_party.vllm import parallel_state as vllm_ps
-from verl.utils.debug import log_gpu_memory_usage
+from verl.utils.debug import log_gpu_memory_usage, GPUMemoryLogger
 
 from .base import BaseShardingManager
 from .patch import patched_ds_v3_load_weights, patched_qwen_moe_load_weights
 
 logger = logging.getLogger(__file__)
-logger.setLevel(os.getenv("VERL_PPO_LOGGING_LEVEL", "WARN"))
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 class FSDPVLLMShardingManager(BaseShardingManager):
@@ -75,6 +75,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
         else:
             self.gen_random_states = None
 
+    @GPUMemoryLogger(role="fsdp vllm sharding_manager", logger=logger)
     def __enter__(self):
         # NOTE: Basically, we only need `torch.cuda.empty_cache()` before vllm wake_up and
         # after vllm sleep, since vllm has its own caching memory allocator CuMemAllocator.
@@ -126,8 +127,8 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             self.torch_random_states = torch.cuda.get_rng_state()
             torch.cuda.set_rng_state(self.gen_random_states)
 
+    @GPUMemoryLogger(role="fsdp vllm sharding_manager", logger=logger)
     def __exit__(self, exc_type, exc_value, traceback):
-        log_gpu_memory_usage("Before vllm offload in sharding manager", logger=logger)
         # TODO(ZSL): check this
         if vllm_version in (
             "0.5.4",
@@ -136,7 +137,6 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             self.inference_engine.offload_model_weights()
         else:
             self.inference_engine.sleep(level=1)
-        log_gpu_memory_usage("After vllm offload in sharding manager", logger=logger)
 
         # self.module.to('cuda')
         # if torch.distributed.get_rank() == 0:
@@ -152,6 +152,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             self.gen_random_states = torch.cuda.get_rng_state()
             torch.cuda.set_rng_state(self.torch_random_states)
 
+    @GPUMemoryLogger(role="fsdp vllm sharding_manager", logger=logger)
     def preprocess_data(self, data: DataProto) -> DataProto:
         """All gather across tp group to make each rank has identical input."""
         if self.tp_size == 1:
@@ -169,6 +170,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
         all_gather_data_proto(data=data, process_group=group)
         return data
 
+    @GPUMemoryLogger(role="fsdp vllm sharding_manager", logger=logger)
     def postprocess_data(self, data: DataProto) -> DataProto:
         """Get chunk data of this tp rank since we do all gather in preprocess."""
         if self.tp_size == 1:


### PR DESCRIPTION
Use wrapper to refactor logging GPU memory enter or exit a function.

Simply use `VERL_LOGGING_LEVEL=DEBUG` to open current implemented memory logger wrapped around common functions.