### PR TITLE
feat: support rollout.n > 1 in hf_rollout

### DIFF
--- a/tests/rollout/test_hf_rollout.py
+++ b/tests/rollout/test_hf_rollout.py
@@ -1,0 +1,180 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import torch
+from omegaconf import OmegaConf
+from torch.distributed.fsdp import CPUOffload, MixedPrecision
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.api import ShardedStateDictConfig, ShardingStrategy, StateDictType
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from verl import DataProto
+from verl.utils.distributed import initialize_global_process_group
+from verl.utils.fs import copy_to_local
+from verl.utils.model import compute_position_id_with_mask
+from verl.workers.rollout.hf_rollout import HFRollout
+
+BASE_HF_ROLLOUT_CONFIG = {
+    "temperature": 1.0,
+    "top_k": -1,
+    "top_p": 1,
+    "prompt_length": 64,
+    "response_length": 64,
+    "do_sample": True,
+    "n": 1,
+    "val_kwargs": {
+        "top_k": -1,
+        "top_p": 1.0,
+        "temperature": 0,
+        "n": 1,
+        "do_sample": False,
+    },
+}
+
+
+def prepare_input_dataproto(tokenizer, config, validate):
+    preencode_prompts = [
+        [{"role": "user", "content": "Who won the Champions League in 2019?"}],
+        [{"role": "user", "content": "The founder of Apple is"}],
+        [{"role": "user", "content": "What's your name"}],
+    ]
+    formatted_prompts = [
+        tokenizer.apply_chat_template(conversation, tokenize=False, add_generation_prompt=True)
+        for conversation in preencode_prompts
+    ]
+    prompts = tokenizer(formatted_prompts, return_tensors="pt", padding="max_length", max_length=config.prompt_length)
+    input_dataproto = DataProto.from_dict(
+        {
+            "input_ids": prompts["input_ids"],
+            "attention_mask": prompts["attention_mask"],
+            "position_ids": compute_position_id_with_mask(prompts["attention_mask"]),
+        },
+        meta_info={
+            "bos_token_id": tokenizer.bos_token_id,
+            "eos_token_id": tokenizer.eos_token_id,
+            "pad_token_id": tokenizer.pad_token_id,
+            "validate": validate,
+        },
+    )
+    return input_dataproto
+
+
+def prepare_fsdp_model(model, world_size):
+    from torch.distributed.device_mesh import init_device_mesh
+
+    device_mesh = init_device_mesh("cuda", mesh_shape=(world_size,), mesh_dim_names=["fsdp"])
+
+    mixed_precision = MixedPrecision(param_dtype=torch.bfloat16, reduce_dtype=torch.float32, buffer_dtype=torch.float32)
+
+    fsdp_model = FSDP(
+        model,
+        use_orig_params=True,
+        auto_wrap_policy=None,
+        device_id=torch.cuda.current_device(),
+        sharding_strategy=ShardingStrategy.FULL_SHARD,
+        mixed_precision=mixed_precision,
+        cpu_offload=CPUOffload(offload_params=False),
+        sync_module_states=False,
+        device_mesh=device_mesh,
+    )
+
+    FSDP.set_state_dict_type(
+        fsdp_model, state_dict_type=StateDictType.SHARDED_STATE_DICT, state_dict_config=ShardedStateDictConfig()
+    )
+    return fsdp_model
+
+
+def test_hf_rollout(n: int = 1, do_sample: bool = True, validate: bool = False):
+    config = OmegaConf.create(BASE_HF_ROLLOUT_CONFIG)
+    config.update({"n": n, "do_sample": do_sample})
+
+    assert torch.cuda.device_count() >= 2, "At least 2 GPUs is required to run tp+dp tests."
+    local_rank, rank, world_size = initialize_global_process_group()
+
+    # Initialize model and tokenizer
+    local_cache_path = "~/.cache/verl/rlhf"
+    local_cache_path = os.path.expanduser(local_cache_path)
+    hdfs_path = "Qwen/Qwen2-7B-Instruct"
+    local_model_path = copy_to_local(src=hdfs_path, cache_dir=local_cache_path)
+    tokenizer = AutoTokenizer.from_pretrained(local_model_path, padding_side="left", trust_remote_code=True)
+    tokenizer.pad_token = tokenizer.eos_token
+
+    # Initialize FSDP model
+    actor_model = AutoModelForCausalLM.from_pretrained(local_model_path, trust_remote_code=True)
+    actor_model.to(torch.bfloat16)
+    fsdp_model = prepare_fsdp_model(actor_model, world_size)
+
+    # Initialize HFRollout and start generate
+    hf_rollout = HFRollout(fsdp_model, OmegaConf.create(config))
+    input = prepare_input_dataproto(tokenizer, config, validate).to(torch.cuda.current_device())
+    outputs = hf_rollout.generate_sequences(input)
+
+    # check generated batch size is expected
+    generated_batch_size = outputs.batch.batch_size[0]
+    assert generated_batch_size == input.batch.batch_size[0] * config.n
+
+    for i in range(generated_batch_size):
+        prompt_tokens = outputs.batch["prompts"][i]
+        prompt_mask = prompt_tokens != tokenizer.pad_token_id
+        prompt_tokens = prompt_tokens[prompt_mask]
+        decoded_prompt = tokenizer.decode(prompt_tokens, skip_special_tokens=False)
+
+        response_tokens = outputs.batch["responses"][i]
+        response_mask = response_tokens != tokenizer.pad_token_id
+        response_tokens = response_tokens[response_mask]
+        decoded_response = tokenizer.decode(response_tokens, skip_special_tokens=False)
+
+        attention_mask = outputs.batch["attention_mask"][i]
+        position_ids = outputs.batch["position_ids"][i]
+        prompt_length = outputs.batch["prompts"].size(1)
+        response_length = outputs.batch["responses"].size(1)
+
+        assert attention_mask.size(0) == prompt_length + response_length
+        assert position_ids.size(0) == prompt_length + response_length
+
+        # check response attention mask is expected
+        response_attention = attention_mask[prompt_length:]
+        eos_positions = (outputs.batch["responses"][i] == tokenizer.pad_token_id).nonzero(as_tuple=True)[0]
+        if len(eos_positions) > 0:
+            first_eos_pos = eos_positions[0].item()
+            assert response_attention[: first_eos_pos + 1].all(), "Response attention mask should be 1 until EOS"
+            if first_eos_pos + 1 < response_length:
+                assert not response_attention[first_eos_pos + 1 :].any(), (
+                    "Response attention mask should be 0 after EOS"
+                )
+        else:
+            assert response_attention.all(), "Response attention mask should be all 1 if no EOS token"
+
+        # check response position ids is expected
+        prompt_positions = position_ids[:prompt_length]
+        response_positions = position_ids[prompt_length:]
+        valid_response_length = min(len(response_tokens), response_length)
+        if valid_response_length > 0:
+            assert response_positions[0] == prompt_positions[-1] + 1
+            for j in range(1, valid_response_length):
+                assert response_positions[j] == response_positions[j - 1] + 1
+
+        # print generated text for inspection
+        if torch.distributed.get_rank() == 0:
+            print(f"prompt: {decoded_prompt}")
+            print(f"response: {decoded_response}")
+            print("=" * 30)
+
+
+if __name__ == "__main__":
+    test_hf_rollout(n=2, do_sample=True, validate=False)
+    # test_hf_rollout(n=1, do_sample=False, validate=True)
+    # test_hf_rollout(n=1, do_sample=True, validate=False)

