### PR TITLE
add `engine_kwargs`  in vllm_rollout_spmd to set params in vllm engine

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -29,12 +29,13 @@ When working with Megatron:
 import logging
 import os
 from contextlib import contextmanager
+from copy import deepcopy
 from typing import Any, Dict, List, Union
 
 import numpy as np
 import torch
 import torch.distributed
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from tensordict import TensorDict
 from vllm import LLM, SamplingParams
 from vllm.distributed import parallel_state as vllm_ps
@@ -124,6 +125,13 @@ class vLLMRollout(BaseRollout):
         if config.get("limit_images", None):  # support for multi-image data
             limit_mm_per_prompt = {"image": config.get("limit_images")}
 
+        # copy it to avoid secretly modifying the engine config
+        engine_kwargs = {} if "engine_kwargs" not in config else OmegaConf.to_container(deepcopy(config.engine_kwargs))
+        # For each vLLM engine parameter,
+        # - `None` means not setting it, so we pop it, and leave it to vLLM default value
+        #    (which can vary across different vLLM versions);
+        # - Otherwise it's the desired value we want to explicitly set.
+        engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
         self.inference_engine = LLM(
             model=model_path,
             enable_sleep_mode=True,
@@ -144,6 +152,7 @@ class vLLMRollout(BaseRollout):
             enable_prefix_caching=True,
             trust_remote_code=trust_remote_code,
             seed=config.get("seed", 0),
+            **engine_kwargs,
         )
 
         # Offload vllm model to reduce peak memory usage


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

> add `engine_kwargs`  in vllm_rollout_spmd to set swap_space in vllm engine. 

### Specific Changes

> add `engine_kwargs` in vllm_rollout_spmd, which can be set in config file. Same changes has been made in vllm_rollout. As the version of vllm is update to 0.8, the default vllm_rollout worker becomes vllm_rollout_spmd, which does not have `engine_kwargs` as in vllm_rollout, so this RP want to complete it.

### Usage Example

> users can set vllm engine param such as `swap_space`, `seed` through the `engine_kwargs` in config file. For example, if  one want to set the swap_space=32 in vllm, he can set the item in config like this
```bash
actor_rollout_ref.rollout.engine_kwargs.swap_space=32
```
