### PR TITLE
[utils] Enrich features to a few `verl` utilities

### DIFF
--- a/.github/workflows/verl_unit_test.yml
+++ b/.github/workflows/verl_unit_test.yml
@@ -48,4 +48,4 @@ jobs:
       - name: Running utils tests
         run: |
           cd tests/verl/utils
-          pytest -s -x --ignore=dataset/ .
+          pytest -s -x --ignore=dataset/ --ignore=test_torch_function.py .

--- a/.github/workflows/verl_unit_test.yml
+++ b/.github/workflows/verl_unit_test.yml
@@ -27,11 +27,11 @@ permissions:
 
 jobs:
   verl_unit_test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10 # Increase this timeout value as needed
-    strategy:
-      matrix:
-        python-version: ["3.10"]
+    runs-on: [L20x8]
+    timeout-minutes: 20 # Increase this timeout value as needed
+    container:
+      image: whatcanyousee/verl:ngc-cu124-vllm0.8.3-sglang0.4.5-mcore0.12.0-te2.2
+      options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/verl_unit_test.yml
+++ b/.github/workflows/verl_unit_test.yml
@@ -48,4 +48,4 @@ jobs:
       - name: Running utils tests
         run: |
           cd tests/verl/utils
-          pytest -s -x --ignore=dataset/ --ignore=test_torch_function.py .
+          pytest -s -x --ignore=dataset/ --ignore=test_torch_functional.py .

--- a/.github/workflows/verl_unit_test_gpu.yml
+++ b/.github/workflows/verl_unit_test_gpu.yml
@@ -1,4 +1,4 @@
-name: verl_unit_test
+name: verl_unit_test_gpu
 
 on:
   # Trigger the workflow on push or pull request,
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 jobs:
-  verl_unit_test:
+  verl_unit_test_gpu:
     runs-on: [L20x8]
     timeout-minutes: 20 # Increase this timeout value as needed
     container:

--- a/.github/workflows/verl_unit_test_gpu.yml
+++ b/.github/workflows/verl_unit_test_gpu.yml
@@ -13,7 +13,7 @@ on:
       - v0.*
     paths:
       - "**/*.py"
-      - .github/workflows/verl_unit_test.yml
+      - .github/workflows/verl_unit_test_gpu.yml
       - "!recipe/**/*.py"
 
 # Cancel jobs on the same ref if a new one is triggered

--- a/.github/workflows/verl_unit_test_gpu.yml
+++ b/.github/workflows/verl_unit_test_gpu.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Running utils tests
         run: |
           cd tests/verl/utils
-          pytest -s -x test_torch_function.py
+          pytest -s -x test_torch_functional.py

--- a/.github/workflows/verl_unit_test_gpu.yml
+++ b/.github/workflows/verl_unit_test_gpu.yml
@@ -27,11 +27,11 @@ permissions:
 
 jobs:
   verl_unit_test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10 # Increase this timeout value as needed
-    strategy:
-      matrix:
-        python-version: ["3.10"]
+    runs-on: [L20x8]
+    timeout-minutes: 20 # Increase this timeout value as needed
+    container:
+      image: whatcanyousee/verl:ngc-cu124-vllm0.8.3-sglang0.4.5-mcore0.12.0-te2.2
+      options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
@@ -41,11 +41,7 @@ jobs:
       - name: Install the current repository
         run: |
           pip install -e .[test]
-      - name: Running test protocol.py
-        run: |
-          cd tests/verl
-          pytest -s -x test_protocol.py
       - name: Running utils tests
         run: |
           cd tests/verl/utils
-          pytest -s -x --ignore=dataset/ .
+          pytest -s -x test_torch_function.py

--- a/tests/verl/utils/test_fs.py
+++ b/tests/verl/utils/test_fs.py
@@ -15,12 +15,7 @@
 import os
 from pathlib import Path
 
-from verl.utils.fs import (
-    _check_directory_structure,
-    _record_directory_structure,
-    copy_to_local,
-    md5_encode,
-)
+import verl.utils.fs as fs
 
 
 def test_record_and_check_directory_structure(tmp_path):
@@ -32,22 +27,22 @@ def test_record_and_check_directory_structure(tmp_path):
     (test_dir / "subdir" / "file2.txt").write_text("test")
 
     # Create structure record
-    record_file = _record_directory_structure(test_dir)
+    record_file = fs._record_directory_structure(test_dir)
 
     # Verify record file exists
     assert os.path.exists(record_file)
 
     # Initial check should pass
-    assert _check_directory_structure(test_dir, record_file) is True
+    assert fs._check_directory_structure(test_dir, record_file) is True
 
     # Modify structure and verify check fails
     (test_dir / "new_file.txt").write_text("test")
