### PR TITLE
[megatron] support mixtral training with megatron backend 

### DIFF
--- a/verl/models/mcore/__init__.py
+++ b/verl/models/mcore/__init__.py
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .registry import get_mcore_forward_fn, get_mcore_weight_converter, hf_to_mcore_config, init_mcore_model
+from .registry import hf_to_mcore_config, init_mcore_model, get_mcore_forward_fn, get_mcore_weight_converter 
 
-__all__ = ["init_mcore_model", "hf_to_mcore_config", "get_mcore_forward_fn", "get_mcore_weight_converter"]
+__all__ = ["hf_to_mcore_config", "init_mcore_model", "get_mcore_forward_fn", "get_mcore_weight_converter"]

--- a/verl/models/mcore/config_converter.py
+++ b/verl/models/mcore/config_converter.py
@@ -1,5 +1,6 @@
 # Copyright 2025 Bytedance Ltd. and/or its affiliates
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,84 +18,95 @@
 
 import torch
 import torch.nn.functional as F
-from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer import TransformerConfig, MLATransformerConfig
 from transformers import PretrainedConfig
+from typing import Dict, Callable, Type, Optional
 
+def _get_base_transformer_config(hf_config: PretrainedConfig, dtype: torch.dtype, **kwargs) -> TransformerConfig:
+    """
+    Create a base TransformerConfig with common parameters across different model architectures.
+    TODO: (ycl) use dataclass or converter config? 
+    https://github.com/NVIDIA/NeMo/blob/0af8b7df793ad7538f149ad9bcb8c2cae5134c1a/nemo/collections/llm/gpt/model/qwen2.py
+    
+    Args:
+        hf_config: HuggingFace model configuration
+        dtype: Data type for the model
+        **kwargs: Additional parameters to override defaults
+        
+    Returns:
+        TransformerConfig with common parameters
+    """
+    from megatron.core import parallel_state as mpu
+    
+    # Common parallel state parameters
+    overlap_p2p_comm = (
+        mpu.get_virtual_pipeline_model_parallel_world_size() is not None
+        and mpu.get_virtual_pipeline_model_parallel_world_size() > 1
+    )
+    batch_p2p_comm = False
+    
+    # Base configuration with common parameters
+    base_config = {
+        # Model architecture parameters
+        "num_layers": hf_config.num_hidden_layers,
+        "hidden_size": hf_config.hidden_size,
+        "num_attention_heads": hf_config.num_attention_heads,
+        "num_query_groups": hf_config.num_key_value_heads,
+        "ffn_hidden_size": hf_config.intermediate_size,
+        "attention_dropout": hf_config.attention_dropout,
+        "hidden_dropout": getattr(hf_config, "hidden_dropout", 0.0),
+        
+        # Activation and normalization
+        "activation_func": F.silu,
+        "normalization": "RMSNorm",
+        "gated_linear_unit": True,
+        
+        # Data types
+        "pipeline_dtype": dtype,
+        "params_dtype": dtype,
+        "bf16": dtype is torch.bfloat16,
+        
+        # Parallel configuration
+        "tensor_model_parallel_size": mpu.get_tensor_model_parallel_world_size(),
+        "pipeline_model_parallel_size": mpu.get_pipeline_model_parallel_world_size(),
+        "virtual_pipeline_model_parallel_size": mpu.get_virtual_pipeline_model_parallel_world_size(),
+        "context_parallel_size": mpu.get_context_parallel_world_size(),
+        "overlap_p2p_comm": overlap_p2p_comm,
+        "batch_p2p_comm": batch_p2p_comm,
+        "sequence_parallel": mpu.get_tensor_model_parallel_world_size() > 1,
+        
+        # Common settings
+        "variable_seq_lengths": True,
+        "masked_softmax_fusion": True,
+        "moe_token_dispatcher_type": "alltoall",
+    }
+    
+    # Update with any provided overrides
+    base_config.update(kwargs)
+    
+    return TransformerConfig(**base_config)
 
 def hf_to_mcore_config_dense(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
     # for LlamaForCausalLM or Qwen2ForCausalLM
-    from megatron.core import parallel_state as mpu
-
     qkv_bias = True if "Qwen2ForCausalLM" in hf_config.architectures else getattr(hf_config, "attention_bias", False)
-    overlap_p2p_comm = mpu.get_virtual_pipeline_model_parallel_world_size() is not None and mpu.get_virtual_pipeline_model_parallel_world_size() > 1
-    batch_p2p_comm = False
-    transformer_config = TransformerConfig(
-        num_layers=hf_config.num_hidden_layers,
-        hidden_size=hf_config.hidden_size,
-        num_attention_heads=hf_config.num_attention_heads,
-        num_query_groups=hf_config.num_key_value_heads,
-        ffn_hidden_size=hf_config.intermediate_size,
-        activation_func=F.silu,
-        normalization="RMSNorm",
-        gated_linear_unit=True,
+    
+    return _get_base_transformer_config(
+        hf_config=hf_config,
+        dtype=dtype,
         use_cpu_initialization=True,
         add_bias_linear=False,
-        tensor_model_parallel_size=mpu.get_tensor_model_parallel_world_size(),
-        pipeline_model_parallel_size=mpu.get_pipeline_model_parallel_world_size(),
-        virtual_pipeline_model_parallel_size=mpu.get_virtual_pipeline_model_parallel_world_size(),
-        context_parallel_size=mpu.get_context_parallel_world_size(),
-        overlap_p2p_comm=overlap_p2p_comm,
-        batch_p2p_comm=batch_p2p_comm,
-        pipeline_dtype=dtype,
-        params_dtype=dtype,
-        sequence_parallel=mpu.get_tensor_model_parallel_world_size() > 1,
-        variable_seq_lengths=True,
-        masked_softmax_fusion=True,
-        moe_token_dispatcher_type="alltoall",
-        attention_dropout=hf_config.attention_dropout,
-        hidden_dropout=getattr(hf_config, "hidden_dropout", 0.0),
         add_qkv_bias=qkv_bias,
-        bf16=dtype is torch.bfloat16,
     )
 
-    return transformer_config
-
-
 def hf_to_mcore_config_qwen2moe(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
-    from megatron.core import parallel_state as mpu
-
-    overlap_p2p_comm = mpu.get_virtual_pipeline_model_parallel_world_size() is not None and mpu.get_virtual_pipeline_model_parallel_world_size() > 1
-    batch_p2p_comm = False
-    transformer_config = TransformerConfig(
-        num_layers=hf_config.num_hidden_layers,
-        hidden_size=hf_config.hidden_size,
-        num_attention_heads=hf_config.num_attention_heads,
-        num_query_groups=hf_config.num_key_value_heads,
-        attention_dropout=hf_config.attention_dropout,
-        hidden_dropout=getattr(hf_config, "hidden_dropout", 0.0),
-        activation_func=F.silu,
-        normalization="RMSNorm",
-        gated_linear_unit=True,
+    return _get_base_transformer_config(
+        hf_config=hf_config,
+        dtype=dtype,
         use_cpu_initialization=False,
         add_bias_linear=False,
-        pipeline_dtype=dtype,
-        params_dtype=dtype,
-        variable_seq_lengths=True,
-        masked_softmax_fusion=True,
-        bf16=dtype is torch.bfloat16,
         layernorm_epsilon=hf_config.rms_norm_eps,
-        ffn_hidden_size=hf_config.intermediate_size,
-        # parallel config
-        tensor_model_parallel_size=mpu.get_tensor_model_parallel_world_size(),
-        pipeline_model_parallel_size=mpu.get_pipeline_model_parallel_world_size(),
-        virtual_pipeline_model_parallel_size=mpu.get_virtual_pipeline_model_parallel_world_size(),
-        context_parallel_size=mpu.get_context_parallel_world_size(),
-        overlap_p2p_comm=overlap_p2p_comm,
-        batch_p2p_comm=batch_p2p_comm,
-        sequence_parallel=mpu.get_tensor_model_parallel_world_size() > 1,
-        # moe specific
+        # MoE specific
         moe_ffn_hidden_size=hf_config.moe_intermediate_size,
-        moe_token_dispatcher_type="alltoall",
         moe_router_bias_update_rate=0.001,
         moe_router_topk=hf_config.num_experts_per_tok,
         num_moe_experts=hf_config.num_experts,
@@ -103,26 +115,47 @@ def hf_to_mcore_config_qwen2moe(hf_config: PretrainedConfig, dtype: torch.dtype)
         # moe_aux_loss_coeff=0.0,
         moe_router_load_balancing_type="aux_loss",
         moe_shared_expert_overlap=True,
-        # moe_permute_fusion=True, # need TE 2.1+
         moe_grouped_gemm=True,
         moe_router_score_function="softmax",
-        # # mcore 0.12 moe
-        # moe_router_dtype="fp64",
-        # disable_bf16_reduced_precision_matmul=True,
-        # other
-        # deallocate_pipeline_outputs=True,
-        # gradient_accumulation_fusion=True,
+        # Other optimizations
         persist_layer_norm=True,
         bias_activation_fusion=True,
         bias_dropout_fusion=True,
-        # qwen specific
+        # Qwen specific
         moe_router_pre_softmax=True,
         add_qkv_bias=True,
     )
-    return transformer_config
 
 
-def hf_to_mcore_config_dpskv3(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
+def hf_to_mcore_config_mixtral(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
+    return _get_base_transformer_config(
+        hf_config=hf_config,
+        dtype=dtype,
+        use_cpu_initialization=False,
+        add_bias_linear=False,
+        layernorm_epsilon=hf_config.rms_norm_eps,
+        # MoE specific
+        num_moe_experts=hf_config.num_local_experts,
+        moe_aux_loss_coeff=hf_config.router_aux_loss_coef,
+        moe_router_topk=hf_config.num_experts_per_tok,
+        moe_router_pre_softmax=True,
+        moe_token_dispatcher_type="alltoall",
+        moe_router_load_balancing_type="aux_loss",
+        moe_router_score_function="softmax",
+        moe_shared_expert_intermediate_size=None,  # mixtral has no shared expert
+        moe_shared_expert_overlap=False,  # mixtral has no shared expert
+        moe_ffn_hidden_size=hf_config.intermediate_size,
+        moe_router_bias_update_rate=0.001,
+        # moe_permute_fusion=True, # need TE 2.1+
+        moe_grouped_gemm=True,
+        # Other optimizations
+        persist_layer_norm=True,
+        apply_rope_fusion=True,
+        bias_activation_fusion=True,
+        bias_dropout_fusion=True,
+    )
+
+def hf_to_mcore_config_dpskv3(hf_config: PretrainedConfig, dtype: torch.dtype) -> MLATransformerConfig:
     # DeepseekV3ForCausalLM
     raise NotImplementedError("DeepseekV3ForCausalLM is not supported yet")
 

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -1,5 +1,6 @@
 # Copyright 2025 Bytedance Ltd. and/or its affiliates
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +18,10 @@ from verl.utils.megatron_utils import unwrap_model
 
 from .util import postprocess_packed_seqs, preprocess_packed_seqs, recover_left_padding, remove_left_padding
 
-
-def gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model=False, pack_seqs=True):
+def gptmodel_forward(
+    model, input_ids, attention_mask, position_ids, sequence_parallel, value_model=False, pack_seqs=True
+):
+    """Default forward pass for GPT models with optional sequence packing."""
     pre_process = unwrap_model(model).pre_process
     post_process = unwrap_model(model).post_process
     if pack_seqs:
@@ -31,29 +34,23 @@ def gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, seque
             position_ids=position_ids,
             packed_seq_params=packed_seq_params,
         )
-
-        output = postprocess_packed_seqs(output_orig, packed_seq_params, attention_mask, batch_size, seq_len, post_process=post_process)
+        
+        output = postprocess_packed_seqs(
+            output_orig, packed_seq_params, attention_mask, batch_size, seq_len, post_process=post_process
+        )
     else:
         batch_size, sequence_length = attention_mask.shape
-        new_input_ids, new_attention_mask, new_position_ids = remove_left_padding(input_ids, attention_mask, position_ids, sequence_parallel, pre_process=pre_process)
+        new_input_ids, new_attention_mask, new_position_ids = remove_left_padding(
+            input_ids, attention_mask, position_ids, sequence_parallel, pre_process=pre_process
+        )
         output = model(input_ids=new_input_ids, attention_mask=new_attention_mask, position_ids=new_position_ids)
-        output = recover_left_padding(output, new_attention_mask, attention_mask, sequence_length, post_process=post_process)
+        output = recover_left_padding(
+            output, new_attention_mask, attention_mask, sequence_length, post_process=post_process
+        )
     if value_model and post_process:
         output = output[..., 0]
     return output
 
-
-def gptmodel_forward_qwen2_moe(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model=False, pack_seqs=True):
-    return gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model, pack_seqs)
-
-
-def gptmodel_forward_llama4(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model=False, pack_seqs=True):
-    return gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model, pack_seqs)
-
-
-def gptmodel_forward_dpskv3(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model=False, pack_seqs=True):
-    return gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model, pack_seqs)
-
-
-def gptmodel_forward_qwen2_5_vl(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model=False, pack_seqs=True):
+def gptmodel_forward_qwen2_5_vl(*args, **kwargs):
+    """Forward pass for Qwen2.5 VL model (not implemented)."""
     raise NotImplementedError("VLM is not supported yet")

--- a/verl/models/mcore/model_initializer.py
+++ b/verl/models/mcore/model_initializer.py
@@ -1,5 +1,6 @@
 # Copyright 2025 Bytedance Ltd. and/or its affiliates
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,132 +15,114 @@
 # limitations under the License.
 
 # use mcore transformer config to initialize the model
+from abc import ABC, abstractmethod
+from typing import Optional, Callable, Any
 
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
+from .config_converter import PretrainedConfig, TransformerConfig
 
-def init_mcore_model_dense(
-    tfconfig,
-    hf_config,
-    pre_process=None,
-    post_process=None,
-    share_embeddings_and_output_weights=False,
-    value=False,
-    **extra_kwargs,
-):
-    # for LlamaForCausalLM, Qwen2ForCausalLM
-    from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
-    from megatron.core.models.gpt.gpt_model import GPTModel
+class BaseModelInitializer(ABC):
+    """Base class for model initializers."""
+    
+    def __init__(self, tfconfig: TransformerConfig, hf_config: PretrainedConfig):
+        self.tfconfig = tfconfig
+        self.hf_config = hf_config
+        
+    @abstractmethod
+    def get_transformer_layer_spec(self):
+        """Get the transformer layer specification."""
+        pass
+        
+    def get_rope_scaling_args(self):
+        rope_scaling_args = {}
+        if "rope_scaling" in self.hf_config:
+            if self.hf_config.rope_scaling is not None:
+                assert self.hf_config.rope_scaling["type"] == "linear", "only linear scaling is supported for now"
+                rope_scaling_args["seq_len_interpolation_factor"] = self.hf_config.rope_scaling["factor"]
+        return rope_scaling_args
 
-    use_te = True
-    assert tfconfig.normalization == "RMSNorm", "only RMSNorm is supported for now"
-    transformer_layer_spec = get_gpt_decoder_block_spec(tfconfig, use_transformer_engine=use_te)
-    rope_scaling_args = {}
-    if hf_config.rope_scaling is not None:
-        assert hf_config.rope_scaling["type"] == "linear", "only linear scaling is supported for now"
-        rope_scaling_args["seq_len_interpolation_factor"] = hf_config.rope_scaling["factor"]
-    model = GPTModel(
-        config=tfconfig,
-        transformer_layer_spec=transformer_layer_spec,
-        vocab_size=hf_config.vocab_size,
-        max_sequence_length=hf_config.max_position_embeddings,
-        pre_process=pre_process,
-        post_process=post_process,
-        share_embeddings_and_output_weights=share_embeddings_and_output_weights,
-        position_embedding_type="rope",
-        rotary_base=hf_config.rope_theta,
-        **rope_scaling_args,
-    )
-    if post_process and value:
-        from verl.models.llama.megatron.layers.parallel_linear import LinearForLastLayer
+    def initialize(
+        self,
+        pre_process: Optional[Callable] = None,
+        post_process: Optional[Callable] = None,
+        share_embeddings_and_output_weights: bool = False,
+        value: bool = False,
+        **extra_kwargs,
+    ) -> GPTModel:
+        """Initialize the model with the given configuration."""
+        transformer_layer_spec = self.get_transformer_layer_spec()
+        rope_scaling_args = self.get_rope_scaling_args()
+        
+        model = GPTModel(
+            config=self.tfconfig,
+            transformer_layer_spec=transformer_layer_spec,
+            vocab_size=self.hf_config.vocab_size,
+            max_sequence_length=self.hf_config.max_position_embeddings,
+            pre_process=pre_process,
+            post_process=post_process,
+            share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+            position_embedding_type="rope",
+            rotary_base=self.hf_config.rope_theta,
+            **rope_scaling_args,
+        )
+        
+        if post_process and value:
+            from verl.models.llama.megatron.layers.parallel_linear import LinearForLastLayer
+            model.output_layer = LinearForLastLayer(
+                input_size=self.tfconfig.hidden_size,
+                output_size=1,
+                config=self.tfconfig
+            )
+            
+        return model
 
-        model.output_layer = LinearForLastLayer(input_size=tfconfig.hidden_size, output_size=1, config=tfconfig)
-    return model
-
-
-def init_mcore_model_qwen2_moe(
-    tfconfig,
-    hf_config,
-    pre_process=None,
-    post_process=None,
-    share_embeddings_and_output_weights=False,
-    value=False,
-    freeze_moe_router=True,
-    **extra_kwargs,
-):
-    from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
-    from megatron.core.models.gpt.gpt_model import GPTModel
-
-    use_te = True
-    if freeze_moe_router:
-        tfconfig.moe_router_load_balancing_type = "none"
-
-    def patch_layer_spec(transformer_layer_spec):
-        # shared_experts.gate=True
+class DenseModel(BaseModelInitializer):
+    """Initializer for dense models like Llama and Qwen2."""
+    
+    def get_transformer_layer_spec(self):
+        assert self.tfconfig.normalization == "RMSNorm", "only RMSNorm is supported for now"
+        return get_gpt_decoder_block_spec(self.tfconfig, use_transformer_engine=True)
+        
+class Qwen2MoEModel(BaseModelInitializer):
+    """Initializer for Qwen2 MoE models."""
+    
+    def get_transformer_layer_spec(self):
+        assert self.tfconfig.normalization == "RMSNorm", "only RMSNorm is supported for now"
+        transformer_layer_spec = get_gpt_decoder_block_spec(self.tfconfig, use_transformer_engine=True)
+        
+        # Patch layer spec for shared experts
         for i in range(len(transformer_layer_spec.layer_specs)):
             transformer_layer_spec.layer_specs[i].submodules.mlp.submodules.shared_experts.params["gate"] = True
+            
         return transformer_layer_spec
+    
+    def initialize(self, freeze_moe_router: bool = True, **kwargs):
+        # Qwen default freeze_moe_router: true
+        model = super().initialize(**kwargs)
+        if freeze_moe_router:
+            for layer in model.decoder.layers:
+                layer.mlp.router.weight.requires_grad = False
+                layer.mlp.shared_experts.gate_weight.requires_grad = False
+        return model
 
-    assert tfconfig.normalization == "RMSNorm", "only RMSNorm is supported for now"
-    transformer_layer_spec = get_gpt_decoder_block_spec(tfconfig, use_transformer_engine=use_te)
-    transformer_layer_spec = patch_layer_spec(transformer_layer_spec)
-    rope_scaling_args = {}
-    if hf_config.rope_scaling is not None:
-        assert hf_config.rope_scaling["type"] == "linear", "only linear scaling is supported for now"
-        rope_scaling_args["seq_len_interpolation_factor"] = hf_config.rope_scaling["factor"]
-    model = GPTModel(
-        config=tfconfig,
-        transformer_layer_spec=transformer_layer_spec,
-        vocab_size=hf_config.vocab_size,
-        max_sequence_length=hf_config.max_position_embeddings,
-        pre_process=pre_process,
-        post_process=post_process,
-        share_embeddings_and_output_weights=share_embeddings_and_output_weights,
-        position_embedding_type="rope",
-        rotary_base=hf_config.rope_theta,
-        **rope_scaling_args,
-    )
-    if freeze_moe_router:
-        for layer in model.decoder.layers:
-            layer.mlp.router.weight.requires_grad = False
-            layer.mlp.shared_experts.gate_weight.requires_grad = False
-    if post_process and value:
-        from verl.models.llama.megatron.layers.parallel_linear import LinearForLastLayer
+class MixtralModel(BaseModelInitializer):
+    """Initializer for Mixtral models."""
+    
+    def get_transformer_layer_spec(self):
+        assert self.tfconfig.normalization == "RMSNorm", "only RMSNorm is supported for now"
+        transformer_layer_spec = get_gpt_decoder_block_spec(self.tfconfig, use_transformer_engine=True)
+        return transformer_layer_spec
+                
+    def initialize(self, freeze_moe_router: bool = False, **kwargs):
+        model = super().initialize(**kwargs)
+        if freeze_moe_router:
+            for layer in model.decoder.layers:
+                layer.mlp.router.weight.requires_grad = False
+        return model
 
-        model.output_layer = LinearForLastLayer(input_size=tfconfig.hidden_size, output_size=1, config=tfconfig)
-    return model
-
-
-def init_mcore_model_llama4(
-    tfconfig,
-    hf_config,
-    pre_process=None,
-    post_process=None,
-    share_embeddings_and_output_weights=False,
-    value=False,
-    **extra_kwargs,
-):
-    return init_mcore_model_dense(tfconfig, hf_config, pre_process, post_process, share_embeddings_and_output_weights, value, **extra_kwargs)
-
-
-def init_mcore_model_dpskv3(
-    tfconfig,
-    hf_config,
-    pre_process=None,
-    post_process=None,
-    share_embeddings_and_output_weights=False,
-    value=False,
-    **extra_kwargs,
-):
-    return init_mcore_model_dense(tfconfig, hf_config, pre_process, post_process, share_embeddings_and_output_weights, value, **extra_kwargs)
-
-
-def init_mcore_model_qwen2_5_vl(
-    tfconfig,
-    hf_config,
-    pre_process=None,
-    post_process=None,
-    share_embeddings_and_output_weights=False,
-    value=False,
-    **extra_kwargs,
-):
-    # Qwen2_5_VLForConditionalGeneration
-    raise NotImplementedError("VLM is not supported yet")
+class Qwen25VLModel(BaseModelInitializer):
+    """Initializer for Qwen2.5 VL models."""
+    
+    def get_transformer_layer_spec(self):
+        raise NotImplementedError("VLM is not supported yet")

--- a/verl/models/mcore/registry.py
+++ b/verl/models/mcore/registry.py
@@ -13,100 +13,160 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Registry module for model architecture components.
+"""
 import torch
 import torch.nn as nn
+from typing import Dict, Type, Callable, Any, Optional, Union
 
 from .config_converter import (
     PretrainedConfig,
     TransformerConfig,
     hf_to_mcore_config_dense,
     hf_to_mcore_config_dpskv3,
+    hf_to_mcore_config_mixtral, 
     hf_to_mcore_config_llama4,
     hf_to_mcore_config_qwen2_5_vl,
     hf_to_mcore_config_qwen2moe,
 )
 from .model_forward import (
-    gptmodel_forward_dense,
-    gptmodel_forward_dpskv3,
-    gptmodel_forward_llama4,
+    gptmodel_forward,
     gptmodel_forward_qwen2_5_vl,
-    gptmodel_forward_qwen2_moe,
 )
 from .model_initializer import (
-    init_mcore_model_dense,
-    init_mcore_model_dpskv3,
-    init_mcore_model_llama4,
-    init_mcore_model_qwen2_5_vl,
-    init_mcore_model_qwen2_moe,
+    BaseModelInitializer,
+    DenseModel,
+    Qwen2MoEModel,
+    MixtralModel,
+    Qwen25VLModel,
 )
-from .weight_converter import McoreToHFWeightConverterDense, McoreToHFWeightConverterQwen2Moe
+from .weight_converter import (
+    McoreToHFWeightConverterDense, 
+    McoreToHFWeightConverterQwen2Moe,
+    McoreToHFWeightConverterMixtral,
+)
 
+# Registry for model configuration converters
+MODEL_CONFIG_CONVERTER_REGISTRY: Dict[str, Callable[[PretrainedConfig, torch.dtype], TransformerConfig]] = {
+    "LlamaForCausalLM": hf_to_mcore_config_dense,
+    "Qwen2ForCausalLM": hf_to_mcore_config_dense,
+    "Qwen2MoeForCausalLM": hf_to_mcore_config_qwen2moe,
+    "DeepseekV3ForCausalLM": hf_to_mcore_config_dpskv3,
+    "MixtralForCausalLM": hf_to_mcore_config_mixtral,
+    "Qwen2_5_VLForConditionalGeneration": hf_to_mcore_config_qwen2_5_vl,
+    "Llama4ForConditionalGeneration": hf_to_mcore_config_llama4,
+}
 
+# Registry for model initializers
+MODEL_INITIALIZER_REGISTRY: Dict[str, Type[BaseModelInitializer]] = {
+    "LlamaForCausalLM": DenseModel,
+    "Qwen2ForCausalLM": DenseModel,
+    "Qwen2MoeForCausalLM": Qwen2MoEModel,
+    "MixtralForCausalLM": MixtralModel,
+    "DeepseekV3ForCausalLM": DenseModel,
+    "Qwen2_5_VLForConditionalGeneration": Qwen25VLModel,
+    "Llama4ForConditionalGeneration": DenseModel,
+}
+
+# Registry for model forward functions
+MODEL_FORWARD_REGISTRY: Dict[str, Callable] = {
+    "LlamaForCausalLM": gptmodel_forward,
+    "Qwen2ForCausalLM": gptmodel_forward,
+    "Qwen2MoeForCausalLM": gptmodel_forward,
+    "MixtralForCausalLM": gptmodel_forward,
+    "DeepseekV3ForCausalLM": gptmodel_forward,
+    "Qwen2_5_VLForConditionalGeneration": gptmodel_forward,
+    "Llama4ForConditionalGeneration": gptmodel_forward,
+}
+
+# Registry for model weight converters
+MODEL_WEIGHT_CONVERTER_REGISTRY: Dict[str, Type] = {
+    "LlamaForCausalLM": McoreToHFWeightConverterDense,
+    "Qwen2ForCausalLM": McoreToHFWeightConverterDense,
+    "Qwen2MoeForCausalLM": McoreToHFWeightConverterQwen2Moe,
+    "MixtralForCausalLM": McoreToHFWeightConverterMixtral,
+}
+
+### Only add model registry above and do not change below 
 def hf_to_mcore_config(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
-    MODEL_CONFIG_CONVERTER_REGISTRY = {
-        "LlamaForCausalLM": hf_to_mcore_config_dense,
-        "Qwen2ForCausalLM": hf_to_mcore_config_dense,
-        "Qwen2MoeForCausalLM": hf_to_mcore_config_qwen2moe,
-        "DeepseekV3ForCausalLM": hf_to_mcore_config_dpskv3,
-        "Qwen2_5_VLForConditionalGeneration": hf_to_mcore_config_qwen2_5_vl,
-        "Llama4ForConditionalGeneration": hf_to_mcore_config_llama4,
-    }
+ 
     assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
     arch = hf_config.architectures[0]
     if arch not in MODEL_CONFIG_CONVERTER_REGISTRY:
-        raise ValueError(f"Model architectures {arch} converter are not supported for now. Supported architectures: {MODEL_CONFIG_CONVERTER_REGISTRY.keys()}")
+        raise ValueError(
+            f"Model architectures {arch} converter are not supported for now. "
+            f"Supported architectures: {MODEL_CONFIG_CONVERTER_REGISTRY.keys()}"
+        )
     return MODEL_CONFIG_CONVERTER_REGISTRY[arch](hf_config, dtype)
 
-
 def init_mcore_model(
-    tfconfig,
-    hf_config,
-    pre_process=None,
-    post_process=None,
-    share_embeddings_and_output_weights=False,
-    value=False,
+    tfconfig: TransformerConfig,
+    hf_config: PretrainedConfig,
+    pre_process: Optional[Callable] = None,
+    post_process: Optional[Callable] = None,
+    *,
+    share_embeddings_and_output_weights: bool = False,
+    value: bool = False,
     **extra_kwargs,  # may be used for vlm and moe
 ) -> nn.Module:
-    MODEL_INITIALIZER_REGISTRY = {
-        "LlamaForCausalLM": init_mcore_model_dense,
-        "Qwen2ForCausalLM": init_mcore_model_dense,
-        "Qwen2MoeForCausalLM": init_mcore_model_qwen2_moe,
-        "DeepseekV3ForCausalLM": init_mcore_model_dpskv3,
-        "Qwen2_5_VLForConditionalGeneration": init_mcore_model_qwen2_5_vl,
-        "Llama4ForConditionalGeneration": init_mcore_model_llama4,
-    }
+    """
+    Initialize a Mcore model.
+    
+    Args:
+        tfconfig: The transformer config.
+        hf_config: The HuggingFace config.
+        pre_process: Optional pre-processing function.
+        post_process: Optional post-processing function.
+        share_embeddings_and_output_weights: Whether to share embeddings and output weights.
+        value: Whether to use value.
+        **extra_kwargs: Additional keyword arguments.
+        
+    Returns:
+        The initialized model.        
+    """
     assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
     arch = hf_config.architectures[0]
     if arch not in MODEL_INITIALIZER_REGISTRY:
-        raise ValueError(f"Model architectures {arch} initializer are not supported for now. Supported architectures: {MODEL_INITIALIZER_REGISTRY.keys()}")
-    return MODEL_INITIALIZER_REGISTRY[arch](tfconfig, hf_config, pre_process, post_process, share_embeddings_and_output_weights, value, **extra_kwargs)
+        raise ValueError(
+            f"Model architectures {arch} initializer are not supported for now. "
+            f"Supported architectures: {MODEL_INITIALIZER_REGISTRY.keys()}"
+        )
+    
+    initializer_cls = MODEL_INITIALIZER_REGISTRY[arch]
+    initializer = initializer_cls(tfconfig, hf_config)
+    
+    return initializer.initialize(
+        pre_process=pre_process,
+        post_process=post_process,
+        share_embeddings_and_output_weights=share_embeddings_and_output_weights,
+        value=value,
+        **extra_kwargs
+    )
 
-
-def get_mcore_forward_fn(hf_config: PretrainedConfig):
-    MODEL_FORWARD_REGISTRY = {
-        "LlamaForCausalLM": gptmodel_forward_dense,
-        "Qwen2ForCausalLM": gptmodel_forward_dense,
-        "Qwen2MoeForCausalLM": gptmodel_forward_qwen2_moe,
-        "DeepseekV3ForCausalLM": gptmodel_forward_dpskv3,
-        "Qwen2_5_VLForConditionalGeneration": gptmodel_forward_qwen2_5_vl,
-        "Llama4ForConditionalGeneration": gptmodel_forward_llama4,
-    }
+def get_mcore_forward_fn(hf_config: PretrainedConfig) -> Callable:
+    """
+    Get the forward function for given model architecture.
+    """
     assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
     arch = hf_config.architectures[0]
     if arch not in MODEL_FORWARD_REGISTRY:
-        raise ValueError(f"Model architectures {arch} forward function are not supported for now. Supported architectures: {MODEL_FORWARD_REGISTRY.keys()}")
+        raise ValueError(
+            f"Model architectures {arch} forward function are not supported for now. "
+            f"Supported architectures: {MODEL_FORWARD_REGISTRY.keys()}"
+        )
     return MODEL_FORWARD_REGISTRY[arch]
 
-
-def get_mcore_weight_converter(hf_config: PretrainedConfig, dtype: torch.dtype):
-    MODEL_WEIGHT_CONVERTER_REGISTRY = {
-        "LlamaForCausalLM": McoreToHFWeightConverterDense,
-        "Qwen2ForCausalLM": McoreToHFWeightConverterDense,
-        "Qwen2MoeForCausalLM": McoreToHFWeightConverterQwen2Moe,
-    }
+def get_mcore_weight_converter(hf_config: PretrainedConfig, dtype: torch.dtype) -> Any:
+    """
+    Get the weight converter for given model architecture.
+    """
     assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
     arch = hf_config.architectures[0]
     if arch not in MODEL_WEIGHT_CONVERTER_REGISTRY:
-        raise ValueError(f"Model architectures {arch} weight converter are not supported for now. Supported architectures: {MODEL_WEIGHT_CONVERTER_REGISTRY.keys()}")
+        raise ValueError(
+            f"Model architectures {arch} weight converter are not supported for now. "
+            f"Supported architectures: {MODEL_WEIGHT_CONVERTER_REGISTRY.keys()}"
+        )
     tfconfig = hf_to_mcore_config(hf_config, dtype)
     return MODEL_WEIGHT_CONVERTER_REGISTRY[arch](hf_config, tfconfig)

--- a/verl/models/mcore/saver.py
+++ b/verl/models/mcore/saver.py
@@ -25,7 +25,9 @@ from torch.nn.parallel import DistributedDataParallel as torchDDP
 from verl.utils.megatron_utils import print_rank_0, unwrap_model
 
 
-def _megatron_calc_global_rank(tp_rank: int = 0, dp_rank: int = 0, pp_rank: int = 0, cp_rank: int = 0, ep_rank: int = 0):
+def _megatron_calc_global_rank(
+    tp_rank: int = 0, dp_rank: int = 0, pp_rank: int = 0, cp_rank: int = 0, ep_rank: int = 0
+):
     """Calculate global rank with support for CP/EP parallelism"""
 
     # Get parallel sizes for each dimension
@@ -37,7 +39,9 @@ def _megatron_calc_global_rank(tp_rank: int = 0, dp_rank: int = 0, pp_rank: int 
 
     # Verify total GPU count matches (must be consistent with parallel_state.py)
     total_size = tp_size * dp_size * pp_size * cp_size
-    assert total_size == torch.distributed.get_world_size(), f"{tp_size}x{dp_size}x{pp_size}x{cp_size} != {torch.distributed.get_world_size()}"
+    assert total_size == torch.distributed.get_world_size(), (
+        f"{tp_size}x{dp_size}x{pp_size}x{cp_size} != {torch.distributed.get_world_size()}"
+    )
 
     # Core calculation logic (corresponds to RankGenerator order parameter)
     # Assumes default order is "tp-cp-ep-dp-pp"
@@ -62,7 +66,9 @@ def _megatron_calc_layer_map(config):
 
     for pp_rank_idx in range(pp_size):
         for virtual_pp_rank_idx in range(virtual_pp_size):
-            layer_offset = virtual_pp_rank_idx * (config.num_hidden_layers // virtual_pp_size) + pp_rank_idx * num_layers_per_model
+            layer_offset = (
+                virtual_pp_rank_idx * (config.num_hidden_layers // virtual_pp_size) + pp_rank_idx * num_layers_per_model
+            )
             for layer_idx in range(num_layers_per_model):
                 layer_map[layer_offset + layer_idx] = (
                     pp_rank_idx,
@@ -115,7 +121,11 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
 
     for i, wrapped_model in enumerate(wrapped_models):
         models[i] = unwrap_model(wrapped_model, (torchDDP, LocalDDP, Float16Module))
-        assert len(models[i].decoder.layers) == num_layers_per_model, "len model layers {} not equal to num_layers_per_model {}".format(len(models[i].decoder.layers), num_layers_per_model)
+        assert len(models[i].decoder.layers) == num_layers_per_model, (
+            "len model layers {} not equal to num_layers_per_model {}".format(
+                len(models[i].decoder.layers), num_layers_per_model
+            )
+        )
 
     state_dict = dict()
 
@@ -376,7 +386,10 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
                 src_pp_rank=src_pp_rank,
             )
 
-            if getattr(sync_layer.self_attention.linear_qkv, "bias", None) is not None and sync_layer.self_attention.linear_qkv.bias.numel() > 0:
+            if (
+                getattr(sync_layer.self_attention.linear_qkv, "bias", None) is not None
+                and sync_layer.self_attention.linear_qkv.bias.numel() > 0
+            ):
                 _broadcast_tp_shard_tensor_qkv(
                     sync_layer.self_attention.linear_qkv.bias,
                     f"{layer_name}.self_attn.q_proj.bias",
@@ -451,5 +464,14 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
     return state_dict
 
 
-def merge_megatron_ckpt_gptmodel_qwen_moe(wrapped_models, config, dtype, is_value_model=False, tie_word_embeddings=False):
+def merge_megatron_ckpt_gptmodel_qwen_moe(
+    wrapped_models, config, dtype, is_value_model=False, tie_word_embeddings=False
+):
     raise NotImplementedError("merge_megatron_ckpt_gptmodel_qwen_moe is not implemented")
+
+
+def merge_megatron_ckpt_gptmodel_mixtral(
+        wrapped_models, config, dtype, is_value_model=False, tie_word_embeddings=False
+):
+    raise NotImplementedError("merge_megatron_ckpt_gptmodel_mixtral is not implemented")
+   

--- a/verl/models/mcore/weight_converter.py
+++ b/verl/models/mcore/weight_converter.py
@@ -1,5 +1,6 @@
 # Copyright 2025 Bytedance Ltd. and/or its affiliates
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +21,6 @@ import torch
 from megatron.core.transformer import TransformerConfig
 from transformers import PretrainedConfig
 
-
 class McoreToHFWeightConverterBase:
     def __init__(self, hf_config: PretrainedConfig, mcore_config: TransformerConfig):
         self.hf_config = hf_config
@@ -28,7 +28,6 @@ class McoreToHFWeightConverterBase:
 
     def convert_param(self, name: str, params_one_group: list[torch.Tensor]) -> torch.Tensor:
         raise NotImplementedError
-
 
 class McoreToHFWeightConverterDense(McoreToHFWeightConverterBase):
     def _convert_attention_param(self, name: str, params: list[torch.Tensor]) -> tuple[list[str], list[torch.Tensor]]:
@@ -135,6 +134,30 @@ class McoreToHFWeightConverterQwen2Moe(McoreToHFWeightConverterDense):
             expert_id = name.split("weight")[-1]
             convert_names.append(f"model.layers.{layer_number}.mlp.experts.{expert_id}.down_proj.weight")
             assert len(params) == 1
+        else:
+            raise NotImplementedError(f"Unsupported parameter name: {name}")
+        return convert_names, params
+
+class McoreToHFWeightConverterMixtral(McoreToHFWeightConverterDense):
+
+    def _convert_mlp_param(self, name: str, params: list[torch.Tensor]) -> tuple[list[str], list[torch.Tensor]]:
+        # decoder.layers.0.mlp.router.weight
+        # decoder.layers.0.mlp.experts.linear_fc1.weight0 - weight7
+        # decoder.layers.0.mlp.experts.linear_fc2.weight0 - weight7
+
+        layer_number = name.split(".")[2]
+        convert_names = []
+        if "pre_mlp_layernorm" in name:
+            convert_names.append(f"model.layers.{layer_number}.post_attention_layernorm.weight")
+        elif "mlp.router.weight" in name:
+            convert_names.append(f"model.layers.{layer_number}.block_sparse_moe.gate.weight")
+        elif "mlp.experts.linear_fc1.weight" in name:  
+            expert_id = name.split("weight")[-1]
+            convert_names.append(f"model.layers.{layer_number}.block_sparse_moe.experts.{expert_id}.w1.weight")
+            convert_names.append(f"model.layers.{layer_number}.block_sparse_moe.experts.{expert_id}.w3.weight")
+        elif "mlp.experts.linear_fc2.weight" in name:
+            expert_id = name.split("weight")[-1]
+            convert_names.append(f"model.layers.{layer_number}.block_sparse_moe.experts.{expert_id}.w2.weight")
         else:
             raise NotImplementedError(f"Unsupported parameter name: {name}")
         return convert_names, params

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -87,6 +87,7 @@ actor_rollout_ref:
       contents: ['model', 'optimizer', 'extra']  # with 'hf_model' you can save whole model as hf format, now only use sharded model checkpoint to save space
   ref:
     strategy: megatron
+    use_torch_compile: ${actor_rollout_ref.actor.use_torch_compile}
     megatron:
       param_offload: False
       tensor_model_parallel_size: 1

--- a/verl/utils/vllm_utils.py
+++ b/verl/utils/vllm_utils.py
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from vllm.model_executor.models.deepseek_v2 import (DeepseekV2ForCausalLM,
-                                                    DeepseekV3ForCausalLM)
-from vllm.model_executor.models.qwen2_moe import Qwen2MoeForCausalLM
-
-model_types = [Qwen2MoeForCausalLM, DeepseekV2ForCausalLM, DeepseekV3ForCausalLM]
-
-try:
-    from vllm.model_executor.models.qwen3_moe import Qwen3MoeForCausalLM
-    model_types.append(Qwen3MoeForCausalLM)
-except ImportError:
-    pass
-
 def patch_vllm_moe_model_weight_loader(model):
     # this is a work around to load the weight of vllm fused moe model
     # it is from a bug from vllm 0.8.2
@@ -42,11 +29,28 @@ def patch_vllm_moe_model_weight_loader(model):
     # (False, 'model.layers.0.post_attention_layernorm.weight') use default
     # (False, 'model.layers.0.mlp.experts.w13_weight')          use mlp.experts.weight_loader
     # (False, 'model.layers.0.mlp.experts.w2_weight')          use mlp.experts.weight_loader
- 
-    if not isinstance(model, tuple(model_types)):
+    from vllm.model_executor.models.deepseek_v2 import (DeepseekV2ForCausalLM,
+                                                        DeepseekV3ForCausalLM)
+    from vllm.model_executor.models.qwen2_moe import Qwen2MoeForCausalLM
+    from vllm.model_executor.models.mixtral import MixtralForCausalLM
+
+    SUPPORTED_MOE_MODELS = (Qwen2MoeForCausalLM, DeepseekV2ForCausalLM, DeepseekV3ForCausalLM, MixtralForCausalLM)
+    
+    # Define MLP attribute mapping for different model types
+    MLP_ATTR_MAPPING = {
+        MixtralForCausalLM: 'block_sparse_moe',
+    }
+    
+    # Default MLP attribute name for models not in the mapping
+    DEFAULT_MLP_ATTR = 'mlp'
+
+    if not isinstance(model, SUPPORTED_MOE_MODELS):
         return
+
     for layer in model.model.layers:
-        mlp = layer.mlp
+        mlp_attr = MLP_ATTR_MAPPING.get(type(model), DEFAULT_MLP_ATTR)
+        mlp = getattr(layer, mlp_attr)
+
         param_dict = dict(mlp.named_parameters())
         for name, param in param_dict.items():
             if "w13_weight" in name or "w2_weight" in name:


### PR DESCRIPTION
# What does this PR do?

Add support of Mixtral MOE model training with Megatron backend including ``Mixtral8x7B`` and ``Mixtral8X22B``. 

# ChangeLog:

It is still labor-heavy to add new type of model to ``mcore`` format including the following changes:
- ``hf_to_mcore_config_mixtral``: convert `hf_config` to `TransformerConfig`. some common configs are merged into one function `_get_base_transformer_config`. 
- ``MixtralModel`` in model_initialzier.py: implement a model initializer class to initialize GPTModel from config.
- `McoreToHFWeightConverterMixtral`:  model conversion class from mcore to huggingface basically rename
- model entry in `registry.py`: add entry function or class in corresponding registries.  

# Usage

- convert [Mixtral-8x7B-Instruct-v0.1](https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1/) to mcore format ([converted](https://huggingface.co/clyu/Mixtral-8x7B-Instruct-v0.1-mcore/tree/main))
- Run RLOO script as follows:

```bash
set -x

train_files=$gsm8k_train_path
test_files=$gsm8k_test_path

export MEGATRON_MODEL="Mixtral-8x7B-Instruct-v0.1-mcore"

python3 -m verl.trainer.main_ppo --config-path=./config --config-name='ppo_megatron_trainer' \
    algorithm.adv_estimator=rloo \
    data.train_files=$train_files \
    data.val_files=$test_files \
    data.train_batch_size=128 \
    data.truncation="left" \
    data.max_prompt_length=512 \
    data.max_response_length=4096 \
    actor_rollout_ref.model.path=Mixtral-8x7B-Instruct-v0.1 \
    actor_rollout_ref.actor.optim.lr=1e-6 \
    actor_rollout_ref.actor.use_kl_loss=True \
    actor_rollout_ref.actor.ppo_mini_batch_size=128 \
    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=8 \
    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=8 \
    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=2 \
    actor_rollout_ref.actor.megatron.use_dist_checkpointing=True \
    actor_rollout_ref.actor.megatron.dist_checkpointing_path=${MEGATRON_MODEL} \
    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
    actor_rollout_ref.rollout.tensor_model_parallel_size=8 \
    actor_rollout_ref.rollout.max_num_batched_tokens=8192 \
    actor_rollout_ref.rollout.name=vllm \
    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
    actor_rollout_ref.rollout.n=4 \
    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=128 \
    actor_rollout_ref.ref.megatron.tensor_model_parallel_size=8 \
    actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=2 \
    actor_rollout_ref.ref.megatron.use_dist_checkpointing=True \
    actor_rollout_ref.ref.megatron.dist_checkpointing_path=${MEGATRON_MODEL} \
    algorithm.use_kl_in_reward=True \
    algorithm.kl_ctrl.kl_coef=0.001 \
    trainer.critic_warmup=0 \
    trainer.val_before_train=True \
    trainer.logger=['console','wandb'] \
    trainer.log_val_generations=100 \
    trainer.project_name='verl_gsm8k_test' \
    trainer.experiment_name='mixtral-8x7b-rloo-gsm8k' \
    trainer.n_gpus_per_node=8 \
    trainer.nnodes=2 \
    trainer.save_freq=50 \
    trainer.test_freq=10 \
    trainer.total_epochs=15
```
- RLOO training can improve GSM8K validation accuracy from 74% to 85%

# What is Missing

- refactor hf2mcore conversion scripts as https://github.com/volcengine/verl/pull/1267
- Have a good design of onboarding new model class to avoid labor-intension changes.  


## Before submitting

- [x] Did you read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide) and finish the [code format check](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting)? 
- [x] Did you make sure to update the documentations with your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs) especially for breaking config etc?
- [ ] Did you write any test cases if necessary? Please add CI tests to your new feature.  

# Additional Info: 
- **Issue Number**: None
- **Training**:  Megatron
- **Inference**:  None
