### PR TITLE
Add custom chat template option

### DIFF
--- a/examples/split_placement/config/ppo_trainer_split.yaml
+++ b/examples/split_placement/config/ppo_trainer_split.yaml
@@ -3,6 +3,7 @@ data:
   train_files: ~/data/rlhf/gsm8k/train.parquet
   val_files: ~/data/rlhf/gsm8k/test.parquet
   prompt_key: prompt
+  custom_chat_template: null
   max_prompt_length: 512
   max_response_length: 512
   train_batch_size: 1024

--- a/examples/split_placement/main_ppo_split.py
+++ b/examples/split_placement/main_ppo_split.py
@@ -120,7 +120,7 @@ def main_task(config):
     # instantiate tokenizer
     from verl.utils import hf_tokenizer
 
-    tokenizer = hf_tokenizer(local_path)
+    tokenizer = hf_tokenizer(local_path, custom_chat_template=config.data.custom_chat_template)
 
     # define worker classes
     if config.actor_rollout_ref.actor.strategy == "fsdp":

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -4,6 +4,7 @@ data:
   val_files: ~/data/rlhf/gsm8k/test.parquet
   prompt_key: prompt
   reward_fn_key: data_source
+  custom_chat_template: null
   max_prompt_length: 512
   max_response_length: 512
   train_batch_size: 1024
@@ -181,6 +182,8 @@ reward_model:
   forward_max_token_len_per_gpu: ${critic.forward_max_token_len_per_gpu}
   reward_manager: naive
   launch_reward_fn_async: False # custom reward function executed async on CPU, during log_prob
+  num_examine: 0
+  val_num_examine: 5
 
 custom_reward_function:
   path: null

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -100,8 +100,12 @@ class TaskRunner:
         # instantiate tokenizer
         from verl.utils import hf_processor, hf_tokenizer
 
-        trust_remote_code = config.data.get("trust_remote_code", False)
-        tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
+
+        custom_chat_template = config.data.get('custom_chat_template', None)
+        trust_remote_code = config.data.get('trust_remote_code', False)
+        tokenizer = hf_tokenizer(local_path, 
+                                 trust_remote_code=trust_remote_code, 
+                                 custom_chat_template=custom_chat_template)
         processor = hf_processor(local_path, use_fast=True)  # used for multimodal LLM, could be none
 
         # define worker classes

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -75,6 +75,7 @@ class RLHFDataset(Dataset):
         self.image_key = config.get("image_key", "images")
         self.video_key = config.get("video_key", "videos")
         self.max_prompt_length = config.get("max_prompt_length", 1024)
+        # self.chat_template_key = config.get("chat_template_key", "chat_template")
 
         self.return_raw_chat = config.get("return_raw_chat", False)
         self.truncation = config.get("truncation", "error")
@@ -82,6 +83,9 @@ class RLHFDataset(Dataset):
 
         self.num_workers = config.get("filter_overlong_prompts_workers", max(1, os.cpu_count() // 4))
         self.num_workers = min(self.num_workers, os.cpu_count())
+
+        no_template = "{{ bos_token }}{{ messages }}"
+        self.tokenizer.chat_template = no_template
 
         # whether to store the dataset in state_dict()
         # default not store

--- a/verl/utils/dataset/sft_dataset.py
+++ b/verl/utils/dataset/sft_dataset.py
@@ -45,6 +45,7 @@ class SFTDataset(Dataset):
         response_dict_keys = config.get("response_dict_keys", None)
         max_length = config.get("max_length", 1024)
         truncation = config.get("truncation", "error")
+        custom_chat_template = config.get('custom_chat_template', None)
 
         assert truncation in ["error", "left", "right"]
         self.truncation = truncation
@@ -54,7 +55,7 @@ class SFTDataset(Dataset):
 
         self.parquet_files = parquet_files
         if isinstance(tokenizer, str):
-            tokenizer = hf_tokenizer(tokenizer)
+            tokenizer = hf_tokenizer(tokenizer, custom_chat_template=custom_chat_template)
         self.tokenizer: PreTrainedTokenizer = tokenizer
 
         self.prompt_key = prompt_key if isinstance(prompt_key, (tuple, list)) else [prompt_key]

--- a/verl/utils/tokenizer.py
+++ b/verl/utils/tokenizer.py
@@ -33,7 +33,7 @@ def set_pad_token_id(tokenizer):
         warnings.warn(f"tokenizer.pad_token is None. Now set to {tokenizer.eos_token}")
 
 
-def hf_tokenizer(name_or_path, correct_pad_token=True, correct_gemma2=True, **kwargs):
+def hf_tokenizer(name_or_path, correct_pad_token=True, correct_gemma2=True, custom_chat_template=None, **kwargs):
     """Create a huggingface pretrained tokenizer which correctness handles eos and pad tokens.
 
     Args:
@@ -41,7 +41,7 @@ def hf_tokenizer(name_or_path, correct_pad_token=True, correct_gemma2=True, **kw
         name (str): The name of the tokenizer.
         correct_pad_token (bool): Whether to correct the pad token id.
         correct_gemma2 (bool): Whether to correct the gemma2 tokenizer.
-
+        custom_chat_template (str | None): The chat template that overrides the default template. 
     Returns:
 
         transformers.PreTrainedTokenizer: The pretrained tokenizer.
@@ -58,6 +58,11 @@ def hf_tokenizer(name_or_path, correct_pad_token=True, correct_gemma2=True, **kw
     tokenizer = AutoTokenizer.from_pretrained(name_or_path, **kwargs)
     if correct_pad_token:
         set_pad_token_id(tokenizer)
+    
+    # Chat template can be overridden, or set if the tokenizer does not have a chat template
+    if custom_chat_template is not None:
+        tokenizer.chat_template = custom_chat_template
+
     return tokenizer
 
 


### PR DESCRIPTION
#390 

Right now the RL and SFT datasets use the chat template of the tokenizer to format the prompt. Some models do not have a chat template (for example `deepseek-ai/deepseek-coder-1.3b-base`), and sometimes it can be useful to override this template. This adds the option to override the template when loading the tokenizer. 

I have added the required code to make this work with the RL dataset, SFT dataset, and main_ppo / main_ppo_split. If there are other parts of the code that should be updated to make this option work, let me know. 

More info here https://huggingface.co/docs/transformers/main/en/chat_templating
