### PR TITLE
[megatron] qwen3 support

### DIFF
--- a/verl/models/mcore/loader.py
+++ b/verl/models/mcore/loader.py
@@ -382,6 +382,16 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
                 sync_layer.self_attention.linear_qkv.layer_norm_weight if dst_pp_rank == pp_rank else None,
                 f"{layer_name}.input_layernorm.weight",
             )
+     
+            if f"{layer_name}.self_attn.q_norm.weight" in state_dict:
+                _broadcast_tensor(
+                    sync_layer.self_attention.q_layernorm.weight if dst_pp_rank == pp_rank else None,
+                    f"{layer_name}.self_attn.q_norm.weight",
+                )
+                _broadcast_tensor(
+                    sync_layer.self_attention.k_layernorm.weight if dst_pp_rank == pp_rank else None,
+                    f"{layer_name}.self_attn.k_norm.weight",
+                )
 
             _broadcast_tp_shard_tensor_qkv(
                 sync_layer.self_attention.linear_qkv.weight if dst_pp_rank == pp_rank else None,

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -47,6 +47,10 @@ def gptmodel_forward_qwen2_moe(model, input_ids, attention_mask, position_ids, s
     return gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model, pack_seqs)
 
 
+def gptmodel_forward_qwen3_moe(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model=False, pack_seqs=True):
+    return gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model, pack_seqs)
+
+
 def gptmodel_forward_llama4(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model=False, pack_seqs=True):
     return gptmodel_forward_dense(model, input_ids, attention_mask, position_ids, sequence_parallel, value_model, pack_seqs)
 

