### PR TITLE
[fix][ci] fix two pipelines that fails on the main branch

### DIFF
--- a/.github/workflows/dataset.yml
+++ b/.github/workflows/dataset.yml
@@ -58,5 +58,5 @@ jobs:
       #          pytest -s -x tests/verl/utils/dataset/test_rm_dataset.py
       - name: Running ray test using cupy (move it to L20 when dockerfile ready)
         run: |
-          cd tests/ray
+          cd tests/ray_gpu
           pytest -s -x test_rvdz.py

--- a/.github/workflows/ray_cpu_test.yml
+++ b/.github/workflows/ray_cpu_test.yml
@@ -28,13 +28,7 @@ permissions:
 jobs:
   ray_cpu:
     runs-on: ubuntu-latest
-    timeout-minutes: 5 # Increase this timeout value as needed
-    env:
-      HTTP_PROXY: ${{ secrets.PROXY_HTTP }}
-      HTTPS_PROXY: ${{ secrets.PROXY_HTTPS }}
-      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com"
-      HF_ENDPOINT: "https://hf-mirror.com"
-      HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable    
+    timeout-minutes: 10 # Increase this timeout value as needed 
     strategy:
       matrix:
         python-version: ["3.10"]


### PR DESCRIPTION

### What does this PR do?

There are two pipelines fail on the main branch right now, which are `dataset` and `ray_cpu`. This PR tries to recover the two failed ci pipelines.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if neccessary.
