### PR TITLE
[docs] Fix pip install instructions

### DIFF
--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -61,8 +61,12 @@ See files under ``docker/`` for NGC-based image or if you want to build your own
 
     # install the nightly version (recommended)
     git clone https://github.com/volcengine/verl && cd verl
-    pip3 install -e . [vllm] or pip3 install -e . [sglang]
-    # or install from pypi instead of git via `pip3 install verl[...]`
+    # pick your choice of inference engine: vllm or sglang
+    # pip3 install -e .[vllm]
+    # pip3 install -e .[sglang]
+    # or install from pypi instead of git via:
+    # pip3 install verl[vllm]
+    # pip3 install verl[sglang]
 
 .. note::
     


### PR DESCRIPTION
### Checklist Before Starting

- [X] Search for similar PR(s).

### What does this PR do?

There should be no space between `.` and `[vllm]` or `[sglang]`, or it will result in error:

```logs
ERROR: Invalid requirement: '[vllm]': Expected package name at the start of dependency specifier
    [vllm]
```

In addition, I rewrite this part to make the instructions more clear (as `.. or ..` can't be executed by bash directly)

### Additional Info.

- **Issue Number**: none
- **Training**: none
- **Inference**: none

### Checklist Before Submitting

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [X] Add `[BREAKING]` to the PR title if it breaks any API.
- [X] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add CI test(s) if neccessary.