--- a/verl/models/mcore/registry.py
+++ b/verl/models/mcore/registry.py
@@ -24,6 +24,7 @@ from .config_converter import (
     hf_to_mcore_config_llama4,
     hf_to_mcore_config_qwen2_5_vl,
     hf_to_mcore_config_qwen2moe,
+    hf_to_mcore_config_qwen3moe,
 )
 from .model_forward import (
     gptmodel_forward_dense,
@@ -31,6 +32,7 @@ from .model_forward import (
     gptmodel_forward_llama4,
     gptmodel_forward_qwen2_5_vl,
     gptmodel_forward_qwen2_moe,
+    gptmodel_forward_qwen3_moe,
 )
 from .model_initializer import (
     init_mcore_model_dense,
@@ -38,8 +40,13 @@ from .model_initializer import (
     init_mcore_model_llama4,
     init_mcore_model_qwen2_5_vl,
     init_mcore_model_qwen2_moe,
+    init_mcore_model_qwen3_moe,
 )
-from .weight_converter import McoreToHFWeightConverterDense, McoreToHFWeightConverterQwen2Moe
+from .weight_converter import (
+    McoreToHFWeightConverterDense,
+    McoreToHFWeightConverterQwen2Moe,
+    McoreToHFWeightConverterQwen3Moe,
+)
 
 
 def hf_to_mcore_config(hf_config: PretrainedConfig, dtype: torch.dtype) -> TransformerConfig:
@@ -47,6 +54,8 @@ def hf_to_mcore_config(hf_config: PretrainedConfig, dtype: torch.dtype) -> Trans
         "LlamaForCausalLM": hf_to_mcore_config_dense,
         "Qwen2ForCausalLM": hf_to_mcore_config_dense,
         "Qwen2MoeForCausalLM": hf_to_mcore_config_qwen2moe,
+        "Qwen3ForCausalLM": hf_to_mcore_config_dense,
+        "Qwen3MoeForCausalLM": hf_to_mcore_config_qwen3moe,
         "DeepseekV3ForCausalLM": hf_to_mcore_config_dpskv3,
         "Qwen2_5_VLForConditionalGeneration": hf_to_mcore_config_qwen2_5_vl,
         "Llama4ForConditionalGeneration": hf_to_mcore_config_llama4,
@@ -71,6 +80,8 @@ def init_mcore_model(
         "LlamaForCausalLM": init_mcore_model_dense,
         "Qwen2ForCausalLM": init_mcore_model_dense,
         "Qwen2MoeForCausalLM": init_mcore_model_qwen2_moe,
+        "Qwen3ForCausalLM": init_mcore_model_dense,
+        "Qwen3MoeForCausalLM": init_mcore_model_qwen3_moe,
         "DeepseekV3ForCausalLM": init_mcore_model_dpskv3,
         "Qwen2_5_VLForConditionalGeneration": init_mcore_model_qwen2_5_vl,
         "Llama4ForConditionalGeneration": init_mcore_model_llama4,
@@ -87,6 +98,8 @@ def get_mcore_forward_fn(hf_config: PretrainedConfig):
         "LlamaForCausalLM": gptmodel_forward_dense,
         "Qwen2ForCausalLM": gptmodel_forward_dense,
         "Qwen2MoeForCausalLM": gptmodel_forward_qwen2_moe,
+        "Qwen3ForCausalLM": gptmodel_forward_dense,
+        "Qwen3MoeForCausalLM": gptmodel_forward_qwen3_moe,
         "DeepseekV3ForCausalLM": gptmodel_forward_dpskv3,
         "Qwen2_5_VLForConditionalGeneration": gptmodel_forward_qwen2_5_vl,
         "Llama4ForConditionalGeneration": gptmodel_forward_llama4,
@@ -103,6 +116,8 @@ def get_mcore_weight_converter(hf_config: PretrainedConfig, dtype: torch.dtype):
         "LlamaForCausalLM": McoreToHFWeightConverterDense,
         "Qwen2ForCausalLM": McoreToHFWeightConverterDense,
         "Qwen2MoeForCausalLM": McoreToHFWeightConverterQwen2Moe,
+        "Qwen3ForCausalLM": McoreToHFWeightConverterDense,
+        "Qwen3MoeForCausalLM": McoreToHFWeightConverterQwen3Moe,
     }
     assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
     arch = hf_config.architectures[0]

--- a/verl/models/mcore/weight_converter.py
+++ b/verl/models/mcore/weight_converter.py
@@ -51,6 +51,12 @@ class McoreToHFWeightConverterDense(McoreToHFWeightConverterBase):
         elif "self_attention.linear_qkv.layer_norm_weight" in name:
             convert_names.append(f"model.layers.{layer_number}.input_layernorm.weight")
             assert len(params) == 1
+        elif "self_attention.q_layernorm.weight" in name:
+            convert_names.append(f"model.layers.{layer_number}.self_attn.q_norm.weight")
+            assert len(params) == 1
+        elif "self_attention.k_layernorm.weight" in name:
+            convert_names.append(f"model.layers.{layer_number}.self_attn.k_norm.weight")
+            assert len(params) == 1
         else:
             raise NotImplementedError(f"Unsupported parameter name: {name}")
         return convert_names, params
@@ -125,6 +131,42 @@ class McoreToHFWeightConverterQwen2Moe(McoreToHFWeightConverterDense):
             assert len(params) == 2
         elif "shared_experts.linear_fc2.weight" in name:
             convert_names.append(f"model.layers.{layer_number}.mlp.shared_expert.down_proj.weight")
+            assert len(params) == 1
+        elif "mlp.experts.linear_fc1" in name:  # split gate_proj and up_proj
+            expert_id = name.split("weight")[-1]
+            convert_names.append(f"model.layers.{layer_number}.mlp.experts.{expert_id}.gate_proj.weight")
+            convert_names.append(f"model.layers.{layer_number}.mlp.experts.{expert_id}.up_proj.weight")
+            assert len(params) == 2
+        elif "mlp.experts.linear_fc2" in name:
+            expert_id = name.split("weight")[-1]
+            convert_names.append(f"model.layers.{layer_number}.mlp.experts.{expert_id}.down_proj.weight")
+            assert len(params) == 1
+        else:
+            raise NotImplementedError(f"Unsupported parameter name: {name}")
+        return convert_names, params
+
+
+class McoreToHFWeightConverterQwen3Moe(McoreToHFWeightConverterDense):
+    def _convert_mlp_param(self, name: str, params: list[torch.Tensor]) -> tuple[list[str], list[torch.Tensor]]:
+        # qwen3 moe no share expert
+
+        # 'decoder.layers.0.pre_mlp_layernorm.weight',
+        # 'decoder.layers.0.mlp.router.weight',
+        # moe1
+        # 'decoder.layers.0.mlp.experts.linear_fc1.weight0',
+        # 'decoder.layers.0.mlp.experts.linear_fc1.weight1',
+        # 'decoder.layers.0.mlp.experts.linear_fc1.weight2',
+        # 'decoder.layers.0.mlp.experts.linear_fc1.weight3',
+        # moe2
+        # 'decoder.layers.0.mlp.experts.linear_fc2.weight0',
+        # 'decoder.layers.0.mlp.experts.linear_fc2.weight1',
+        layer_number = name.split(".")[2]
+        convert_names = []
+        if "pre_mlp_layernorm" in name:
+            convert_names.append(f"model.layers.{layer_number}.post_attention_layernorm.weight")
+            assert len(params) == 1
+        elif "mlp.router.weight" in name:
+            convert_names.append(f"model.layers.{layer_number}.mlp.gate.weight")
             assert len(params) == 1
         elif "mlp.experts.linear_fc1" in name:  # split gate_proj and up_proj
             expert_id = name.split("weight")[-1]

--- a/verl/models/weight_loader_registry.py
+++ b/verl/models/weight_loader_registry.py
@@ -33,6 +33,8 @@ def get_weight_saver(arch: str):
         "LlamaForCausalLM": merge_megatron_ckpt_gptmodel,
         "Qwen2ForCausalLM": merge_megatron_ckpt_gptmodel,
         "Qwen2MoeForCausalLM": merge_megatron_ckpt_gptmodel_qwen_moe,
+        "Qwen3ForCausalLM": merge_megatron_ckpt_gptmodel,
+        "Qwen3MoeForCausalLM": merge_megatron_ckpt_gptmodel_qwen_moe,
     }
     if arch in _MODEL_WEIGHT_MEGATRON_SAVER_REGISTRY:
         return _MODEL_WEIGHT_MEGATRON_SAVER_REGISTRY[arch]

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -645,7 +645,7 @@ class CriticWorker(MegatronWorker):
         if self._is_offload_param:
             load_megatron_model_to_gpu(self.critic_module)
         if self._is_offload_optimizer:
-            load_megatron_optimizer(optimizer=self.critic_optimizer)
+            load_megatron_optimizer(self.critic_optimizer)
 
         dataloader = self.critic.make_minibatch_iterator(data)
         with Timer(name="update_critic", logger=None) as timer:


### PR DESCRIPTION
# What does this PR do?

support qwen3 to run with megatron-core.
test by:
    dense: Qwen3-8B
    moe: Qwen3-30B-A3B


# Usage

Use scripts/converter_hf_to_mcore.py to convert hf ckpt to mcore ckpt, then run with enable use_dist_checkpointing.

```python
# Add code snippet or script demonstrating how to use this 
```
- For algorithm implementation and new model support, you can add training curve plots and evaluatuion results below. 

## Before submitting

- [ ] Did you read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide) and finish the [code format check](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting)? 
- [ ] Did you make sure to update the documentations with your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs) especially for breaking config etc?
- [ ] Did you write any test cases if neccessary? Please add CI tests to your new feature.  

# Additional Info: 
- **Issue Number**: Fixes issue # or discussion # if any. 
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]
