### PR TITLE
Feat/memory optimized loss

### DIFF
--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -264,6 +264,8 @@ def forward_without_logits(
     r"""
     Copy paste LLaMa's forward
     https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/model/llama.py
+
+    This function should be generic enough for all pure text models.
     ```"""
     output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
     output_hidden_states = (

--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -14,7 +14,6 @@
 
 from dataclasses import dataclass
 import sys
-from turtle import forward
 from typing import Callable, List, Optional, Tuple, Union
 
 import torch

--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 import sys
-from typing import Callable, Optional, Tuple
+from turtle import forward
+from typing import Callable, List, Optional, Tuple, Union
 
 import torch
 
@@ -24,6 +26,7 @@ else:
 
 from transformers.cache_utils import Cache
 from transformers.modeling_flash_attention_utils import _flash_attention_forward
+from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 from transformers.utils import logging
 
@@ -235,3 +238,63 @@ def llama_attn_forward(
     attn_output = attn_output.reshape(bsz, q_len, -1).contiguous()
     attn_output = self.o_proj(attn_output)
     return attn_output, attn_weights
+
+
+@dataclass
+class CausalLMOutputWithoutLogits(CausalLMOutputWithPast):
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+def forward_without_logits(
+    self,
+    input_ids: torch.LongTensor = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[Union["Cache", List[torch.FloatTensor]]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    logits_to_keep: Union[int, torch.Tensor] = 0,
+    **loss_kwargs,
+) -> Union[Tuple, CausalLMOutputWithoutLogits]:
+    r"""
+    Copy paste LLaMa's forward
+    https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/model/llama.py
+    ```"""
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+    outputs = self.model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+        cache_position=cache_position,
+    )
+
+    hidden_states = outputs[0]
+
+    if labels is not None:
+        raise NotImplementedError("foward_without_logits does not support labels")
+    if not return_dict:
+        raise NotImplementedError("foward_without_logits has to return_dict")
+
+    return CausalLMOutputWithoutLogits(
+        last_hidden_state=hidden_states,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+    )

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -105,7 +105,12 @@ def _ulysses_flash_attention_forward(
     return attn_output
 
 
-def apply_monkey_patch(model: PreTrainedModel, ulysses_sp_size: int):
+def apply_monkey_patch(
+    model: PreTrainedModel,
+    use_remove_padding: bool = False,
+    ulysses_sp_size: int = 1,
+    return_last_hidden_states: bool = False,
+):
     """Replace _flash_attention_forward to _ulysses_flash_attention_forward"""
     module = sys.modules[model.__module__]
 
@@ -119,27 +124,60 @@ def apply_monkey_patch(model: PreTrainedModel, ulysses_sp_size: int):
         f"kv heads are repeated to ensure correctness."
     )
     # TODO: VLM models only, unify monkey patch to LLM models.
-    if model.config.model_type in ("qwen2_vl", "qwen2_5_vl"):  # patch remove padding for qwen2vl mrope
-        from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VLFlashAttention2
-        from transformers.models.qwen2_vl.modeling_qwen2_vl import Qwen2VLFlashAttention2
+    if model.config.model_type == "qwen2_5_vl":
+        from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
+            Qwen2_5_VLFlashAttention2,
+            Qwen2_5_VLForConditionalGeneration,
+        )
 
-        from verl.models.transformers.qwen2_vl import ulysses_flash_attn_forward
+        if use_remove_padding or ulysses_sp_size > 1:
+            from verl.models.transformers.qwen2_vl import ulysses_flash_attn_forward
 
-        Qwen2VLFlashAttention2.forward = ulysses_flash_attn_forward
-        Qwen2_5_VLFlashAttention2.forward = ulysses_flash_attn_forward
-        print("Monkey patch FlashAttention2.forward in Qwen2VL")
+            Qwen2_5_VLFlashAttention2.forward = ulysses_flash_attn_forward
+            print("Monkey patch FlashAttention2.forward in Qwen2.5VL")
+
+        if return_last_hidden_states:
+            from verl.models.transformers.qwen2_5_vl import forward_without_logits
+
+            Qwen2_5_VLForConditionalGeneration.forward = forward_without_logits
+
+        return
+
+    elif model.config.model_type == "qwen2_vl":
+        from transformers.models.qwen2_vl.modeling_qwen2_vl import (
+            Qwen2VLFlashAttention2,
+            Qwen2VLForConditionalGeneration,
+        )
+
+        if use_remove_padding or ulysses_sp_size > 1:
+            from verl.models.transformers.qwen2_vl import ulysses_flash_attn_forward
+
+            Qwen2VLFlashAttention2.forward = ulysses_flash_attn_forward
+            print("Monkey patch FlashAttention2.forward in Qwen2VL")
+
+        if return_last_hidden_states:
+            from verl.models.transformers.qwen2_vl import forward_without_logits
+
+            Qwen2VLForConditionalGeneration.forward = forward_without_logits
+
         return
 
     # transformers<=4.47.1
-    if hasattr(module, "_flash_attention_forward"):
-        module._flash_attention_forward = _ulysses_flash_attention_forward
-        print(f"Monkey patch _flash_attention_forward in {model.__module__}")
-    else:
-        # transformers>=4.48.0
-        from transformers.integrations import flash_attention
+    if use_remove_padding or ulysses_sp_size > 1:
+        if hasattr(module, "_flash_attention_forward"):
+            module._flash_attention_forward = _ulysses_flash_attention_forward
+            print(f"Monkey patch _flash_attention_forward in {model.__module__}")
+        else:
+            # transformers>=4.48.0
+            from transformers.integrations import flash_attention
 
-        flash_attention._flash_attention_forward = _ulysses_flash_attention_forward
-        print(f"Monkey patch _flash_attention_forward in {flash_attention.__name__}")
+            flash_attention._flash_attention_forward = _ulysses_flash_attention_forward
+            print(f"Monkey patch _flash_attention_forward in {flash_attention.__name__}")
+
+    if return_last_hidden_states:
+        from verl.models.transformers.llama import forward_without_logits
+
+        model.__class__.forward = forward_without_logits
 
 
 import importlib.metadata

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -109,7 +109,7 @@ def apply_monkey_patch(
     model: PreTrainedModel,
     use_remove_padding: bool = False,
     ulysses_sp_size: int = 1,
-    return_last_hidden_states: bool = False,
+    return_last_hidden_state: bool = False,
 ):
     """Replace _flash_attention_forward to _ulysses_flash_attention_forward"""
     module = sys.modules[model.__module__]
@@ -136,7 +136,7 @@ def apply_monkey_patch(
             Qwen2_5_VLFlashAttention2.forward = ulysses_flash_attn_forward
             print("Monkey patch FlashAttention2.forward in Qwen2.5VL")
 
-        if return_last_hidden_states:
+        if return_last_hidden_state:
             from verl.models.transformers.qwen2_5_vl import forward_without_logits
 
             Qwen2_5_VLForConditionalGeneration.forward = forward_without_logits
@@ -155,7 +155,7 @@ def apply_monkey_patch(
             Qwen2VLFlashAttention2.forward = ulysses_flash_attn_forward
             print("Monkey patch FlashAttention2.forward in Qwen2VL")
 
-        if return_last_hidden_states:
+        if return_last_hidden_state:
             from verl.models.transformers.qwen2_vl import forward_without_logits
 
             Qwen2VLForConditionalGeneration.forward = forward_without_logits
@@ -174,7 +174,7 @@ def apply_monkey_patch(
             flash_attention._flash_attention_forward = _ulysses_flash_attention_forward
             print(f"Monkey patch _flash_attention_forward in {flash_attention.__name__}")
 
-    if return_last_hidden_states:
+    if return_last_hidden_state:
         from verl.models.transformers.llama import forward_without_logits
 
         model.__class__.forward = forward_without_logits

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -107,8 +107,8 @@ def _ulysses_flash_attention_forward(
 
 def apply_monkey_patch(
     model: PreTrainedModel,
-    use_remove_padding: bool = False,
     ulysses_sp_size: int = 1,
+    use_remove_padding: bool = True,
     return_last_hidden_state: bool = False,
 ):
     """Replace _flash_attention_forward to _ulysses_flash_attention_forward"""

--- a/verl/models/transformers/qwen2_5_vl.py
+++ b/verl/models/transformers/qwen2_5_vl.py
@@ -1,0 +1,151 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple, Union
+
+import torch
+from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
+    Qwen2_5_VLCausalLMOutputWithPast,
+    Qwen2_5_VLForConditionalGeneration,
+)
+
+
+@dataclass
+class Qwen2_5_VLCausalLMOutputWithoutLogits(Qwen2_5_VLCausalLMOutputWithPast):
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+def forward_without_logits(
+    self: Qwen2_5_VLForConditionalGeneration,
+    input_ids: torch.LongTensor = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[List[torch.FloatTensor]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    pixel_values: Optional[torch.Tensor] = None,
+    pixel_values_videos: Optional[torch.FloatTensor] = None,
+    image_grid_thw: Optional[torch.LongTensor] = None,
+    video_grid_thw: Optional[torch.LongTensor] = None,
+    rope_deltas: Optional[torch.LongTensor] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    second_per_grid_ts: Optional[torch.Tensor] = None,
+    **loss_kwargs,
+) -> Union[Tuple, Qwen2_5_VLCausalLMOutputWithoutLogits]:
+    r"""
+    Copy paste Qwen2_5_VL's forward
+    https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/model/qwen2_5_vl.py
+    ```"""
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    if inputs_embeds is None:
+        inputs_embeds = self.model.embed_tokens(input_ids)
+        if pixel_values is not None:
+            pixel_values = pixel_values.type(self.visual.dtype)
+            image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
+            n_image_tokens = (input_ids == self.config.image_token_id).sum().item()
+            n_image_features = image_embeds.shape[0]
+            if n_image_tokens != n_image_features:
+                raise ValueError(
+                    f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
+                )
+
+            mask = input_ids == self.config.image_token_id
+            mask_unsqueezed = mask.unsqueeze(-1)
+            mask_expanded = mask_unsqueezed.expand_as(inputs_embeds)
+            image_mask = mask_expanded.to(inputs_embeds.device)
+
+            image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
+        if pixel_values_videos is not None:
+            pixel_values_videos = pixel_values_videos.type(self.visual.dtype)
+            video_embeds = self.visual(pixel_values_videos, grid_thw=video_grid_thw)
+            n_video_tokens = (input_ids == self.config.video_token_id).sum().item()
+            n_video_features = video_embeds.shape[0]
+            if n_video_tokens != n_video_features:
+                raise ValueError(
+                    f"Video features and video tokens do not match: tokens: {n_video_tokens}, features {n_video_features}"
+                )
+
+            mask = input_ids == self.config.video_token_id
+            mask_unsqueezed = mask.unsqueeze(-1)
+            mask_expanded = mask_unsqueezed.expand_as(inputs_embeds)
+            video_mask = mask_expanded.to(inputs_embeds.device)
+
+            video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(inputs_embeds.device)
+
+    # if we get 4D attention mask we cannot calculate rope deltas anymore. TODO @raushan fixme
+    if position_ids is None and (attention_mask is None or attention_mask.ndim == 2):
+        # calculate RoPE index once per generation in the pre-fill stage only
+        if (cache_position is not None and cache_position[0] == 0) or self.rope_deltas is None:
+            position_ids, rope_deltas = self.get_rope_index(
+                input_ids,
+                image_grid_thw,
+                video_grid_thw,
+                second_per_grid_ts,
+                attention_mask,
+            )
+            self.rope_deltas = rope_deltas
+        # then use the prev pre-calculated rope-deltas to get the correct position ids
+        else:
+            batch_size, seq_length, _ = inputs_embeds.shape
+            delta = (cache_position[0] + self.rope_deltas).to(inputs_embeds.device) if cache_position is not None else 0
+            position_ids = torch.arange(seq_length, device=inputs_embeds.device)
+            position_ids = position_ids.view(1, -1).expand(batch_size, -1)
+            if cache_position is not None:  # otherwise `deltas` is an int `0`
+                delta = delta.repeat_interleave(batch_size // delta.shape[0], dim=0)
+            position_ids = position_ids.add(delta)
+            position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+
+    outputs = self.model(
+        input_ids=None,
+        position_ids=position_ids,
+        attention_mask=attention_mask,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+        cache_position=cache_position,
+    )
+
+    hidden_states = outputs[0]
+
+    if labels is not None:
+        raise NotImplementedError("foward_without_logits does not support labels")
+    if not return_dict:
+        raise NotImplementedError("foward_without_logits has to return_dict")
+
+    return Qwen2_5_VLCausalLMOutputWithoutLogits(
+        last_hidden_state=hidden_states,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+        rope_deltas=rope_deltas,
+    )

--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -14,12 +14,24 @@
 
 import inspect
 import os
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import torch
+from torch.nn import CrossEntropyLoss
 from transformers.modeling_flash_attention_utils import _flash_attention_forward
-from transformers.utils import is_flash_attn_greater_or_equal
+from transformers.models.qwen2_vl.modeling_qwen2_vl import (
+    _CONFIG_FOR_DOC,
+    QWEN2_VL_INPUTS_DOCSTRING,
+    Qwen2VLCausalLMOutputWithPast,
+    Qwen2VLForConditionalGeneration,
+)
+from transformers.utils import (
+    add_start_docstrings_to_model_forward,
+    is_flash_attn_greater_or_equal,
+    replace_return_docstrings,
+)
 
+from verl.utils.liger import is_liger_kernel_available
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
     gather_seq_scatter_heads,
@@ -297,3 +309,189 @@ def ulysses_flash_attn_forward(
     attn_output = attn_output.reshape(bsz, q_len, self.hidden_size).contiguous()
     attn_output = self.o_proj(attn_output)
     return attn_output, None, None
+
+
+@add_start_docstrings_to_model_forward(QWEN2_VL_INPUTS_DOCSTRING)
+@replace_return_docstrings(output_type=Qwen2VLCausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
+def patched_forward(
+    self: Qwen2VLForConditionalGeneration,
+    input_ids: torch.LongTensor = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[List[torch.FloatTensor]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    pixel_values: Optional[torch.Tensor] = None,
+    pixel_values_videos: Optional[torch.FloatTensor] = None,
+    image_grid_thw: Optional[torch.LongTensor] = None,
+    video_grid_thw: Optional[torch.LongTensor] = None,
+    rope_deltas: Optional[torch.LongTensor] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    **loss_kwargs,
+) -> Union[Tuple, Qwen2VLCausalLMOutputWithPast]:
+    r"""
+    Copy paste Qwen2VL's forward but replace torch cross entropy with liger fused linear cross entropy
+
+    Args:
+        labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
+            config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+            (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+    Returns:
+
+    Example:
+
+    ```python
+    >>> from PIL import Image
+    >>> import requests
+    >>> from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
+
+    >>> model = Qwen2VLForConditionalGeneration.from_pretrained("Qwen/Qwen2-VL-7B-Instruct")
+    >>> processor = AutoProcessor.from_pretrained("Qwen/Qwen2-VL-7B-Instruct")
+
+    >>> messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image"},
+                {"type": "text", "text": "What is shown in this image?"},
+            ],
+        },
+    ]
+    >>> url = "https://www.ilankelman.org/stopsigns/australia.jpg"
+    >>> image = Image.open(requests.get(url, stream=True).raw)
+
+    >>> text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    >>> inputs = processor(text=[text], images=[image], vision_infos=[vision_infos])
+
+    >>> # Generate
+    >>> generate_ids = model.generate(inputs.input_ids, max_length=30)
+    >>> tokenizer.batch_decode(generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
+    "The image shows a street scene with a red stop sign in the foreground. In the background, there is a large red gate with Chinese characters ..."
+    ```"""
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    if inputs_embeds is None:
+        inputs_embeds = self.model.embed_tokens(input_ids)
+        if pixel_values is not None:
+            pixel_values = pixel_values.type(self.visual.get_dtype())
+            image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
+            n_image_tokens = (input_ids == self.config.image_token_id).sum().item()
+            n_image_features = image_embeds.shape[0]
+            if n_image_tokens != n_image_features:
+                raise ValueError(
+                    f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
+                )
+            image_mask = (
+                (input_ids == self.config.image_token_id)
+                .unsqueeze(-1)
+                .expand_as(inputs_embeds)
+                .to(inputs_embeds.device)
+            )
+            image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
+        if pixel_values_videos is not None:
+            pixel_values_videos = pixel_values_videos.type(self.visual.get_dtype())
+            video_embeds = self.visual(pixel_values_videos, grid_thw=video_grid_thw)
+            n_video_tokens = (input_ids == self.config.video_token_id).sum().item()
+            n_video_features = video_embeds.shape[0]
+            if n_video_tokens != n_video_features:
+                raise ValueError(
+                    f"Video features and video tokens do not match: tokens: {n_video_tokens}, features {n_video_features}"
+                )
+            video_mask = (
+                (input_ids == self.config.video_token_id)
+                .unsqueeze(-1)
+                .expand_as(inputs_embeds)
+                .to(inputs_embeds.device)
+            )
+            video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(inputs_embeds.device)
+
+    if position_ids is None and (attention_mask is None or attention_mask.ndim == 2):
+        # calculate RoPE index once per generation in the pre-fill stage only
+        if (cache_position is not None and cache_position[0] == 0) or self.rope_deltas is None:
+            position_ids, rope_deltas = self.get_rope_index(
+                input_ids, image_grid_thw, video_grid_thw, attention_mask
+            )
+            self.rope_deltas = rope_deltas
+        # then use the prev pre-calculated rope-deltas to get the correct position ids
+        else:
+            batch_size, seq_length, _ = inputs_embeds.shape
+            delta = cache_position[0] + self.rope_deltas if cache_position is not None else 0
+            position_ids = torch.arange(seq_length, device=inputs_embeds.device)
+            position_ids = position_ids.view(1, -1).expand(batch_size, -1)
+            if cache_position is not None:  # otherwise `deltas` is an int `0`
+                delta = delta.repeat_interleave(batch_size // delta.shape[0], dim=0)
+            position_ids = position_ids.add(delta)
+            position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+
+    outputs = self.model(
+        input_ids=None,
+        position_ids=position_ids,
+        attention_mask=attention_mask,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+        cache_position=cache_position,
+    )
+
+    hidden_states = outputs[0]
+
+    loss = None
+    logits = None
+
+    if is_liger_kernel_available() and self.training and (labels is not None):
+        from liger_kernel.transformers.model.loss_utils import LigerForCausalLMLoss
+
+        loss = LigerForCausalLMLoss(
+            hidden_states=hidden_states,
+            lm_head_weight=self.lm_head.weight,
+            labels=labels,
+            hidden_size=self.config.hidden_size,
+            **loss_kwargs,
+        )
+    else:
+        logits = self.lm_head(hidden_states)
+        if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
+            # Shift so that tokens < n predict n
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            # Flatten the tokens
+            loss_fct = CrossEntropyLoss()
+            shift_logits = shift_logits.view(-1, self.config.vocab_size)
+            shift_labels = shift_labels.view(-1)
+            # Enable model parallelism
+            shift_labels = shift_labels.to(shift_logits.device)
+            loss = loss_fct(shift_logits, shift_labels)
+
+    if not return_dict:
+        output = (logits,) + outputs[1:]
+        return (loss,) + output if loss is not None else output
+
+    return Qwen2VLCausalLMOutputWithPast(
+        loss=loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+        rope_deltas=rope_deltas,
+    )

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -29,6 +29,8 @@ actor_rollout_ref:
     enable_gradient_checkpointing: True
     use_remove_padding: False
     use_liger: False
+    return_last_hidden_state: False
+    use_fused_loss: False
   actor:
     strategy: fsdp  # This is for backward-compatibility
     ppo_mini_batch_size: 256

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -433,6 +433,11 @@ class RayPPOTrainer:
                 "When using sequence parallelism for actor/ref policy, you must enable `use_remove_padding`."
             )
 
+        if config.actor_rollout_ref.model.use_fused_loss:
+            assert config.actor_rollout_ref.model.return_last_hidden_state, (
+                "When `use_fused_loss` is enabled, you must enable `use_remove_padding`."
+            )
+
         if self.use_critic and config.critic.strategy == "fsdp":
             if config.critic.get("ulysses_sequence_parallel_size", 1) > 1:
                 assert config.critic.model.use_remove_padding, (

--- a/verl/utils/experimental/__init__.py
+++ b/verl/utils/experimental/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -45,7 +45,7 @@ class FusedEntropy(torch.autograd.Function):
 
         entropy_broadcasted = entropy.unsqueeze(-1)
         grad_logits = -pd * (torch.log_softmax(logits, dim=-1) + entropy_broadcasted) / seq_len
-        grad_logits = grad_logits.to(orig_logits_dtype)
+        grad_logits = grad_logits.to(orig_logits_dtype) / temperature
 
         grad_hidden_states = grad_logits @ vocab_weights
         grad_vocab_weights = (grad_logits.transpose(-1, -2) @ hidden_states).sum(0)
@@ -110,6 +110,7 @@ class FusedEntropy(torch.autograd.Function):
                 grad_output=chunk_grad_output,
                 hidden_states=chunk_hidden,
                 vocab_weights=vocab_weights,
+                temperature=temperature,
             )
             grad_hidden_states[:, chunk_start:chunk_end] += h
             grad_vocab_weights += v

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -286,15 +286,6 @@ def fused_log_probs(
     Returns:
         torch.Tensor: _description_
     """
-    return checkpoint(
-        FusedTokenLogProbs.apply,
-        hidden_states,
-        vocab_weights,
-        input_ids,
-        temperature,
-        chunk_size,
-        use_reentrant=True,
-    )
     return FusedTokenLogProbs.apply(
         hidden_states,
         vocab_weights,

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -43,8 +43,9 @@ class FusedEntropy(torch.autograd.Function):
         pd = torch.nn.functional.softmax(logits, dim=-1)
         entropy = torch.logsumexp(logits, dim=-1) - torch.sum(pd * logits, dim=-1)
 
-        grad_logits = pd * (torch.log_softmax(logits, dim=-1) + entropy.unsqueeze(-1))
-        grad_logits *= -grad_output.unsqueeze(-1)
+        # Safer to do this rather than log(pd)
+        log_pd = torch.log_softmax(logits, dim=-1)
+        grad_logits = pd * (log_pd + entropy.unsqueeze(-1)) * (-grad_output.unsqueeze(-1))
         grad_logits = grad_logits.to(orig_logits_dtype) / temperature
 
         grad_hidden_states = grad_logits @ vocab_weights

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -19,7 +19,7 @@ class FusedEntropy(torch.autograd.Function):
             entropy (torch.Tensor): [B, T]
         """
         output_dtype = hidden_states.dtype
-        logits = torch.einsum("bth,vh->btv", hidden_states, vocab_weights)
+        logits = (hidden_states @ vocab_weights.t())
         logits.div_(temperature)
         logits = logits.to(torch.float32)
         pd = torch.nn.functional.softmax(logits, dim=-1)
@@ -108,6 +108,7 @@ class FusedEntropy(torch.autograd.Function):
 def fused_entropy(
     hidden_states: torch.Tensor,
     vocab_weights: torch.Tensor,
+    temperature: float = 1.0,
     chunk_size: int = 512,
 ) -> torch.Tensor:
     """Fuse the logits calculations with entropy calculation to save memory.
@@ -122,6 +123,7 @@ def fused_entropy(
     return FusedEntropy.apply(
         hidden_states,
         vocab_weights,
+        temperature,
         chunk_size,
     )
 

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -34,7 +34,9 @@ class FusedEntropy(torch.autograd.Function):
         vocab_weights: torch.Tensor,
         temperature: float = 1.0,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        # seq_len = grad_output.shape[-1]
+        """This function mirrors entroyp_fwd.
+        Down to the location where casting of logits to fp32 is done.
+        """
 
         logits = (hidden_states @ vocab_weights.t()) / temperature
         orig_logits_dtype = logits.dtype

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -1,0 +1,244 @@
+import torch
+
+
+class FusedEntropy(torch.autograd.Function):
+    @staticmethod
+    def entropy_fn(hidden_states: torch.Tensor, vocab_weights: torch.Tensor) -> torch.Tensor:
+        """Naive entropy function
+
+        Args:
+            hidden_states (torch.Tensor): [B, T, D]
+            vocab_weights (torch.Tensor): [V, D]
+
+        Returns:
+            entropy (torch.Tensor): [B, T]
+        """
+        output_dtype = hidden_states.dtype
+        logits = torch.einsum("bth,vh->btv", hidden_states, vocab_weights)
+        logits = logits.to(torch.float32)
+        pd = torch.nn.functional.softmax(logits, dim=-1)
+        entropy = torch.logsumexp(logits, dim=-1) - torch.sum(pd * logits, dim=-1)
+        return entropy.to(output_dtype)
+
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        vocab_weights: torch.Tensor,
+        chunk_size: int = 512,
+    ) -> torch.Tensor:
+        B, T, _ = hidden_states.shape
+        entropy = torch.empty(
+            B,
+            T,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+        # Process in chunks to save memory
+        for chunk_start in range(0, T, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, T)
+            chunk_hidden = hidden_states[:, chunk_start:chunk_end, :]
+
+            chunk_entropy = FusedEntropy.entropy_fn(chunk_hidden, vocab_weights)
+
+            entropy[:, chunk_start:chunk_end] = chunk_entropy
+
+        # Save necessary tensors for backward
+        ctx.save_for_backward(hidden_states, vocab_weights)
+        ctx.chunk_size = chunk_size
+
+        return entropy
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        hidden_states, vocab_weights = ctx.saved_tensors
+        chunk_size = ctx.chunk_size
+        B, T, H = hidden_states.shape
+        V = vocab_weights.shape[0]
+
+        # Initialize gradients
+        grad_hidden_states = torch.zeros_like(hidden_states)
+        grad_vocab_weights = torch.zeros_like(vocab_weights)
+
+        # Process in chunks to save memory
+        for chunk_start in range(0, T, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, T)
+            chunk_hidden = hidden_states[:, chunk_start:chunk_end, :].detach().requires_grad_(True)
+            chunk_grad_output = grad_output[:, chunk_start:chunk_end]
+
+            with torch.enable_grad():
+                chunk_entropy = FusedEntropy.entropy_fn(chunk_hidden, vocab_weights)
+                torch.autograd.backward(chunk_entropy, grad_tensors=chunk_grad_output, retain_graph=False)
+
+            # Accumulate gradients
+            grad_hidden_states[:, chunk_start:chunk_end, :] += chunk_hidden.grad
+            grad_vocab_weights += vocab_weights.grad if vocab_weights.grad is not None else 0
+
+            if chunk_hidden.grad is not None:
+                chunk_hidden.grad.zero_()
+            if vocab_weights.grad is not None:
+                vocab_weights.grad.zero_()
+
+        return (
+            grad_hidden_states,  # hidden_states
+            grad_vocab_weights,  # vocab_weights
+            None,  # chunk_size
+        )
+
+
+def fused_entropy(
+    hidden_states: torch.Tensor,
+    vocab_weights: torch.Tensor,
+    chunk_size: int = 512,
+):
+    """Fuse the logits calculations with entropy calculation to save memory.
+
+    Args:
+        hidden_states (torch.Tensor): Last hidden states
+        vocab_weights (torch.Tensor): lm_head weights
+        chunk_size (int): Chunk size
+    Returns:
+        entropy (torch.Tensor): [B, T] shaped tensor representing token entropy.
+    """
+    return FusedEntropy.apply(
+        hidden_states,
+        vocab_weights,
+        chunk_size,
+    )
+
+
+class FusedTokenLogProbs(torch.autograd.Function):
+    @staticmethod
+    def log_probs_fn(
+        hidden_states: torch.Tensor,
+        vocab_weights: torch.Tensor,
+        input_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        """Naive token log probs function
+
+        Args:
+            hidden_states (torch.FloatTensor): [B, T, D]
+            vocab_weights (torch.FloatTensor): [V, D]
+            input_ids (torch.LongTensor): [B, T]
+
+        Returns:
+            token_log_probs (torch.FloatTensor): [B, T]
+        """
+        output_dtype = hidden_states.dtype
+        logits = torch.einsum("bth,vh->btv", hidden_states, vocab_weights)
+        log_probs = torch.log_softmax(logits.to(torch.float32), dim=-1)
+        token_log_probs = log_probs.gather(-1, input_ids.unsqueeze(-1)).squeeze(-1)
+        return token_log_probs.to(output_dtype)
+
+    @staticmethod
+    def forward(
+        ctx,
+        hidden_states: torch.Tensor,
+        vocab_weights: torch.Tensor,
+        input_ids: torch.Tensor,
+        chunk_size: int = 512,
+    ) -> torch.Tensor:
+        B, T, H = hidden_states.shape
+        V = vocab_weights.shape[0]
+
+        # Initialize output tensor
+        token_log_probs = torch.empty(
+            B,
+            T,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+        # Process in chunks to save memory
+        for chunk_start in range(0, T, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, T)
+            chunk_hidden = hidden_states[:, chunk_start:chunk_end, :]
+            chunk_ids = input_ids[:, chunk_start:chunk_end]
+
+            chunk_token_log_probs = FusedTokenLogProbs.log_probs_fn(
+                hidden_states=chunk_hidden,
+                vocab_weights=vocab_weights,
+                input_ids=chunk_ids,
+            )
+
+            token_log_probs[:, chunk_start:chunk_end] = chunk_token_log_probs
+
+        ctx.save_for_backward(input_ids, hidden_states, vocab_weights)
+        ctx.chunk_size = chunk_size
+
+        return token_log_probs
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input_ids, hidden_states, vocab_weights = ctx.saved_tensors
+        chunk_size = ctx.chunk_size
+        B, T, H = hidden_states.shape
+        V = vocab_weights.shape[0]
+
+        # Initialize gradients
+        grad_hidden = torch.zeros_like(hidden_states)
+        grad_vocab = torch.zeros_like(vocab_weights)
+
+        # Process in chunks to save memory
+        for chunk_start in range(0, T, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, T)
+            chunk_hidden = hidden_states[:, chunk_start:chunk_end, :].detach().requires_grad_(True)
+            chunk_ids = input_ids[:, chunk_start:chunk_end]
+            chunk_grad = grad_output[:, chunk_start:chunk_end]
+
+            with torch.enable_grad():
+                chunk_token_log_probs = FusedTokenLogProbs.log_probs_fn(
+                    hidden_states=chunk_hidden,
+                    vocab_weights=vocab_weights,
+                    input_ids=chunk_ids,
+                )
+
+                # Compute gradients for this chunk
+                torch.autograd.backward(
+                    chunk_token_log_probs,
+                    grad_tensors=chunk_grad,
+                    retain_graph=False,
+                )
+
+            # Accumulate gradients
+            grad_hidden[:, chunk_start:chunk_end, :] += chunk_hidden.grad
+            grad_vocab += vocab_weights.grad if vocab_weights.grad is not None else 0
+
+            # Clean up to save memory
+            if chunk_hidden.grad is not None:
+                chunk_hidden.grad.zero_()
+            if vocab_weights.grad is not None:
+                vocab_weights.grad.zero_()
+
+        return (
+            grad_hidden,  # hidden_states
+            grad_vocab,  # vocab_weights
+            None,  # input_ids
+            None,  # chunk_size
+        )
+
+
+def fused_log_probs(
+    hidden_states: torch.Tensor,
+    vocab_weights: torch.Tensor,
+    input_ids: torch.Tensor,
+    chunk_size: int = 512,
+) -> torch.Tensor:
+    """Fuse the logits calculations with log probs calculation to save memory.
+
+    Args:
+        hidden_states (torch.Tensor): Last hidden states
+        vocab_weights (torch.Tensor): lm_head weights
+        input_ids (torch.Tensor): Token ids of log_probs
+        chunk_size (int): Chunk size
+
+    Returns:
+        torch.Tensor: _description_
+    """
+    return FusedTokenLogProbs.apply(
+        hidden_states,
+        vocab_weights,
+        input_ids,
+        512,
+    )

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -149,6 +149,7 @@ class DataParallelPPOActor(BasePPOActor):
                         entropy_rmpad = fused_entropy(
                             hidden_states=hidden_states,
                             vocab_weights=vocab_weights,
+                            temperature=temperature,
                         ).squeeze(0)
 
                 else:
@@ -220,6 +221,7 @@ class DataParallelPPOActor(BasePPOActor):
                     entropy = fused_entropy(
                         hidden_states=hidden_states,
                         vocab_weights=vocab_weights,
+                        temperature=temperature,
                     )
 
                 else:

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -149,7 +149,7 @@ class DataParallelPPOActor(BasePPOActor):
                     if self.return_last_hidden_state:
                         hidden_states = output.last_hidden_state
                         logits = self.actor_module.lm_head(hidden_states)
-                        logits_rmpad = logits.squeeze(0)    # (total_nnz, vocab_size)
+                        logits_rmpad = logits.squeeze(0)  # (total_nnz, vocab_size)
                     else:
                         logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
 

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -1026,7 +1026,6 @@ class RewardModelWorker(Worker):
         self.ulysses_sharding_manager = FSDPUlyssesShardingManager(self.ulysses_device_mesh)
 
         self.use_remove_padding = self.config.model.get("use_remove_padding", False)
-        self.return_last_hidden_state = self.config.model.get("return_last_hidden_state", False)
 
         # normalize config
         if self.config.micro_batch_size is not None:

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -496,8 +496,8 @@ class ActorRolloutRefWorker(Worker):
             OmegaConf.set_struct(self.config.ref, True)
             with open_dict(self.config.ref):
                 self.config.ref.use_remove_padding = use_remove_padding
-                self.config.actor.return_last_hidden_state = return_last_hidden_state
-                self.config.actor.use_fused_loss = use_fused_loss
+                self.config.ref.return_last_hidden_state = return_last_hidden_state
+                self.config.ref.use_fused_loss = use_fused_loss
             self.ref_policy = DataParallelPPOActor(config=self.config.ref, actor_module=self.ref_module_fsdp)
 
         if self._is_actor:


### PR DESCRIPTION
## What's new?
Fused entropy & log probs function.

## How does it work?
The method to reduce memory cost during loss calculations is to not materialize the logits tensor.
To demonstrate, let's suppose you have the following configs
- token_per_batch = 32k
- vocab_size = 128k

Then assuming that we keep logits in fp16, we will have

logits_memory_size = 32k * 128k * 2 / 1e6 = 8GB

But wait... during loss calculations, we usually have to calculate probabilities, then when doing backwards, we have to store gradients. So the peak memory consumption will be 32GB! Then if we want better accuracy, we need to double that to 64GB.

To solve the problem of high memory consumption, we can use chunking. Specifically we chunk on the sequence length dimension. Calculate the forward and backward for each chunk then accumulate the gradients.

Suppose we use chunk_size = 512 and fp32 for loss calculations, we will have

peak_memory_usage = 512 * 128k * 4 / 1e6 * 4 ~= 1GB

This way we massively save on memory consumption

## Changes
- Added the options `return_last_hidden_state` and `use_fused_loss`
- monkey patch to make `model.forward` return `last_hidden_state` and not calculate `logits`
- Fused entropy and token_log_probs functions in verl/utils/experimental/torch_functional.py