### PR TITLE
[fix bug] delete wrong assertion

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -398,7 +398,6 @@ class RayPPOTrainer:
         #    ppo_mini_batch_size is divisible by ppo_micro_batch_size
         #    ppo_micro_batch_size * sequence_parallel_size >= n_gpus
         if not config.actor_rollout_ref.actor.use_dynamic_bsz:
-            assert config.data.train_batch_size >= config.actor_rollout_ref.actor.ppo_mini_batch_size
             sp_size = config.actor_rollout_ref.actor.get("ulysses_sequence_parallel_size", 1)
             if config.actor_rollout_ref.actor.ppo_micro_batch_size is not None:
                 assert (
@@ -420,7 +419,6 @@ class RayPPOTrainer:
 
         # critic
         if self.use_critic and not config.critic.use_dynamic_bsz:
-            assert config.data.train_batch_size >= config.critic.ppo_mini_batch_size
             sp_size = config.critic.get("ulysses_sequence_parallel_size", 1)
             if config.critic.ppo_micro_batch_size is not None:
                 assert config.critic.ppo_mini_batch_size % config.critic.ppo_micro_batch_size == 0


### PR DESCRIPTION
按照训练代码，ppo_mini_batch_size没有理由必须不大于train_batch_size，它只是在ppo时成立，对于grpo甚至可以等于train_batch_size * rollout_n，这样就相当于一个RL的Explore Step结束后只进行一次梯度更新参数