### PR TITLE
[Metric] fix: boostrap with `n == n_resps` since with replacement

### DIFF
--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -214,20 +214,14 @@ def process_validation_metrics(data_sources: list[str], sample_inputs: list[str]
                 metric[f"mean@{n_resps}"] = np.mean(var_vals)
 
                 if n_resps > 1:
-                    # n = n_resps
                     metric[f"std@{n_resps}"] = np.std(var_vals)
 
-                    metric[f"best@{n_resps}/mean"] = np.max(var_vals)
-                    metric[f"worst@{n_resps}/mean"] = np.min(var_vals)
-                    if var2vals.get("pred", None) is not None:
-                        vote_data = [{"val": val, "pred": pred} for val, pred in zip(var_vals, var2vals["pred"])]
-                        metric[f"maj@{n_resps}/mean"] = calc_maj_val(vote_data, vote_key="pred", val_key="val")
-                    # 1 < n < n_resps
                     ns = []
                     n = 2
                     while n < n_resps:
                         ns.append(n)
                         n *= 2
+                    ns.append(n_resps)
 
                     for n in ns:
                         [(bon_mean, bon_std), (won_mean, won_std)] = bootstrap_metric(data=var_vals, subset_size=n, reduce_fns=[np.max, np.min], seed=seed)


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

This PR fixes https://github.com/volcengine/verl/pull/1320 since bootstrapping is done with replacement, which makes it still meaningful even when `n == n_resps`

### Additional Info.

- **Issue Number**: https://github.com/volcengine/verl/pull/1320
- **Training**: none
- **Inference**: none

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if neccessary.
