### PR TITLE
[fix] Remove grad_offload in rloo example script

### DIFF
--- a/examples/rloo_trainer/run_qwen2-7b.sh
+++ b/examples/rloo_trainer/run_qwen2-7b.sh
@@ -20,7 +20,6 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.actor.use_kl_loss=False \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.fsdp_config.param_offload=False \
-    actor_rollout_ref.actor.fsdp_config.grad_offload=False \
     actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=160 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=2 \


### PR DESCRIPTION


# What does this PR do?

`grad_offload` option was removed in #284 for fsdp backend, current script will error out due to this.

# ChangeLog:

- Remove grad_offload in rloo example script

# Usage

- Run the changed script

## Before submitting

- [X] Did you read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide) and finish the [code format check](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting)? 
- [X] Did you make sure to update the documentations with your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs) especially for breaking config etc?
- [X] Did you write any test cases if neccessary? Please add CI tests to your new feature.  

# Additional Info: 
- **Issue Number**: N/A
- **Training**: FSDP
- **Inference**: None
