### PR TITLE
fixt: typo

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -90,7 +90,6 @@ class AdvantageEstimator(str, Enum):
 class ResourcePoolManager:
     """
     Define a resource pool specification. Resource pool will be initialized first.
-    Mapping
     """
 
     resource_pool_spec: dict[str, list[int]]


### PR DESCRIPTION
Alternatively, we should properly expand on the role of the parameter `mapping`