-    assert _check_directory_structure(test_dir, record_file) is False
+    assert fs._check_directory_structure(test_dir, record_file) is False
 
 
-def test_copy_from_hdfs_with_mocks(tmp_path, mocker):
+def test_copy_from_hdfs_with_mocks(tmp_path, monkeypatch):
     # Mock HDFS dependencies
-    mocker.patch("verl.utils.fs.is_non_local", return_value=True)
+    monkeypatch.setattr(fs, "is_non_local", lambda path: True)
 
     # side_effect will simulate the copy by creating parent dirs + empty file
     def fake_copy(src: str, dst: str, *args, **kwargs):
@@ -55,22 +50,22 @@ def test_copy_from_hdfs_with_mocks(tmp_path, mocker):
         dst_path.parent.mkdir(parents=True, exist_ok=True)
         dst_path.write_bytes(b"")  # touch an empty file
 
-    mocker.patch("verl.utils.fs.copy", side_effect=fake_copy)  # Mock actual HDFS copy
+    monkeypatch.setattr(fs, "copy", fake_copy)  # Mock actual HDFS copy
 
     # Test parameters
     test_cache = tmp_path / "cache"
     hdfs_path = "hdfs://test/path/file.txt"
 
     # Test initial copy
-    local_path = copy_to_local(hdfs_path, cache_dir=test_cache)
-    expected_path = os.path.join(test_cache, md5_encode(hdfs_path), os.path.basename(hdfs_path))
+    local_path = fs.copy_to_local(hdfs_path, cache_dir=test_cache)
+    expected_path = os.path.join(test_cache, fs.md5_encode(hdfs_path), os.path.basename(hdfs_path))
     assert local_path == expected_path
     assert os.path.exists(local_path)
 
 
-def test_always_recopy_flag(tmp_path, mocker):
+def test_always_recopy_flag(tmp_path, monkeypatch):
     # Mock HDFS dependencies
-    mocker.patch("verl.utils.fs.is_non_local", return_value=True)
+    monkeypatch.setattr(fs, "is_non_local", lambda path: True)
 
     copy_call_count = 0
 
@@ -81,19 +76,19 @@ def test_always_recopy_flag(tmp_path, mocker):
         dst_path.parent.mkdir(parents=True, exist_ok=True)
         dst_path.write_bytes(b"")
 
-    mocker.patch("verl.utils.fs.copy", side_effect=fake_copy)
+    monkeypatch.setattr(fs, "copy", fake_copy)  # Mock actual HDFS copy
 
     test_cache = tmp_path / "cache"
     hdfs_path = "hdfs://test/path/file.txt"
 
     # Initial copy (always_recopy=False)
-    copy_to_local(hdfs_path, cache_dir=test_cache)
+    fs.copy_to_local(hdfs_path, cache_dir=test_cache)
     assert copy_call_count == 1
 
     # Force recopy (always_recopy=True)
-    copy_to_local(hdfs_path, cache_dir=test_cache, always_recopy=True)
+    fs.copy_to_local(hdfs_path, cache_dir=test_cache, always_recopy=True)
     assert copy_call_count == 2
 
     # Subsequent normal call (always_recopy=False)
-    copy_to_local(hdfs_path, cache_dir=test_cache)
+    fs.copy_to_local(hdfs_path, cache_dir=test_cache)
     assert copy_call_count == 2  # Should not increment

