### PR TITLE
fix: remove deprecated remove_previous_ckpt key in prime_ray_trainer.py

### DIFF
--- a/recipe/prime/prime_ray_trainer.py
+++ b/recipe/prime/prime_ray_trainer.py
@@ -248,7 +248,6 @@ class RayPRIMETrainer(RayPPOTrainer):
             actor_local_path,
             actor_remote_path,
             self.global_steps,
-            remove_previous_ckpt=self.config.trainer.remove_previous_ckpt_in_save,
         )
 
         if self.use_rm:
@@ -262,7 +261,6 @@ class RayPRIMETrainer(RayPPOTrainer):
                 reward_local_path,
                 reward_remote_path,
                 self.global_steps,
-                remove_previous_ckpt=self.config.trainer.remove_previous_ckpt_in_save,
             )
 
         # save dataloader

--- a/recipe/prime/run_prime_qwen.sh
+++ b/recipe/prime/run_prime_qwen.sh
@@ -5,6 +5,8 @@ set -x
 
 gsm8k_train_path=$HOME/data/gsm8k/train.parquet
 gsm8k_test_path=$HOME/data/gsm8k/test.parquet
+
+# download from https://huggingface.co/datasets/PRIME-RL/Eurus-2-RL-Data
 math_train_path=$HOME/data/math/train.parquet
 math_test_path=$HOME/data/math/test.parquet
 


### PR DESCRIPTION
deprecated remove_previous_ckpt key cause save checkpoint crash.
See: https://github.com/volcengine/verl/issues/1183