### PR TITLE
Fix Arxiv Link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,7 @@
 Welcome to verl's documentation!
 ================================================
 
-.. _hf_arxiv: https://arxiv.org/pdf/2409.19256
-
-verl is a flexible, efficient and production-ready RL training framework designed for large language models (LLMs) post-training. It is an open source implementation of the `HybridFlow <hf_arxiv>`_ paper.
+verl is a flexible, efficient and production-ready RL training framework designed for large language models (LLMs) post-training. It is an open source implementation of the `HybridFlow <https://arxiv.org/pdf/2409.19256>`_ paper.
 
 verl is flexible and easy to use with:
 


### PR DESCRIPTION
Arxiv link is not rendering on github or https://verl.readthedocs.io/en/latest/index.html#

### Checklist Before Starting

- [x ] Search for similar PR(s).

### What does this PR do?

Makes external link to arxiv paper resolve properly.

### High-Level Design

N/A

### Specific Changes

Single line doc change

### API

N/A

### Usage Example

N/A

### Test
N/A
### Additional Info.

### Checklist Before Submitting

All N/A
