### PR TITLE
[single_controller][decorator] Define a `DynamicEnum` class to make `Dispatch` and `Execute` extensible.

### DIFF
--- a/tests/verl/test_decorator.py
+++ b/tests/verl/test_decorator.py
@@ -15,7 +15,7 @@
 import pytest
 
 import verl.single_controller.base.decorator as decorator_module
-from verl.single_controller.base.decorator import DISPATCH_MODE_FN_REGISTRY, Dispatch, _check_dispatch_mode, register_dispatch_mode, update_dispatch_mode
+from verl.single_controller.base.decorator import DISPATCH_MODE_FN_REGISTRY, Dispatch, _check_dispatch_mode, get_predefined_dispatch_fn, register_dispatch_mode, update_dispatch_mode
 
 
 @pytest.fixture
@@ -42,7 +42,7 @@ def test_register_new_dispatch_mode(reset_dispatch_registry):
     _check_dispatch_mode(Dispatch.TEST_MODE)
 
     # Verify registry update
-    assert DISPATCH_MODE_FN_REGISTRY[Dispatch.TEST_MODE] == {"dispatch_fn": dummy_dispatch, "collect_fn": dummy_collect}
+    assert get_predefined_dispatch_fn(Dispatch.TEST_MODE) == {"dispatch_fn": dummy_dispatch, "collect_fn": dummy_collect}
     # Clean up
     Dispatch.remove("TEST_MODE")
 
@@ -62,5 +62,5 @@ def test_update_existing_dispatch_mode(reset_dispatch_registry):
     update_dispatch_mode(original_mode, new_dispatch, new_collect)
 
     # Verify update
-    assert DISPATCH_MODE_FN_REGISTRY[original_mode]["dispatch_fn"] == new_dispatch
-    assert DISPATCH_MODE_FN_REGISTRY[original_mode]["collect_fn"] == new_collect
+    assert get_predefined_dispatch_fn(original_mode)["dispatch_fn"] == new_dispatch
+    assert get_predefined_dispatch_fn(original_mode)["collect_fn"] == new_collect

--- a/tests/verl/test_decorator.py
+++ b/tests/verl/test_decorator.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
 import verl.single_controller.base.decorator as decorator_module

