### PR TITLE
[test] fix: test arithmetic_sequence failed to run

### DIFF
--- a/tests/e2e/arithmetic_sequence/rl/README.md
+++ b/tests/e2e/arithmetic_sequence/rl/README.md
@@ -14,7 +14,7 @@ The response should be [4, 5, 6, 7%6, 8%6] = [4, 5, 6, 0, 1].
 
 # Environment definition
 
-The core definition of the task is defined in verl/envs/digit_completion/task.py
+The core definition of the task is defined in tests/e2e/envs/digit_completion/task.py
 
 It is highly recommended to take a look at it for better understanding.
 
@@ -22,16 +22,9 @@ It is highly recommended to take a look at it for better understanding.
 
 # Run experiments
 
-The users are required to specify the config path and config name (and the relative model config path to the current working directory)
+An example of running the task is provided in `tests/e2e/run_ray_trainer.sh`.
 
 ```bash
-# cd examples/arithmetic_sequence/rl
-
-# Specify the config path and config name (current working dir)
-python3 -m verl.trainer.ppo.ray_megatron_train_synchronous --config-path=$(pwd)/config --config-name='ray_megatron'
-
-# The default relative path of model config is 'config/model_config', if you want to change it, you can rewrite it in ray_megatron.yaml or using:
-python3 -m verl.trainer.ppo.ray_megatron_train_synchronous --config-path=$(pwd)/config --config-name='ray_megatron' ++model.base_path=config/model_config
-
+bash tests/e2e/run_ray_trainer.sh
 ```
 

--- a/tests/e2e/arithmetic_sequence/rl/main_trainer.py
+++ b/tests/e2e/arithmetic_sequence/rl/main_trainer.py
@@ -110,6 +110,9 @@ def main(config):
     local_path = copy_to_local(config.actor_rollout_ref.model.path)
     local_path = os.path.expanduser(local_path)
     # instantiate tokenizern
+    from transformers import LlamaConfig
+    from tests.e2e.envs.digit_completion import CharTokenizer
+    AutoTokenizer.register(LlamaConfig, CharTokenizer, exist_ok=True)
     tokenizer = AutoTokenizer.from_pretrained(local_path)
     print(f"Tokenizer vocab_size: {tokenizer.vocab_size}")
 

--- a/tests/e2e/arithmetic_sequence/rl/main_trainer.py
+++ b/tests/e2e/arithmetic_sequence/rl/main_trainer.py
@@ -111,7 +111,9 @@ def main(config):
     local_path = os.path.expanduser(local_path)
     # instantiate tokenizern
     from transformers import LlamaConfig
+
     from tests.e2e.envs.digit_completion import CharTokenizer
+
     AutoTokenizer.register(LlamaConfig, CharTokenizer, exist_ok=True)
     tokenizer = AutoTokenizer.from_pretrained(local_path)
     print(f"Tokenizer vocab_size: {tokenizer.vocab_size}")

--- a/verl/utils/vllm_utils.py
+++ b/verl/utils/vllm_utils.py
@@ -13,17 +13,18 @@
 # limitations under the License.
 
 
-from vllm.model_executor.models.deepseek_v2 import (DeepseekV2ForCausalLM,
-                                                    DeepseekV3ForCausalLM)
+from vllm.model_executor.models.deepseek_v2 import DeepseekV2ForCausalLM, DeepseekV3ForCausalLM
 from vllm.model_executor.models.qwen2_moe import Qwen2MoeForCausalLM
 
 model_types = [Qwen2MoeForCausalLM, DeepseekV2ForCausalLM, DeepseekV3ForCausalLM]
 
 try:
     from vllm.model_executor.models.qwen3_moe import Qwen3MoeForCausalLM
+
     model_types.append(Qwen3MoeForCausalLM)
 except ImportError:
     pass
+
 
 def patch_vllm_moe_model_weight_loader(model):
     # this is a work around to load the weight of vllm fused moe model
@@ -42,7 +43,7 @@ def patch_vllm_moe_model_weight_loader(model):
     # (False, 'model.layers.0.post_attention_layernorm.weight') use default
     # (False, 'model.layers.0.mlp.experts.w13_weight')          use mlp.experts.weight_loader
     # (False, 'model.layers.0.mlp.experts.w2_weight')          use mlp.experts.weight_loader
- 
+
     if not isinstance(model, tuple(model_types)):
         return
     for layer in model.model.layers:


### PR DESCRIPTION
# What does this PR do?

e2e test `arithmetic_sequence` is currently broken, with error `TypeError: not a string` thrown on code `tokenizer = AutoTokenizer.from_pretrained(local_path)` when running `tests/e2e/run_ray_trainer.sh`. This PR aims to fix it.

In the `arithmetic_sequence` task, `tests.e2e.envs.digit_completion` module was imported in the beginning but not used. This import seems meaningless. However, when this library is imported, `AutoTokenizer.register()` will be called to set configurations for `AutoTokenizer`. Only after that can `AutoTokenizer` be successfully initialized in test code to perform subsequent tasks.

## Timeline

- In #934 , to improve CI efficiency, the CI corresponding to `arithmetic_sequence` was removed.
- In #1010 , according to the `unused_import` rule, this import was deleted, triggering the bug.

# ChangeLog

- `AutoTokenizer.register` was added explicitly, which ensures the configurations were set before initialization of `AutoTokenizer`.


# Usage

- the original code `tests/e2e/run_ray_trainer.sh` is available for tests.

```python
bash tests/e2e/run_ray_trainer.sh
``` 

## Before submitting

- [x] Did you read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide) and finish the [code format check](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting)? 
- [x] Did you make sure to update the documentations with your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs) especially for breaking config etc?
- [x] Did you write any test cases if neccessary? Please add CI tests to your new feature.  

# Additional Info: 
- **Issue Number**: none
- **Training**: none
- **Inference**: none
