### PR TITLE
WIP [worker] Adding `destroy` API to `WorkerGroup` and `RayWorkerGroup`

### DIFF
--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -229,3 +229,16 @@ class Worker(WorkerHelper):
     def execute_func_rank_zero(self, func, *args, **kwargs):
         result = func(*args, **kwargs)
         return result
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def ready(self):
+        # Whether the worker is ready to be used for computing.
+        # Subclasses can override this method to implement custom readiness checks,
+        # e.g., for additional model initialization
+        return True
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def will_be_destroyed(self):
+        # Method called before destruction, should not block,
+        # used for final resource cleanup and memory release
+        pass

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -229,16 +229,3 @@ class Worker(WorkerHelper):
     def execute_func_rank_zero(self, func, *args, **kwargs):
         result = func(*args, **kwargs)
         return result
-
-    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
-    def ready(self):
-        # Whether the worker is ready to be used for computing.
-        # Subclasses can override this method to implement custom readiness checks,
-        # e.g., for additional model initialization
-        return True
-
-    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
-    def will_be_destroyed(self):
-        # Method called before destruction, should not block,
-        # used for final resource cleanup and memory release
-        pass

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -29,7 +29,7 @@ class DistRankInfo:
     tp_rank: int
     dp_rank: int
     pp_rank: int
-    cp_rank: int
+    cp_rank: int = 0
 
 
 @dataclass
@@ -37,7 +37,7 @@ class DistGlobalInfo:
     tp_size: int
     dp_size: int
     pp_size: int
-    cp_size: int
+    cp_size: int = 1
 
 
 class WorkerHelper:

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -208,4 +208,5 @@ class WorkerGroup:
         return method_names
 
     def destroy(self):
+        # Implement this method in derived class if needed
         raise NotImplementedError("WorkerGroup.destroy called, should be implemented in derived class.")

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -206,3 +206,6 @@ class WorkerGroup:
                     raise ValueError(f"Fail to set method_name {method_name}") from e
 
         return method_names
+
+    def destroy(self):
+        raise NotImplementedError("WorkerGroup.destroy called, should be implemented in derived class.")

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -429,6 +429,15 @@ class RayWorkerGroup(WorkerGroup):
     def world_size(self):
         return self._world_size
 
+    def destroy(self):
+        # delete underlying actors
+        for w in self._workers:
+            ray.kill(w)
+        # delete placement groups if it's dedicated to this worker group
+        if self.resource_pool.is_shared_pgs is False and self.resource_pool.pgs:
+            for pg in self.resource_pool.pgs:
+                ray.util.remove_placement_group(pg)
+
 
 """
 Utilities that enables creating workers inside the same ray.Actor, 


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s). credit to LX

### What does this PR do?

Introduce one new abstract API to worker and worker group. 

* `WorkerGroup::destroy()` which will destroy the worker group and release related resource; 

### API

Adding a new API `WorkerGroup::destroy()`

### Usage Example

```python
# destroy the worker group and cleanup related resources.
wg.destroy()
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if neccessary.
