### PR TITLE
[ray] fix: make spawn worker group hold strong reference to actors

### DIFF
--- a/tests/rollout/test_vllm_multi_turn.py
+++ b/tests/rollout/test_vllm_multi_turn.py
@@ -55,7 +55,7 @@ def test_vllm_multi_turn(config):
 
     # =========================== 1. Init rollout manager ===========================
     model_name = "/".join(config.actor_rollout_ref.model.path.split("/")[-2:])
-    worker_groups, async_rollout_manager = init_async_rollout_manager(config)
+    async_rollout_manager = init_async_rollout_manager(config)
 
     # test sleep and wake_up
     async_rollout_manager.sleep()
@@ -145,7 +145,7 @@ async def test_vllm_streaming_response(config):
     )
 
     model_name = "/".join(config.actor_rollout_ref.model.path.split("/")[-2:])
-    worker_groups, async_rollout_manager = init_async_rollout_manager(config)
+    async_rollout_manager = init_async_rollout_manager(config)
     async_llm_server = async_rollout_manager.async_llm_servers[0]
 
     # non-streaming request

--- a/tests/rollout/test_vllm_tool_calling.py
+++ b/tests/rollout/test_vllm_tool_calling.py
@@ -264,7 +264,7 @@ def test_vllm_tool_calling():
     # Init sandbox and async rollout manager
     sandbox = Sandbox.options(num_cpus=1).remote()
     sandbox_address = ray.get(sandbox.get_server_address.remote())
-    worker_groups, async_rollout_manager = init_async_rollout_manager(config, scheduler_kwargs={"sandbox_address": sandbox_address, "system_prompt": system_prompt})
+    async_rollout_manager = init_async_rollout_manager(config, scheduler_kwargs={"sandbox_address": sandbox_address, "system_prompt": system_prompt})
 
     # Build dataset
     dataset = load_dataset("Maxwell-Jia/AIME_2024", split="train")

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -189,6 +189,7 @@ class RayWorkerGroup(WorkerGroup):
         name_prefix: str = None,
         detached=False,
         worker_names=None,
+        worker_handles: List[ray.actor.ActorHandle] = None,
         ray_wait_register_center_timeout: int = 300,
         **kwargs,
     ) -> None:
@@ -206,7 +207,7 @@ class RayWorkerGroup(WorkerGroup):
             self._worker_names = worker_names
 
         if self._is_init_with_detached_workers:
-            self._init_with_detached_workers(worker_names=worker_names)
+            self._init_with_detached_workers(worker_names=worker_names, worker_handles=worker_handles)
         else:
             self._init_with_resource_pool(resource_pool=resource_pool, ray_cls_with_init=ray_cls_with_init, bin_pack=bin_pack, detached=detached)
 
@@ -220,8 +221,12 @@ class RayWorkerGroup(WorkerGroup):
         worker_state_dict = get_actor(worker._actor_id.hex())
         return worker_state_dict.get("state", "undefined") == "ALIVE" if worker_state_dict is not None else False
 
-    def _init_with_detached_workers(self, worker_names):
-        workers = [ray.get_actor(name=name) for name in worker_names]
+    def _init_with_detached_workers(self, worker_names, worker_handles):
+        # ray.get_actor holds a weak reference to the actor, which causes actors garbage collected unexpectedly
+        # if we only hold spawn RayWorkerGroup. By passing actor handle explicitly, spawn RayWorkerGroup have
+        # strong reference to these actors.
+        # https://github.com/ray-project/ray/pull/45699
+        workers = worker_handles if worker_handles else [ray.get_actor(name=name) for name in worker_names]
         self._workers = workers
         self._world_size = len(worker_names)
 
@@ -319,9 +324,10 @@ class RayWorkerGroup(WorkerGroup):
         cls,
         name_prefix,
         worker_names=None,
+        worker_handles=None,
         ray_cls_with_init=None,
     ):
-        worker_group = cls(resource_pool=None, ray_cls_with_init=ray_cls_with_init, name_prefix=name_prefix, worker_names=worker_names)
+        worker_group = cls(resource_pool=None, ray_cls_with_init=ray_cls_with_init, name_prefix=name_prefix, worker_names=worker_names, worker_handles=worker_handles)
         return worker_group
 
     def spawn(self, prefix_set):
@@ -349,6 +355,7 @@ class RayWorkerGroup(WorkerGroup):
             new_worker_group = self.from_detached(
                 name_prefix=self.name_prefix,
                 worker_names=self._worker_names,
+                worker_handles=self._workers,
                 ray_cls_with_init=self.ray_cls_with_init,
             )
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -708,7 +708,6 @@ class RayPPOTrainer:
         # Instead, directly pass different resource pool to different worker groups.
         # See https://github.com/volcengine/verl/blob/master/examples/ray/tutorial.ipynb for more information.
         all_wg = {}
-        self.wg_dicts = []
         wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
         if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
             wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
@@ -718,8 +717,6 @@ class RayPPOTrainer:
             wg_dict = self.ray_worker_group_cls(resource_pool=resource_pool, ray_cls_with_init=worker_dict_cls, **wg_kwargs)
             spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())
             all_wg.update(spawn_wg)
-            # keep the referece of WorkerDict to support ray >= 2.31. Ref: https://github.com/ray-project/ray/pull/45699
-            self.wg_dicts.append(wg_dict)
 
         if self.use_critic:
             self.critic_wg = all_wg["critic"]


### PR DESCRIPTION
### Checklist Before Starting

- [ ] Search for similar PR(s).

### What does this PR do?

Spawned RayWorkerGroup get actors by name, which holds a weak reference to the actor and causes actors garbage collected unexpectedly. Pass actor handle explicitly in spawn to make RayWorkerGroup have strong reference to these actors. close #1365 https://github.com/volcengine/verl/pull/1138#issuecomment-2862087324

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if neccessary.