--- a/tests/verl/utils/test_fs.py
+++ b/tests/verl/utils/test_fs.py
@@ -1,0 +1,87 @@
+import os
+from pathlib import Path
+
+from verl.utils.fs import (
+    _check_directory_structure,
+    _record_directory_structure,
+    copy_to_local,
+    md5_encode,
+)
+
+
+def test_record_and_check_directory_structure(tmp_path):
+    # Create test directory structure
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+    (test_dir / "file1.txt").write_text("test")
+    (test_dir / "subdir").mkdir()
+    (test_dir / "subdir" / "file2.txt").write_text("test")
+
+    # Create structure record
+    record_file = _record_directory_structure(test_dir)
+
+    # Verify record file exists
+    assert os.path.exists(record_file)
+
+    # Initial check should pass
+    assert _check_directory_structure(test_dir, record_file) is True
+
+    # Modify structure and verify check fails
+    (test_dir / "new_file.txt").write_text("test")
+    assert _check_directory_structure(test_dir, record_file) is False
+
+
+def test_copy_from_hdfs_with_mocks(tmp_path, mocker):
+    # Mock HDFS dependencies
+    mocker.patch("verl.utils.fs.is_non_local", return_value=True)
+
+    # side_effect will simulate the copy by creating parent dirs + empty file
+    def fake_copy(src: str, dst: str, *args, **kwargs):
+        dst_path = Path(dst)
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
+        dst_path.write_bytes(b"")  # touch an empty file
+
+    mocker.patch("verl.utils.fs.copy", side_effect=fake_copy)  # Mock actual HDFS copy
+
+    # Test parameters
+    test_cache = tmp_path / "cache"
+    hdfs_path = "hdfs://test/path/file.txt"
+
+    # Test initial copy
+    local_path = copy_to_local(hdfs_path, cache_dir=test_cache)
+    expected_path = os.path.join(test_cache, md5_encode(hdfs_path), os.path.basename(hdfs_path))
+    assert local_path == expected_path
+    assert os.path.exists(local_path)
+
+    # Test recopy with always_recopy=True
+
+
+def test_always_recopy_flag(tmp_path, mocker):
+    # Mock HDFS dependencies
+    mocker.patch("verl.utils.fs.is_non_local", return_value=True)
+
+    copy_call_count = 0
+
+    def fake_copy(src: str, dst: str, *args, **kwargs):
+        nonlocal copy_call_count
+        copy_call_count += 1
+        dst_path = Path(dst)
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
+        dst_path.write_bytes(b"")
+
+    mocker.patch("verl.utils.fs.copy", side_effect=fake_copy)
+
+    test_cache = tmp_path / "cache"
+    hdfs_path = "hdfs://test/path/file.txt"
+
+    # Initial copy (always_recopy=False)
+    copy_to_local(hdfs_path, cache_dir=test_cache)
+    assert copy_call_count == 1
+
+    # Force recopy (always_recopy=True)
+    copy_to_local(hdfs_path, cache_dir=test_cache, always_recopy=True)
+    assert copy_call_count == 2
+
+    # Subsequent normal call (always_recopy=False)
+    copy_to_local(hdfs_path, cache_dir=test_cache)
+    assert copy_call_count == 2  # Should not increment

--- a/tests/verl/utils/test_fs.py
+++ b/tests/verl/utils/test_fs.py
@@ -53,8 +53,6 @@ def test_copy_from_hdfs_with_mocks(tmp_path, mocker):
     assert local_path == expected_path
     assert os.path.exists(local_path)
 
-    # Test recopy with always_recopy=True
-
 
 def test_always_recopy_flag(tmp_path, mocker):
     # Mock HDFS dependencies

--- a/tests/verl/utils/test_fs.py
+++ b/tests/verl/utils/test_fs.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from pathlib import Path
 

--- a/tests/verl/utils/test_torch_functional.py
+++ b/tests/verl/utils/test_torch_functional.py
@@ -82,7 +82,10 @@ def _worker_mask(rank: int, world_size: int, rendezvous_file: str):
         mask = torch.tensor([0, 1], device=f"cuda:{rank}", dtype=torch.float32)
 
     gmean = distributed_masked_mean(local_tensor, mask)
-    assert torch.allclose(gmean.cpu(), torch.tensor(2.5)), f"masked_mean@{rank}"
+
+    valid_values = [1.0] + [2 * i + 2.0 for i in range(1, world_size)]
+    expected_mean = sum(valid_values) / len(valid_values)
+    assert torch.allclose(gmean.cpu(), torch.tensor(expected_mean)), f"masked_mean@{rank}"
 
     dist.destroy_process_group()
 