--- a/verl/workers/rollout/hf_rollout.py
+++ b/verl/workers/rollout/hf_rollout.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """
 Rollout with huggingface models.
-TODO: refactor this class. Currently, it will hang when using FSDP HybridShard. We should actually create a single GPU model.
-Then, get full state_dict and bind the state_dict to the single GPU model. Then, use the single GPU model to perform generation.
+TODO: refactor this class. Currently, it will hang when using FSDP HybridShard. We should actually create a single
+GPU model. Then, get full state_dict and bind the state_dict to the single GPU model. Then, use the single GPU model
+to perform generation.
 """
 
 import contextlib
@@ -50,7 +51,47 @@ class HFRollout(BaseRollout):
 
     @torch.no_grad()
     def _generate_minibatch(self, prompts: DataProto) -> DataProto:
+        # make sampling args can be overriden by inputs
+        do_sample = prompts.meta_info.get("do_sample", self.config.do_sample)
+        is_validate = prompts.meta_info.get("validate", False)
+
+        temperature = prompts.meta_info.get("temperature", self.config.temperature)
+        response_length = prompts.meta_info.get("response_length", self.config.response_length)
+        top_p = prompts.meta_info.get("top_p", self.config.get("top_p", 1.0))
+        top_k = max(0, prompts.meta_info.get("top_k", self.config.get("top_k", 0)))  # to be compatible with vllm
+
+        if not do_sample:
+            # do_sample==False -> greedy decoding
+            kwargs = {
+                "do_sample": False,
+                "num_beams": 1,
+            }
+        elif is_validate:
+            # do validate and do sample -> use val_kwargs
+            kwargs = {
+                "do_sample": True,
+                "num_beams": 1,
+                "top_k": max(0, self.config.val_kwargs.top_k),  # to be compatible with vllm
+                "top_p": self.config.val_kwargs.top_p,
+                "temperature": self.config.val_kwargs.temperature,
+                "num_return_sequences": 1,  # if validate, already repeat in ray_trainer
+            }
+        else:
+            # do_sample -> use rollout config
+            kwargs = {
+                "do_sample": True,
+                "num_beams": 1,
+                "top_p": top_p,
+                "top_k": top_k,
+                "temperature": temperature,
+                "num_return_sequences": self.config.n,
+            }
+
+        # make config according to generate mode
+        generation_config = GenerationConfig(**kwargs)
+
         idx = prompts.batch["input_ids"]  # (bs, prompt_length)