--- a/tests/verl/test_decorator.py
+++ b/tests/verl/test_decorator.py
@@ -1,0 +1,52 @@
+import pytest
+
+import verl.single_controller.base.decorator as decorator_module
+from verl.single_controller.base.decorator import DISPATCH_MODE_FN_REGISTRY, Dispatch, _check_dispatch_mode, register_dispatch_mode, update_dispatch_mode
+
+
+@pytest.fixture
+def reset_dispatch_registry():
+    # Store original state
+    original_registry = DISPATCH_MODE_FN_REGISTRY.copy()
+    yield
+    # Reset registry after test
+    decorator_module.DISPATCH_MODE_FN_REGISTRY.clear()
+    decorator_module.DISPATCH_MODE_FN_REGISTRY.update(original_registry)
+
+
+def test_register_new_dispatch_mode(reset_dispatch_registry):
+    # Test registration
+    def dummy_dispatch(worker_group, *args, **kwargs):
+        return args, kwargs
+
+    def dummy_collect(worker_group, output):
+        return output
+
+    register_dispatch_mode("TEST_MODE", dummy_dispatch, dummy_collect)
+
+    # Verify enum extension
+    _check_dispatch_mode(Dispatch.TEST_MODE)
+
+    # Verify registry update
+    assert DISPATCH_MODE_FN_REGISTRY[Dispatch.TEST_MODE] == {"dispatch_fn": dummy_dispatch, "collect_fn": dummy_collect}
+    # Clean up
+    Dispatch.remove("TEST_MODE")
+
+
+def test_update_existing_dispatch_mode(reset_dispatch_registry):
+    # Store original implementation
+    original_mode = Dispatch.ONE_TO_ALL
+
+    # New implementations
+    def new_dispatch(worker_group, *args, **kwargs):
+        return args, kwargs
+
+    def new_collect(worker_group, output):
+        return output
+
+    # Test update=
+    update_dispatch_mode(original_mode, new_dispatch, new_collect)
+
+    # Verify update
+    assert DISPATCH_MODE_FN_REGISTRY[original_mode]["dispatch_fn"] == new_dispatch
+    assert DISPATCH_MODE_FN_REGISTRY[original_mode]["collect_fn"] == new_collect

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -428,7 +428,6 @@ DISPATCH_MODE_FN_REGISTRY = {
 
 
 def get_predefined_dispatch_fn(dispatch_mode):
-    print(f"[debug] {DISPATCH_MODE_FN_REGISTRY.keys()=}")
     return DISPATCH_MODE_FN_REGISTRY[dispatch_mode]
 
 

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -428,6 +428,7 @@ DISPATCH_MODE_FN_REGISTRY = {
 
 
 def get_predefined_dispatch_fn(dispatch_mode):
+    print(f"[debug] {DISPATCH_MODE_FN_REGISTRY.keys()=}")
     return DISPATCH_MODE_FN_REGISTRY[dispatch_mode]
 
 

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -169,9 +169,6 @@ class WorkerGroup:
                 # get dispatch fn
                 if isinstance(dispatch_mode, Dispatch):
                     # get default dispatch fn
-                    from verl.single_controller.base.decorator import DISPATCH_MODE_FN_REGISTRY
-
-                    assert dispatch_mode in DISPATCH_MODE_FN_REGISTRY, f"dispatch_mode {dispatch_mode} is not registered {DISPATCH_MODE_FN_REGISTRY.keys()}"
                     fn = get_predefined_dispatch_fn(dispatch_mode=dispatch_mode)
                     dispatch_fn = fn["dispatch_fn"]
                     collect_fn = fn["collect_fn"]

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -169,6 +169,9 @@ class WorkerGroup:
                 # get dispatch fn
                 if isinstance(dispatch_mode, Dispatch):
                     # get default dispatch fn
+                    from verl.single_controller.base.decorator import DISPATCH_MODE_FN_REGISTRY
+
+                    assert dispatch_mode in DISPATCH_MODE_FN_REGISTRY, f"dispatch_mode {dispatch_mode} is not registered {DISPATCH_MODE_FN_REGISTRY.keys()}"
                     fn = get_predefined_dispatch_fn(dispatch_mode=dispatch_mode)
                     dispatch_fn = fn["dispatch_fn"]
                     collect_fn = fn["collect_fn"]

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -21,6 +21,8 @@ import threading
 import time
 from typing import Any, Callable, Dict, List
 
+import verl.single_controller.base.decorator  # noqa: F401
+
 from .decorator import MAGIC_ATTR, Dispatch, get_predefined_dispatch_fn, get_predefined_execute_fn
 
 

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -21,8 +21,6 @@ import threading
 import time
 from typing import Any, Callable, Dict, List
 
-import verl.single_controller.base.decorator  # noqa: F401
-
 from .decorator import MAGIC_ATTR, Dispatch, get_predefined_dispatch_fn, get_predefined_execute_fn
 
 

--- a/verl/utils/py_functional.py
+++ b/verl/utils/py_functional.py
@@ -203,6 +203,12 @@ class DynamicEnum(metaclass=DynamicEnumMeta):
     def __repr__(self):
         return f"<{self.__class__.__name__}.{self.name}: {self.value}>"
 
+    def __eq__(self, other):
+        return isinstance(other, DynamicEnum) and self.__class__ == other.__class__ and self.name == other.name and self.value == other.value
+
+    def __hash__(self):
+        return hash((self.__class__, self.name, self.value))
+
     @classmethod
     def register(cls, name: str) -> "DynamicEnum":
         key = name.upper()

--- a/verl/utils/py_functional.py
+++ b/verl/utils/py_functional.py
@@ -16,15 +16,13 @@ Contain small python utility functions
 """
 
 import multiprocessing
-import time
 import os
+import queue  # Import the queue module for exception type hint
 import signal
-import threading # <-- Import threading here
 from functools import wraps
 from types import SimpleNamespace
-from typing import Dict, Any, Tuple, Callable
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple
 
-import queue # Import the queue module for exception type hint
 
 # --- Top-level helper for multiprocessing timeout ---
 # This function MUST be defined at the top level to be pickleable
@@ -35,13 +33,14 @@ def _mp_target_wrapper(target_func: Callable, mp_queue: multiprocessing.Queue, a
     """
     try:
         result = target_func(*args, **kwargs)
-        mp_queue.put((True, result)) # Indicate success and put result
+        mp_queue.put((True, result))  # Indicate success and put result
     except Exception as e:
         # Ensure the exception is pickleable for the queue
         try:
             import pickle
-            pickle.dumps(e) # Test if the exception is pickleable
-            mp_queue.put((False, e)) # Indicate failure and put exception
+
+            pickle.dumps(e)  # Test if the exception is pickleable
+            mp_queue.put((False, e))  # Indicate failure and put exception
         except (pickle.PicklingError, TypeError):
             # Fallback if the original exception cannot be pickled
             mp_queue.put((False, RuntimeError(f"Original exception type {type(e).__name__} not pickleable: {e}")))
@@ -66,6 +65,7 @@ def timeout_limit(seconds: float, use_signals: bool = False):
         RuntimeError: If the child process exits with an error (multiprocessing mode).
         NotImplementedError: If the OS is not POSIX (signals are only supported on POSIX).
     """
+
     def decorator(func):
         if use_signals:
             if os.name != "posix":
@@ -76,6 +76,7 @@ def timeout_limit(seconds: float, use_signals: bool = False):
                 Signals are unreliable outside the main thread. \
                 Please use the default multiprocessing-based timeout (use_signals=False)."
             )
+
             @wraps(func)
             def wrapper_signal(*args, **kwargs):
                 def handler(signum, frame):
@@ -94,44 +95,43 @@ def timeout_limit(seconds: float, use_signals: bool = False):
                     signal.setitimer(signal.ITIMER_REAL, 0)
                     signal.signal(signal.SIGALRM, old_handler)
                 return result
+
             return wrapper_signal
         else:
             # --- Multiprocessing based timeout (existing logic) ---
             @wraps(func)
             def wrapper_mp(*args, **kwargs):
                 q = multiprocessing.Queue(maxsize=1)
-                process = multiprocessing.Process(
-                    target=_mp_target_wrapper,
-                    args=(func, q, args, kwargs)
-                )
+                process = multiprocessing.Process(target=_mp_target_wrapper, args=(func, q, args, kwargs))
                 process.start()
                 process.join(timeout=seconds)
 
                 if process.is_alive():
                     process.terminate()
-                    process.join(timeout=0.5) # Give it a moment to terminate
+                    process.join(timeout=0.5)  # Give it a moment to terminate
                     if process.is_alive():
-                         print(f"Warning: Process {process.pid} did not terminate gracefully after timeout.")
+                        print(f"Warning: Process {process.pid} did not terminate gracefully after timeout.")
                     # Update function name in error message if needed (optional but good practice)
                     raise TimeoutError(f"Function {func.__name__} timed out after {seconds} seconds (multiprocessing)!")
 
                 try:
-                    success, result_or_exc = q.get(timeout=0.1) # Small timeout for queue read
+                    success, result_or_exc = q.get(timeout=0.1)  # Small timeout for queue read
                     if success:
                         return result_or_exc
                     else:
-                        raise result_or_exc # Reraise exception from child
-                except queue.Empty:
+                        raise result_or_exc  # Reraise exception from child
+                except queue.Empty as err:
                     exitcode = process.exitcode
                     if exitcode is not None and exitcode != 0:
-                        raise RuntimeError(f"Child process exited with error (exitcode: {exitcode}) before returning result.")
+                        raise RuntimeError(f"Child process exited with error (exitcode: {exitcode}) before returning result.") from err
                     else:
                         # Should have timed out if queue is empty after join unless process died unexpectedly
                         # Update function name in error message if needed (optional but good practice)
-                        raise TimeoutError(f"Operation timed out or process finished unexpectedly without result (exitcode: {exitcode}).")
+                        raise TimeoutError(f"Operation timed out or process finished unexpectedly without result (exitcode: {exitcode}).") from err
                 finally:
                     q.close()
                     q.join_thread()
+
             return wrapper_mp
 
     return decorator
@@ -171,3 +171,56 @@ class NestedNamespace(SimpleNamespace):
             else:
                 self.__setattr__(key, value)
 
+
+class DynamicEnumMeta(type):
+    def __iter__(cls) -> Iterator[Any]:
+        return iter(cls._registry.values())
+
+    def __contains__(cls, item: Any) -> bool:
+        # allow `name in EnumClass` or `member in EnumClass`
+        if isinstance(item, str):
+            return item in cls._registry
+        return item in cls._registry.values()
+
+    def __getitem__(cls, name: str) -> Any:
+        return cls._registry[name]
+
+    def names(cls):
+        return list(cls._registry.keys())
+
+    def values(cls):
+        return list(cls._registry.values())
+
+
+class DynamicEnum(metaclass=DynamicEnumMeta):
+    _registry: Dict[str, "DynamicEnum"] = {}
+    _next_value: int = 0
+
+    def __init__(self, name: str, value: int):
+        self.name = name
+        self.value = value
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}.{self.name}: {self.value}>"
+
+    @classmethod
+    def register(cls, name: str) -> "DynamicEnum":
+        key = name.upper()
+        if key in cls._registry:
+            raise ValueError(f"{key} already registered")
+        member = cls(key, cls._next_value)
+        cls._registry[key] = member
+        setattr(cls, key, member)
+        cls._next_value += 1
+        return member
+
+    @classmethod
+    def remove(cls, name: str):
+        key = name.upper()
+        member = cls._registry.pop(key)
+        delattr(cls, key)
+        return member
+
+    @classmethod
+    def from_name(cls, name: str) -> Optional["DynamicEnum"]:
+        return cls._registry.get(name.upper())


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Today, extending `verl` in proprietary usage large requires forking it, and padding code changes in the private fork. 
For example, the current `verl` API doesn't support adding new `Dispatch` and `Execute` mode in runtime. The only way to achieve it is to make a new private fork.

This PR replace the static `Enum` type of `Dispatch` and `Execute` into a new `"DynamicEnum"` type, that the users can use new APIs `register_dispatch_mode` and `update_dispatch_mode` to adding and define new distributed mode at runtime using native `verl` API, instead of making a fork.


### Specific Changes

* Defined `DynamicEnum` class in `utils.py_functional.py`;
* Re-defined `Dispatch` and `Execute` classes, all existing Enum API and usage are still usbale;
* Added `register_dispatch_mode` and `update_dispatch_mode` for users to register new dispatch modes at runtime;
* nit: `pre-commit` automatically fixed part of code format in another PR #1331 

### Usage Example

> Provide usage example(s) for easier usage.

```python
def test_register_new_dispatch_mode():
    # Test registration
    def dummy_dispatch(worker_group, *args, **kwargs):
        return args, kwargs

    def dummy_collect(worker_group, output):
        return output

    register_dispatch_mode("TEST_MODE", dummy_dispatch, dummy_collect)

    # Verify enum extension
    _check_dispatch_mode(Dispatch.TEST_MODE)

    # Verify registry update
    assert get_predefined_dispatch_fn(Dispatch.TEST_MODE) == {"dispatch_fn": dummy_dispatch, "collect_fn": dummy_collect}
```

### Test

Added `tests/verl/test_decorator.py`

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if neccessary.