--- a/tests/verl/utils/test_torch_functional.py
+++ b/tests/verl/utils/test_torch_functional.py
@@ -1,0 +1,87 @@
+# tests/test_distributed_utils.py
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from verl.utils.torch_functional import distributed_masked_mean, distributed_mean_max_min_std
+
+
+def _worker_mean(rank: int, world_size: int, rendezvous_file: str):
+    # 1) set GPU and init NCCL
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"file://{rendezvous_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+
+    # each rank holds tensor [rank+1]
+    local = torch.tensor([float(rank + 1)], device=f"cuda:{rank}")
+    mean, gmax, gmin, gstd = distributed_mean_max_min_std(local, True, True, True)
+
+    values = [float(i + 1) for i in range(world_size)]
+    exp_mean = sum(values) / len(values)
+    exp_max = max(values)
+    exp_min = min(values)
+    var = sum((x - exp_mean) ** 2 for x in values) / (len(values) - 1)
+    exp_std = var**0.5
+
+    # all ranks should see the same result
+    assert torch.allclose(mean.cpu(), torch.tensor(exp_mean)), f"mean@{rank}"
+    assert torch.allclose(gmax.cpu(), torch.tensor(exp_max)), f"max@{rank}"
+    assert torch.allclose(gmin.cpu(), torch.tensor(exp_min)), f"min@{rank}"
+    assert torch.allclose(gstd.cpu(), torch.tensor(exp_std)), f"std@{rank}"
+
+    dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_distributed_mean_max_min_std(world_size, tmp_path):
+    rendezvous_file = str(tmp_path / "rdzv_mean")
+    os.makedirs(os.path.dirname(rendezvous_file), exist_ok=True)
+
+    mp.spawn(
+        fn=_worker_mean,
+        args=(world_size, rendezvous_file),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+def _worker_mask(rank: int, world_size: int, rendezvous_file: str):
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"file://{rendezvous_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+
+    # build per‐rank tensor and mask
+    local_tensor = torch.tensor([rank * 2 + 1.0, rank * 2 + 2.0], device=f"cuda:{rank}")
+    if rank == 0:
+        mask = torch.tensor([1, 0], device=f"cuda:{rank}", dtype=torch.float32)
+    else:
+        mask = torch.tensor([0, 1], device=f"cuda:{rank}", dtype=torch.float32)
+
+    gmean = distributed_masked_mean(local_tensor, mask)
+    assert torch.allclose(gmean.cpu(), torch.tensor(2.5)), f"masked_mean@{rank}"
+
+    dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_distributed_masked_mean(world_size, tmp_path):
+    rendezvous_file = str(tmp_path / "rdzv_mask")
+    os.makedirs(os.path.dirname(rendezvous_file), exist_ok=True)
+
+    mp.spawn(
+        fn=_worker_mask,
+        args=(world_size, rendezvous_file),
+        nprocs=world_size,
+        join=True,
+    )

--- a/tests/verl/utils/test_torch_functional.py
+++ b/tests/verl/utils/test_torch_functional.py
@@ -1,4 +1,17 @@
-# tests/test_distributed_utils.py
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 import pytest

--- a/verl/utils/fs.py
+++ b/verl/utils/fs.py
@@ -40,14 +40,17 @@ def md5_encode(path: str) -> str:
 
 
 def get_local_temp_path(hdfs_path: str, cache_dir: str) -> str:
-    """Return a local temp path that joins cache_dir and basename of hdfs_path
+    """Generate a unique local cache path for an HDFS resource.
+    Creates a MD5-hashed subdirectory in cache_dir to avoid name conflicts,
+    then returns path combining this subdirectory with the HDFS basename.
 
     Args:
-        hdfs_path:
-        cache_dir:
+        hdfs_path (str): Source HDFS path to be cached
+        cache_dir (str): Local directory for storing cached files
 
     Returns:
-
+        str: Absolute local filesystem path in format:
+            {cache_dir}/{md5(hdfs_path)}/{basename(hdfs_path)}
     """
     # make a base64 encoding of hdfs_path to avoid directory conflict
     encoded_hdfs_path = md5_encode(hdfs_path)
@@ -89,15 +92,17 @@ def _check_directory_structure(folder_path, record_file):
 
 
 def copy_to_local(src: str, cache_dir=None, filelock=".file.lock", verbose=False, always_recopy=False) -> str:
-    """Copy src from hdfs to local if src is on hdfs or directly return src.
-    If cache_dir is None, we will use the default cache dir of the system. Note that this may cause conflicts if
-    the src name is the same between calls
+    """Copy files/directories from HDFS to local cache with validation.
 
     Args:
-        src (str): a HDFS path of a local path
+        src (str): Source path - HDFS path (hdfs://...) or local filesystem path
+        cache_dir (str, optional): Local directory for cached files. Uses system tempdir if None
+        filelock (str): Base name for file lock. Defaults to ".file.lock"
+        verbose (bool): Enable copy operation logging. Defaults to False
+        always_recopy (bool): Force fresh copy ignoring cache. Defaults to False
 
     Returns:
-        a local path of the copied file
+        str: Local filesystem path to copied resource
     """
     return copy_local_path_from_hdfs(src, cache_dir, filelock, verbose, always_recopy)
 

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -17,7 +17,7 @@ Contain small torch utilities
 
 import math
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import torch
 import torch.distributed
@@ -26,9 +26,7 @@ from tensordict import TensorDict
 from torch import nn
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LambdaLR
-
-if TYPE_CHECKING:
-    from transformers import PreTrainedTokenizer
+from transformers import PreTrainedTokenizer
 
 try:
     from flash_attn.ops.triton.cross_entropy import cross_entropy_loss


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

1. In `verl/utils/fs.py`: adding a `always_recopy` kwarg to `copy_to_local` function, so that the file copied will always be triggered regardless of the local cache, which could be useful in certain cases.
2. In `verl/utils/torch_funcitonal`.py: adding two utilities `distributed_mean_max_min_std` and `distributed_masked_mean` to distributed torch tensor stats collection.

### Test

1. Added `tests/verl/utils/test_fs.py` and ``tests/verl/utils/test_torch_functional.py` to unit test the corresponding utility functions.
2. Changing `verl_unit_test` to run a [8*L20] to run torch tests, which uses cuda and nccl.


### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if neccessary.
