### PR TITLE
[FSDPCheckpointManager] feat: save huggingface model when 'hf_model' in checkpoint_contents

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -479,6 +479,7 @@ class ActorRolloutRefWorker(Worker):
                 lr_scheduler=self.actor_lr_scheduler,
                 processing_class=self.processor if self.processor is not None else self.tokenizer,
                 checkpoint_contents=self.config.actor.checkpoint.contents,
+                local_model_path=self.config.model.path,
             )
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)


### PR DESCRIPTION
Before, `FSDPCheckpointManager` will not save hf model when `hf_model` is given in `checkpoint_contents`, instead, it only save the hf model's config.

This PR correctly save the huggingface model when 'hf_model' is in `checkpoint_contents`.