### PR TITLE
[doc] fix dataset path for gsm8k

### DIFF
--- a/examples/sglang_multiturn/readme.md
+++ b/examples/sglang_multiturn/readme.md
@@ -8,7 +8,7 @@ This example demonstrates how to perform **multi-turn rollout** using SGLang wit
 ### Step 1: Download GSM8K Dataset
 
 ```bash
-cd examples/sglang_multiturn
+cd examples/data_preprocess
 python3 gsm8k.py
 ```
 


### PR DESCRIPTION
# What does this PR do?

fix dataset path for gsm8k

# ChangeLog:

change the readme file to fix gsm8k download path.

# Usage

- You can add one use example below.

```python
# Add code snippet or script demonstrating how to use this 
```
- For algorithm implementation and new model support, you can add training curve plots and evaluatuion results below. 

## Before submitting

- [ ] Did you read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide) and finish the [code format check](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting)? 
- [ ] Did you make sure to update the documentations with your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs) especially for breaking config etc?
- [ ] Did you write any test cases if neccessary? Please add CI tests to your new feature.  

# Additional Info: 
- **Issue Number**: Fixes issue # or discussion # if any. 
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]