+        prompt_length = idx.size(1)
         attention_mask = prompts.batch["attention_mask"]  # left-padded attention_mask
         position_ids = prompts.batch["position_ids"]
 
@@ -58,25 +99,8 @@ class HFRollout(BaseRollout):
         eos_token_id = prompts.meta_info["eos_token_id"]
         pad_token_id = prompts.meta_info["pad_token_id"]
 
-        batch_size = idx.size(0)
-        prompt_length = idx.size(1)
-
         self.module.eval()
         param_ctx = contextlib.nullcontext()
-
-        # make sampling args can be overriden by inputs
-        do_sample = prompts.meta_info.get("do_sample", self.config.do_sample)
-        response_length = prompts.meta_info.get("response_length", self.config.response_length)
-        top_p = prompts.meta_info.get("top_p", self.config.get("top_p", 1.0))
-        top_k = prompts.meta_info.get("top_k", self.config.get("top_k", 0))
-
-        if top_k is None:
-            top_k = 0
-        top_k = max(0, top_k)  # to be compatible with vllm
-
-        temperature = prompts.meta_info.get("temperature", self.config.temperature)
-
-        generation_config = GenerationConfig(temperature=temperature, top_p=top_p, top_k=top_k)
 
         if isinstance(self.module, FSDP):
             # recurse need to set to False according to https://github.com/pytorch/pytorch/issues/100069
@@ -87,17 +111,17 @@ class HFRollout(BaseRollout):
                 attention_mask=attention_mask,
                 do_sample=do_sample,
                 max_new_tokens=response_length,
-                # max_length=max_length,
                 eos_token_id=eos_token_id,
                 pad_token_id=pad_token_id,
                 generation_config=generation_config,
-                # renormalize_logits=True,
                 output_scores=False,  # this is potentially very large
                 return_dict_in_generate=True,
                 use_cache=True,
             )
+
         # TODO: filter out the seq with no answers like ds-chat
         seq = output.sequences
+        generated_batch_size = seq.size(0)  # bs * num_return_sequences
 
         # huggingface generate will stop generating when all the batch reaches [EOS].
         # We have to pad to response_length
@@ -105,18 +129,23 @@ class HFRollout(BaseRollout):
         delta_length = sequence_length - seq.shape[1]
 
         if delta_length > 0:
-            delta_tokens = torch.ones(size=(batch_size, delta_length), device=seq.device, dtype=seq.dtype)
+            delta_tokens = torch.ones(size=(generated_batch_size, delta_length), device=seq.device, dtype=seq.dtype)
             delta_tokens = pad_token_id * delta_tokens
             seq = torch.cat((seq, delta_tokens), dim=1)
-
         assert seq.shape[1] == sequence_length
 
-        prompt = seq[:, :prompt_length]  # (bs, prompt_length)
-        response = seq[:, prompt_length:]  # (bs, response_length)
+        # make necessary reputations if num_return_sequences > 1
+        num_return_sequences = kwargs.get("num_return_sequences", 1)
+        if num_return_sequences > 1:
+            position_ids = position_ids.repeat_interleave(num_return_sequences, dim=0)
+            attention_mask = attention_mask.repeat_interleave(num_return_sequences, dim=0)
+
+        prompt = seq[:, :prompt_length]  # (generated_batch_size, prompt_length)
+        response = seq[:, prompt_length:]  # (generated_batch_size, response_length)
 
         response_length = response.size(1)
         delta_position_id = torch.arange(1, response_length + 1, device=position_ids.device)
-        delta_position_id = delta_position_id.unsqueeze(0).repeat(batch_size, 1)
+        delta_position_id = delta_position_id.unsqueeze(0).repeat(generated_batch_size, 1)
 
         response_position_ids = position_ids[:, -1:] + delta_position_id
         position_ids = torch.cat([position_ids, response_position_ids], dim=-1)
@@ -134,7 +163,7 @@ class HFRollout(BaseRollout):
                 "attention_mask": attention_mask,
                 "position_ids": position_ids,
             },
-            batch_size=batch_size,
+            batch_size=generated_batch_size,
         )
 
         # empty cache before compute old_log_prob


### PR DESCRIPTION
Currently, the hf rollout backend only support `rollout.n == 1`, when `rollout.n > 1` it will lead to an error (https://github.com/volcengine/verl/issues/1134)

This PR make hf rollout support `do_sample` and `is_validate` to make it consistent with vllm and sglang backend, and correctly support `rollout.n > 1`.