### PR TITLE
[vllm] add moe patch for qwen3-moe

### DIFF
--- a/verl/utils/vllm_utils.py
+++ b/verl/utils/vllm_utils.py
@@ -32,8 +32,9 @@ def patch_vllm_moe_model_weight_loader(model):
     # (False, 'model.layers.0.mlp.experts.w2_weight')          use mlp.experts.weight_loader
     from vllm.model_executor.models.deepseek_v2 import DeepseekV2ForCausalLM, DeepseekV3ForCausalLM
     from vllm.model_executor.models.qwen2_moe import Qwen2MoeForCausalLM
+    from vllm.model_executor.models.qwen3_moe import Qwen3MoeForCausalLM
 
-    if not isinstance(model, (Qwen2MoeForCausalLM, DeepseekV2ForCausalLM, DeepseekV3ForCausalLM)):
+    if not isinstance(model, (Qwen2MoeForCausalLM, DeepseekV2ForCausalLM, DeepseekV3ForCausalLM, Qwen3MoeForCausalLM)):
         return
     for layer in model.model.layers:
         mlp = layer.mlp

--- a/verl/utils/vllm_utils.py
+++ b/verl/utils/vllm_utils.py
@@ -13,6 +13,18 @@
 # limitations under the License.
 
 
+from vllm.model_executor.models.deepseek_v2 import (DeepseekV2ForCausalLM,
+                                                    DeepseekV3ForCausalLM)
+from vllm.model_executor.models.qwen2_moe import Qwen2MoeForCausalLM
+
+model_types = (Qwen2MoeForCausalLM, DeepseekV2ForCausalLM, DeepseekV3ForCausalLM)
+
+try:
+    from vllm.model_executor.models.qwen3_moe import Qwen3MoeForCausalLM
+    model_types = model_types + (Qwen3MoeForCausalLM)
+except ImportError:
+    pass
+
 def patch_vllm_moe_model_weight_loader(model):
     # this is a work around to load the weight of vllm fused moe model
     # it is from a bug from vllm 0.8.2
@@ -30,11 +42,8 @@ def patch_vllm_moe_model_weight_loader(model):
     # (False, 'model.layers.0.post_attention_layernorm.weight') use default
     # (False, 'model.layers.0.mlp.experts.w13_weight')          use mlp.experts.weight_loader
     # (False, 'model.layers.0.mlp.experts.w2_weight')          use mlp.experts.weight_loader
-    from vllm.model_executor.models.deepseek_v2 import DeepseekV2ForCausalLM, DeepseekV3ForCausalLM
-    from vllm.model_executor.models.qwen2_moe import Qwen2MoeForCausalLM
-    from vllm.model_executor.models.qwen3_moe import Qwen3MoeForCausalLM
-
-    if not isinstance(model, (Qwen2MoeForCausalLM, DeepseekV2ForCausalLM, DeepseekV3ForCausalLM, Qwen3MoeForCausalLM)):
+ 
+    if not isinstance(model, model_types):
         return
     for layer in model.model.layers:
         mlp = layer.mlp

--- a/verl/utils/vllm_utils.py
+++ b/verl/utils/vllm_utils.py
@@ -17,11 +17,11 @@ from vllm.model_executor.models.deepseek_v2 import (DeepseekV2ForCausalLM,
                                                     DeepseekV3ForCausalLM)
 from vllm.model_executor.models.qwen2_moe import Qwen2MoeForCausalLM
 
-model_types = (Qwen2MoeForCausalLM, DeepseekV2ForCausalLM, DeepseekV3ForCausalLM)
+model_types = [Qwen2MoeForCausalLM, DeepseekV2ForCausalLM, DeepseekV3ForCausalLM]
 
 try:
     from vllm.model_executor.models.qwen3_moe import Qwen3MoeForCausalLM
-    model_types = model_types + (Qwen3MoeForCausalLM)
+    model_types.append(Qwen3MoeForCausalLM)
 except ImportError:
     pass
 
@@ -43,7 +43,7 @@ def patch_vllm_moe_model_weight_loader(model):
     # (False, 'model.layers.0.mlp.experts.w13_weight')          use mlp.experts.weight_loader
     # (False, 'model.layers.0.mlp.experts.w2_weight')          use mlp.experts.weight_loader
  
-    if not isinstance(model, model_types):
+    if not isinstance(model, tuple(model_types)):
         return
     for layer in model.model.layers:
         mlp = layer.mlp


### PR DESCRIPTION
# What does this PR do?

Add moe patch for qwen3-moe. Fix the weight loader issue in vLLM MoE models. This isn’t a permanent solution, and we may need to contribute code to vLLM to address the problem caused by FusedMoE. I’m already seeking suggestions for this.

# ChangeLog:

- Add Qwen3MoeForCausalLM class for moe_patch


