### PR TITLE
fix: catch any error in math reward function

### DIFF
--- a/verl/utils/reward_score/math.py
+++ b/verl/utils/reward_score/math.py
@@ -99,7 +99,7 @@ def fix_fracs(string):
             else:
                 try:
                     assert len(substr) >= 2
-                except AssertionError:
+                except:  # noqa: E722
                     return string
                 a = substr[0]
                 b = substr[1]
@@ -130,7 +130,7 @@ def fix_a_slash_b(string):
         assert string == "{}/{}".format(a, b)
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
-    except AssertionError:
+    except:  # noqa: E722
         return string
 
 

--- a/verl/utils/reward_score/prime_math/math_normalize.py
+++ b/verl/utils/reward_score/prime_math/math_normalize.py
@@ -51,7 +51,7 @@ def normalize_answer(answer: Optional[str]) -> Optional[str]:
         if m is not None:
             answer = m.group("text").strip()
         return _strip_string(answer)
-    except AssertionError:
+    except:  # noqa: E722
         return answer
 
 
@@ -67,7 +67,7 @@ def _fix_fracs(string):
             else:
                 try:
                     assert len(substr) >= 2
-                except AssertionError:
+                except:  # noqa: E722
                     return string
                 a = substr[0]
                 b = substr[1]
@@ -98,7 +98,7 @@ def _fix_a_slash_b(string):
         assert string == "{}/{}".format(a, b)
         new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
         return new_string
-    except AssertionError:
+    except:  # noqa: E722
         return string
 
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes collapse in the math reward function by catch any possible errors.

## Before submitting

- [x] Did you read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide) and finish the [code format check](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting)? 
- [x] Did you make sure to update the documentations with your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs) especially for breaking config etc?
- [x] Did you write any test cases if neccessary? Please add CI tests to your new feature.  

# Additional Info: 
- **Issue Number**: None
- **Training**: None
- **Inference**: None
