### PR TITLE
[single controller] feat: support directly register dispatch device mesh

### DIFF
--- a/tests/ray/test_dist_info.py
+++ b/tests/ray/test_dist_info.py
@@ -50,3 +50,60 @@ def test_dist_global_info():
 
     for info, expected_info in zip(result, expected_result):
         assert info == expected_info
+
+
+from verl.single_controller.base import Worker
+from verl.single_controller.base.decorator import register, Dispatch
+from verl import DataProto
+import ray
+
+@ray.remote
+class TestActor(Worker):
+    def __init__(self) -> None:
+        super().__init__()
+
+        import torch.distributed
+        torch.distributed.init_process_group(backend='nccl')
+        self.infer_device_mesh = torch.distributed.device_mesh.init_device_mesh(device_type='cuda', 
+                                                                                mesh_shape=[2, 4], mesh_dim_names=['dp', 'tp'])
+        self.train_device_mesh = torch.distributed.device_mesh.init_device_mesh(device_type='cuda', 
+                                                                                mesh_shape=[2, 2, 2], mesh_dim_names=['pp', 'dp', 'tp'])
+
+
+    @register(dispatch_mode=Dispatch.nDProto, mesh='infer')
+    def generate(self, data: DataProto):
+        tp_rank = self.infer_device_mesh['tp'].get_local_rank()
+        dp_rank = self.infer_device_mesh['dp'].get_local_rank()
+        data.batch['a'] += tp_rank * dp_rank
+        return data
+
+    @register(dispatch_mode=Dispatch.nDProto, mesh='train')
+    def train(self, data: DataProto):
+        tp_rank = self.train_device_mesh['tp'].get_local_rank()
+        dp_rank = self.train_device_mesh['dp'].get_local_rank()
+        pp_rank = self.train_device_mesh['pp'].get_local_rank()
+        
+
+
+
+def test_dist_global_info_wg():
+    # create a worker group with size 8
+    # register a infer dist info with tp=4, dp=2
+    # register a train dist info with tp=2, dp=2, pp=2
+    # test the correctness of data dispatch and computation
+    from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
+    
+
+    ray.init()
+    
+    ray_cls = RayClassWithInitArgs(TestActor)
+    resource_pool = RayResourcePool(process_on_nodes=[8])
+    wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls)
+
+    wg.register_dist_info(name='infer', dist_global_info=DistGlobalInfo(tp_size=4, dp_size=2))
+    wg.register_dist_info(name='train', dist_global_info=DistGlobalInfo(tp_size=2, dp_size=2, pp_size=2))
+
+    
+
+    pass
+

