### PR TITLE
[BUG] fix swanlab init bug when config is None

### DIFF
--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -70,6 +70,9 @@ class Tracking:
             SWANLAB_MODE = os.environ.get("SWANLAB_MODE", "cloud")
             if SWANLAB_API_KEY:
                 swanlab.login(SWANLAB_API_KEY)  # NOTE: previous login information will be overwritten
+            
+            if config is None:
+                config = {} # make sure config is not None, otherwise **config will raise error
             swanlab.init(
                 project=project_name,
                 experiment_name=experiment_name,


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

> Add one-line overview of what this PR aims to achieve or accomplish. 

When user choose swanlab logger and not set config, original code `config={"FRAMEWORK": "verl", **config}` would raise error. This PR try to fix this by init config as an empty dict if it is None

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

```
if config is None:
    config = {} # make sure config is not None, otherwise **config will raise error
swanlab.init(
    project=project_name,
    experiment_name=experiment_name,
    config={"FRAMEWORK": "verl", **config}, # this is the cause of error when config is None
    logdir=SWANLAB_LOG_DIR,
    mode=SWANLAB_MODE,
)
```

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if neccessary.