--- a/tests/ray/test_dist_info.py
+++ b/tests/ray/test_dist_info.py
@@ -1,9 +1,32 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Test the global distributed info
 """
 
+import ray
 import torch
-from verl.single_controller.base.worker import DistRankInfo, DistGlobalInfo
+
+from verl import DataProto
+from verl.single_controller.base import Worker
+from verl.single_controller.base.decorator import (
+    make_nd_compute_dataproto_dispatch_fn,
+    make_nd_compute_dispatch_fn,
+    register,
+)
+from verl.single_controller.base.worker import DistGlobalInfo, DistRankInfo
 
 
 def test_dist_global_info():
@@ -12,7 +35,7 @@ def test_dist_global_info():
     result = []
 
     for i in range(dist_info.get_world_size()):
-        result.append(dist_info.get_rank_info(global_rank=i, order='tp-pp-dp-ep-cp'))
+        result.append(dist_info.get_rank_info(global_rank=i, order="tp-pp-dp-ep-cp"))
 
     expected_result = [
         DistRankInfo(tp_rank=0, cp_rank=0, ep_rank=0, dp_rank=0, pp_rank=0),
@@ -53,50 +76,47 @@ def test_dist_global_info():
         assert info == expected_info
 
 
-from verl.single_controller.base import Worker
-from verl.single_controller.base.decorator import register, Dispatch, make_nd_compute_dataproto_dispatch_fn, make_nd_compute_dispatch_fn
-from verl import DataProto
-import ray
-
 @ray.remote
 class TestActor(Worker):
     def __init__(self) -> None:
         super().__init__()
 
         import torch.distributed
-        torch.distributed.init_process_group(backend='nccl')
-        self.infer_device_mesh = torch.distributed.device_mesh.init_device_mesh(device_type='cuda', 
-                                                                                mesh_shape=[2, 4], mesh_dim_names=['dp', 'tp'])
-        self.train_device_mesh = torch.distributed.device_mesh.init_device_mesh(device_type='cuda', 
-                                                                                mesh_shape=[2, 2, 2], mesh_dim_names=['pp', 'dp', 'tp'])
 
+        torch.distributed.init_process_group(backend="nccl")
+        self.infer_device_mesh = torch.distributed.device_mesh.init_device_mesh(
+            device_type="cuda", mesh_shape=[2, 4], mesh_dim_names=["dp", "tp"]
+        )
+        self.train_device_mesh = torch.distributed.device_mesh.init_device_mesh(
+            device_type="cuda", mesh_shape=[2, 2, 2], mesh_dim_names=["pp", "dp", "tp"]
+        )
 
-    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name='infer'))
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="infer"))
     def generate_data_proto(self, data: DataProto):
-        tp_rank = self.infer_device_mesh['tp'].get_local_rank()
-        dp_rank = self.infer_device_mesh['dp'].get_local_rank()
-        data.batch['a'] += (tp_rank + 1) * dp_rank
-        return data
-    
-    @register(dispatch_mode=make_nd_compute_dispatch_fn(mesh_name='infer'))
-    def generate(self, data: int):
-        tp_rank = self.infer_device_mesh['tp'].get_local_rank()
-        dp_rank = self.infer_device_mesh['dp'].get_local_rank()
-        print(f'tp_rank: {tp_rank}, dp_rank: {dp_rank}, init data: {data}')
-        data += (tp_rank + 1) * dp_rank
-        print(f'tp_rank: {tp_rank}, dp_rank: {dp_rank}, output data: {data}')
+        tp_rank = self.infer_device_mesh["tp"].get_local_rank()
+        dp_rank = self.infer_device_mesh["dp"].get_local_rank()
+        data.batch["a"] += (tp_rank + 1) * dp_rank
         return data
 
-    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name='train'))
+    @register(dispatch_mode=make_nd_compute_dispatch_fn(mesh_name="infer"))
+    def generate(self, data: int):
+        tp_rank = self.infer_device_mesh["tp"].get_local_rank()
+        dp_rank = self.infer_device_mesh["dp"].get_local_rank()
+        print(f"tp_rank: {tp_rank}, dp_rank: {dp_rank}, init data: {data}")
+        data += (tp_rank + 1) * dp_rank
+        print(f"tp_rank: {tp_rank}, dp_rank: {dp_rank}, output data: {data}")
+        return data
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="train"))
     def train_data_proto(self, data: DataProto):
-        tp_rank = self.train_device_mesh['tp'].get_local_rank()
-        dp_rank = self.train_device_mesh['dp'].get_local_rank()
-        pp_rank = self.train_device_mesh['pp'].get_local_rank()
-        data.batch['a'] += (tp_rank + 1) * (dp_rank + 2) * (pp_rank + 3)
+        tp_rank = self.train_device_mesh["tp"].get_local_rank()
+        dp_rank = self.train_device_mesh["dp"].get_local_rank()
+        pp_rank = self.train_device_mesh["pp"].get_local_rank()
+        data.batch["a"] += (tp_rank + 1) * (dp_rank + 2) * (pp_rank + 3)
         # tp rank 0, pp rank 1, dp rank 0, output data added: 8 + 3 = 11
         # tp rank 0, pp rank 1, dp rank 1, output data added: 12 + 4 = 16
         return data
-        
+
 
 def test_dist_global_info_wg():
     # create a worker group with size 8
@@ -111,22 +131,22 @@ def test_dist_global_info_wg():
     resource_pool = RayResourcePool(process_on_nodes=[8])
     wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls)
 
-    wg.register_dist_info(name='infer', dist_global_info=DistGlobalInfo(tp_size=4, dp_size=2))
-    wg.register_dist_info(name='train', dist_global_info=DistGlobalInfo(tp_size=2, dp_size=2, pp_size=2))
+    wg.register_dist_info(name="infer", dist_global_info=DistGlobalInfo(tp_size=4, dp_size=2))
+    wg.register_dist_info(name="train", dist_global_info=DistGlobalInfo(tp_size=2, dp_size=2, pp_size=2))
 
     infer_input_data = [1, 2]
     infer_output_data = wg.generate(infer_input_data)
 
     assert infer_output_data == [1, 3]
 
-    infer_input_data_proto = DataProto.from_single_dict(data={'a': torch.tensor([1, 2])})
+    infer_input_data_proto = DataProto.from_single_dict(data={"a": torch.tensor([1, 2])})
     infer_output_data_proto = wg.generate_data_proto(infer_input_data_proto)
 
-    assert torch.all(torch.eq(infer_output_data_proto.batch['a'], torch.tensor([1, 3])))
+    assert torch.all(torch.eq(infer_output_data_proto.batch["a"], torch.tensor([1, 3])))
 
-    train_input_data_proto = DataProto.from_single_dict(data={'a': torch.tensor([3, 4])})
+    train_input_data_proto = DataProto.from_single_dict(data={"a": torch.tensor([3, 4])})
     train_output_data_proto = wg.train_data_proto(train_input_data_proto)
 
-    assert torch.all(torch.eq(train_output_data_proto.batch['a'], torch.tensor([11, 16])))
+    assert torch.all(torch.eq(train_output_data_proto.batch["a"], torch.tensor([11, 16])))
 
     ray.shutdown()

--- a/tests/ray/test_dist_info.py
+++ b/tests/ray/test_dist_info.py
@@ -87,14 +87,16 @@ class TestActor(Worker):
         print(f'tp_rank: {tp_rank}, dp_rank: {dp_rank}, output data: {data}')
         return data
 
-    # @register(dispatch_mode=Dispatch.nDProto, mesh='train')
-    # def train(self, data: DataProto):
-    #     tp_rank = self.train_device_mesh['tp'].get_local_rank()
-    #     dp_rank = self.train_device_mesh['dp'].get_local_rank()
-    #     pp_rank = self.train_device_mesh['pp'].get_local_rank()
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name='train'))
+    def train_data_proto(self, data: DataProto):
+        tp_rank = self.train_device_mesh['tp'].get_local_rank()
+        dp_rank = self.train_device_mesh['dp'].get_local_rank()
+        pp_rank = self.train_device_mesh['pp'].get_local_rank()
+        data.batch['a'] += (tp_rank + 1) * (dp_rank + 2) * (pp_rank + 3)
+        # tp rank 0, pp rank 1, dp rank 0, output data added: 8 + 3 = 11
+        # tp rank 0, pp rank 1, dp rank 1, output data added: 12 + 4 = 16
+        return data
         
-
-
 
 # def test_dist_global_info_wg():
 # create a worker group with size 8
@@ -116,6 +118,14 @@ wg.register_dist_info(name='train', dist_global_info=DistGlobalInfo(tp_size=2, d
 infer_input_data = [1, 2]
 infer_output_data = wg.generate(infer_input_data)
 
+assert infer_output_data == [1, 3]
+
 infer_input_data_proto = DataProto.from_single_dict(data={'a': torch.tensor([1, 2])})
 infer_output_data_proto = wg.generate_data_proto(infer_input_data_proto)
 
+assert torch.all(torch.eq(infer_output_data_proto.batch['a'], torch.tensor([1, 3])))
+
+train_input_data_proto = DataProto.from_single_dict(data={'a': torch.tensor([3, 4])})
+train_output_data_proto = wg.train_data_proto(train_input_data_proto)
+
+assert torch.all(torch.eq(train_output_data_proto.batch['a'], torch.tensor([11, 16])))

--- a/tests/ray/test_dist_info.py
+++ b/tests/ray/test_dist_info.py
@@ -98,34 +98,35 @@ class TestActor(Worker):
         return data
         
 
-# def test_dist_global_info_wg():
-# create a worker group with size 8
-# register a infer dist info with tp=4, dp=2
-# register a train dist info with tp=2, dp=2, pp=2
-# test the correctness of data dispatch and computation
-from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
+def test_dist_global_info_wg():
+    # create a worker group with size 8
+    # register a infer dist info with tp=4, dp=2
+    # register a train dist info with tp=2, dp=2, pp=2
+    # test the correctness of data dispatch and computation
+    from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 
+    ray.init()
 
-ray.init()
+    ray_cls = RayClassWithInitArgs(TestActor)
+    resource_pool = RayResourcePool(process_on_nodes=[8])
+    wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls)
 
-ray_cls = RayClassWithInitArgs(TestActor)
-resource_pool = RayResourcePool(process_on_nodes=[8])
-wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls)
+    wg.register_dist_info(name='infer', dist_global_info=DistGlobalInfo(tp_size=4, dp_size=2))
+    wg.register_dist_info(name='train', dist_global_info=DistGlobalInfo(tp_size=2, dp_size=2, pp_size=2))
 
-wg.register_dist_info(name='infer', dist_global_info=DistGlobalInfo(tp_size=4, dp_size=2))
-wg.register_dist_info(name='train', dist_global_info=DistGlobalInfo(tp_size=2, dp_size=2, pp_size=2))
+    infer_input_data = [1, 2]
+    infer_output_data = wg.generate(infer_input_data)
 
-infer_input_data = [1, 2]
-infer_output_data = wg.generate(infer_input_data)
+    assert infer_output_data == [1, 3]
 
-assert infer_output_data == [1, 3]
+    infer_input_data_proto = DataProto.from_single_dict(data={'a': torch.tensor([1, 2])})
+    infer_output_data_proto = wg.generate_data_proto(infer_input_data_proto)
 
-infer_input_data_proto = DataProto.from_single_dict(data={'a': torch.tensor([1, 2])})
-infer_output_data_proto = wg.generate_data_proto(infer_input_data_proto)
+    assert torch.all(torch.eq(infer_output_data_proto.batch['a'], torch.tensor([1, 3])))
 
-assert torch.all(torch.eq(infer_output_data_proto.batch['a'], torch.tensor([1, 3])))
+    train_input_data_proto = DataProto.from_single_dict(data={'a': torch.tensor([3, 4])})
+    train_output_data_proto = wg.train_data_proto(train_input_data_proto)
 
-train_input_data_proto = DataProto.from_single_dict(data={'a': torch.tensor([3, 4])})
-train_output_data_proto = wg.train_data_proto(train_input_data_proto)
+    assert torch.all(torch.eq(train_output_data_proto.batch['a'], torch.tensor([11, 16])))
 
-assert torch.all(torch.eq(train_output_data_proto.batch['a'], torch.tensor([11, 16])))
+    ray.shutdown()

--- a/tests/ray/test_dist_info.py
+++ b/tests/ray/test_dist_info.py
@@ -1,0 +1,52 @@
+"""
+Test the global distributed info
+"""
+
+from verl.single_controller.base.worker import DistRankInfo, DistGlobalInfo
+
+
+def test_dist_global_info():
+    dist_info = DistGlobalInfo(tp_size=2, cp_size=2, ep_size=2, dp_size=2, pp_size=2)
+
+    result = []
+
+    for i in range(dist_info.get_world_size()):
+        result.append(dist_info.get_rank_info(global_rank=i, order='tp-pp-dp-ep-cp'))
+
+    expected_result = [
+        DistRankInfo(tp_rank=0, cp_rank=0, ep_rank=0, dp_rank=0, pp_rank=0),
+        DistRankInfo(tp_rank=1, cp_rank=0, ep_rank=0, dp_rank=0, pp_rank=0),
+        DistRankInfo(tp_rank=0, cp_rank=0, ep_rank=0, dp_rank=0, pp_rank=1),
+        DistRankInfo(tp_rank=1, cp_rank=0, ep_rank=0, dp_rank=0, pp_rank=1),
+        DistRankInfo(tp_rank=0, cp_rank=0, ep_rank=0, dp_rank=1, pp_rank=0),
+        DistRankInfo(tp_rank=1, cp_rank=0, ep_rank=0, dp_rank=1, pp_rank=0),
+        DistRankInfo(tp_rank=0, cp_rank=0, ep_rank=0, dp_rank=1, pp_rank=1),
+        DistRankInfo(tp_rank=1, cp_rank=0, ep_rank=0, dp_rank=1, pp_rank=1),
+        DistRankInfo(tp_rank=0, cp_rank=0, ep_rank=1, dp_rank=0, pp_rank=0),
+        DistRankInfo(tp_rank=1, cp_rank=0, ep_rank=1, dp_rank=0, pp_rank=0),
+        DistRankInfo(tp_rank=0, cp_rank=0, ep_rank=1, dp_rank=0, pp_rank=1),
+        DistRankInfo(tp_rank=1, cp_rank=0, ep_rank=1, dp_rank=0, pp_rank=1),
+        DistRankInfo(tp_rank=0, cp_rank=0, ep_rank=1, dp_rank=1, pp_rank=0),
+        DistRankInfo(tp_rank=1, cp_rank=0, ep_rank=1, dp_rank=1, pp_rank=0),
+        DistRankInfo(tp_rank=0, cp_rank=0, ep_rank=1, dp_rank=1, pp_rank=1),
+        DistRankInfo(tp_rank=1, cp_rank=0, ep_rank=1, dp_rank=1, pp_rank=1),
+        DistRankInfo(tp_rank=0, cp_rank=1, ep_rank=0, dp_rank=0, pp_rank=0),
+        DistRankInfo(tp_rank=1, cp_rank=1, ep_rank=0, dp_rank=0, pp_rank=0),
+        DistRankInfo(tp_rank=0, cp_rank=1, ep_rank=0, dp_rank=0, pp_rank=1),
+        DistRankInfo(tp_rank=1, cp_rank=1, ep_rank=0, dp_rank=0, pp_rank=1),
+        DistRankInfo(tp_rank=0, cp_rank=1, ep_rank=0, dp_rank=1, pp_rank=0),
+        DistRankInfo(tp_rank=1, cp_rank=1, ep_rank=0, dp_rank=1, pp_rank=0),
+        DistRankInfo(tp_rank=0, cp_rank=1, ep_rank=0, dp_rank=1, pp_rank=1),
+        DistRankInfo(tp_rank=1, cp_rank=1, ep_rank=0, dp_rank=1, pp_rank=1),
+        DistRankInfo(tp_rank=0, cp_rank=1, ep_rank=1, dp_rank=0, pp_rank=0),
+        DistRankInfo(tp_rank=1, cp_rank=1, ep_rank=1, dp_rank=0, pp_rank=0),
+        DistRankInfo(tp_rank=0, cp_rank=1, ep_rank=1, dp_rank=0, pp_rank=1),
+        DistRankInfo(tp_rank=1, cp_rank=1, ep_rank=1, dp_rank=0, pp_rank=1),
+        DistRankInfo(tp_rank=0, cp_rank=1, ep_rank=1, dp_rank=1, pp_rank=0),
+        DistRankInfo(tp_rank=1, cp_rank=1, ep_rank=1, dp_rank=1, pp_rank=0),
+        DistRankInfo(tp_rank=0, cp_rank=1, ep_rank=1, dp_rank=1, pp_rank=1),
+        DistRankInfo(tp_rank=1, cp_rank=1, ep_rank=1, dp_rank=1, pp_rank=1),
+    ]
+
+    for info, expected_info in zip(result, expected_result):
+        assert info == expected_info

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -24,11 +24,11 @@ from .decorator import Dispatch, Execute, register
 
 @dataclass
 class DistRankInfo:
-    tp_rank: int
-    cp_rank: int
-    ep_rank: int
-    dp_rank: int
-    pp_rank: int
+    tp_rank: int = 0
+    cp_rank: int = 0
+    ep_rank: int = 0
+    dp_rank: int = 0
+    pp_rank: int = 0
 
 
 @dataclass
@@ -42,15 +42,9 @@ class DistGlobalInfo:
     def get_world_size(self):
         return self.tp_size * self.cp_size * self.ep_size * self.dp_size * self.pp_size
 
-    def get_rank_info(self, global_rank, order='tp-cp-ep-dp-pp') -> DistRankInfo:
-        sizes = {
-            'tp': self.tp_size,
-            'cp': self.cp_size,
-            'ep': self.ep_size,
-            'dp': self.dp_size,
-            'pp': self.pp_size
-        }
-        sub_orders = order.split('-')
+    def get_rank_info(self, global_rank, order="tp-cp-ep-dp-pp") -> DistRankInfo:
+        sizes = {"tp": self.tp_size, "cp": self.cp_size, "ep": self.ep_size, "dp": self.dp_size, "pp": self.pp_size}
+        sub_orders = order.split("-")
         assert len(sub_orders) == len(sizes), f"order must be from {list(sizes.keys())}, got {order}"
 
         remaining_rank = global_rank
@@ -62,13 +56,12 @@ class DistGlobalInfo:
             remaining_rank //= size
 
         return DistRankInfo(
-            tp_rank=ranks.get('tp', 0),
-            cp_rank=ranks.get('cp', 0),
-            ep_rank=ranks.get('ep', 0),
-            dp_rank=ranks.get('dp', 0),
-            pp_rank=ranks.get('pp', 0)
+            tp_rank=ranks.get("tp", 0),
+            cp_rank=ranks.get("cp", 0),
+            ep_rank=ranks.get("ep", 0),
+            dp_rank=ranks.get("dp", 0),
+            pp_rank=ranks.get("pp", 0),
         )
-        
 
 
 class WorkerHelper:
@@ -160,7 +153,8 @@ class Worker(WorkerHelper):
             os.environ.update(rank_zero_info)
 
     def __init__(self, cuda_visible_devices=None) -> None:
-        # construct a meta from envrionment variable. Note that the import must be inside the class because it is executed remotely
+        # construct a meta from envrionment variable.
+        # Note that the import must be inside the class because it is executed remotely
         import os
 
         ###

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -33,11 +33,11 @@ class DistRankInfo:
 
 @dataclass
 class DistGlobalInfo:
-    tp_size: int
-    cp_size: int
-    ep_size: int
-    dp_size: int
-    pp_size: int
+    tp_size: int = 1
+    cp_size: int = 1
+    ep_size: int = 1
+    dp_size: int = 1
+    pp_size: int = 1
 
     def get_world_size(self):
         return self.tp_size * self.cp_size * self.ep_size * self.dp_size * self.pp_size

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -91,8 +91,6 @@ def check_workers_alive(workers: List, is_alive: Callable, gap_time: float = 1) 
         time.sleep(gap_time)
 
 
-from .worker import DistGlobalInfo, DistRankInfo
-
 class WorkerGroup:
     """A group of workers"""
 
@@ -140,10 +138,11 @@ class WorkerGroup:
     def world_size(self):
         return len(self._workers)
     
-    def register_dist_info(self, name, dist_global_info: DistGlobalInfo, ordering='tp-cp-ep-dp-pp'):
+    def register_dist_info(self, name, dist_global_info, order='tp-cp-ep-dp-pp'):
         """register the nD distributed info. Currently, we only support megatron mesh
         # TODO: we can support general device mesh in the future
         """
+        from verl.single_controller.base.worker import DistGlobalInfo
         assert isinstance(dist_global_info, DistGlobalInfo)
         assert name not in self._dist_global_info, f"dist_info {name} already exists"
         assert name not in self._dist_workers_info, f"dist_info {name} already exists"
@@ -155,7 +154,7 @@ class WorkerGroup:
             f"world_size mismatch. Got {self.world_size} and {dist_global_info.get_world_size()}"
 
         for i in range(self.world_size):
-            dist_rank_info = dist_global_info.get_rank_info(global_rank=i, ordering=ordering)
+            dist_rank_info = dist_global_info.get_rank_info(global_rank=i, order=order)
             self._dist_workers_info[name].append(dist_rank_info)
         
 


### PR DESCRIPTION
The current dispatch methods are quite limited:
- In hybrid engine, we would like to dispatch infer_tp x infer_dp for generation and train_tp x train_dp x train_pp for training. However, currently implementation can only dispatch train_tp x train_dp x train_pp for training and dp for generation and perform allgather inside the workergroup.
- When two megatron models colocate, their device mesh has to be identical.
- We have to subclass RayWorkerGroup in order to implement various distributed strategies. This makes create_colocated_worker hacky to implement in the future.

The difference in this implementation:
- The nD device mesh is not obtained from worker, then broadcast to workergroup. It is directly registered to the worker group in driver. It's the user's responsibility to make sure that the registered device mesh matches with the device mesh established internally.

By doing so, we can completely remote MegatronWorker and the necessity to subclass RayWorkerGroup in the future to implement flexible dispatch methods.

Currently, we only support tp-cp-ep-dp-pp. This meets the current requirements of megatron and vllm/sglang. We can introduce more flexible device mesh like dispatch method in the future.