### PR TITLE
[SFTTrainer] Port features (dtype, save_freq, test_freq) from PPO config to SFT config

### DIFF
--- a/verl/trainer/config/sft_trainer.yaml
+++ b/verl/trainer/config/sft_trainer.yaml
@@ -23,7 +23,7 @@ data:
 model:
   partial_pretrain: ~/models/gemma-1.1-7b-it
   fsdp_config:
-    model_dtype: bfloat16
+    model_dtype: fp32
     wrap_policy:
       min_num_params: 0
     cpu_offload: False

--- a/verl/trainer/config/sft_trainer.yaml
+++ b/verl/trainer/config/sft_trainer.yaml
@@ -23,6 +23,7 @@ data:
 model:
   partial_pretrain: ~/models/gemma-1.1-7b-it
   fsdp_config:
+    model_dtype: bfloat16
     wrap_policy:
       min_num_params: 0
     cpu_offload: False
@@ -44,13 +45,18 @@ optim:
 ulysses_sequence_parallel_size: 1
 use_remove_padding: False
 trainer:
-  default_local_dir: /tmp/sft_model
-  default_hdfs_dir: hdfs://tmp/experiments/gsm8k/gemma-1.1-7b-it/ # change the hdfs path here
+  default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
+  default_hdfs_dir: null
   resume_path: null
   project_name: gsm8k-sft
   experiment_name: test
   total_epochs: 4
   total_training_steps: null
-  logger: ['console']
+  logger: [ 'console', 'wandb' ]
   seed: 1
 
+  save_freq: -1
+  test_freq: -1
+  nnodes: 1
+  n_gpus_per_node: 8
+  max_ckpt_to_keep: null # TODO

--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -45,11 +45,11 @@ import verl.utils.hdfs_io as hdfs_io
 from verl.utils.dataset import SFTDataset
 from verl.utils.dataset.multiturn_sft_dataset import MultiTurnSFTDataset
 from verl.utils.debug import log_gpu_memory_usage
-<<<<<<< HEAD
 from verl.utils.distributed import initialize_global_process_group
 from verl.utils.fs import copy_to_local
 from verl.utils.fsdp_utils import get_fsdp_wrap_policy, get_init_weight_context_manager, init_fn
 from verl.utils.torch_functional import get_cosine_schedule_with_warmup, get_wsd_schedule_with_warmup
+from verl.utils.torch_dtypes import PrecisionType
 from verl.utils.tracking import Tracking
 from verl.utils.ulysses import (
     gather_outpus_and_unpad,
@@ -57,20 +57,6 @@ from verl.utils.ulysses import (
     ulysses_pad_and_slice_inputs,
 )
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
-||||||| parent of 0348e38 (SFT: support dtype, save/test_freq)
-from peft import LoraConfig, TaskType, get_peft_model
-
-from verl.workers.sharding_manager import FSDPUlyssesShardingManager
-from verl.utils.ulysses import ulysses_pad_and_slice_inputs, gather_outpus_and_unpad
-from verl import DataProto
-=======
-from peft import LoraConfig, TaskType, get_peft_model
-
-from verl.workers.sharding_manager import FSDPUlyssesShardingManager
-from verl.utils.ulysses import ulysses_pad_and_slice_inputs, gather_outpus_and_unpad
-from verl import DataProto
-from verl.utils.torch_dtypes import PrecisionType
->>>>>>> 0348e38 (SFT: support dtype, save/test_freq)
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_SFT_LOGGING_LEVEL", "WARN"))
@@ -202,27 +188,13 @@ class FSDPSFTTrainer:
         init_context = get_init_weight_context_manager(use_meta_tensor=not config.tie_word_embeddings, mesh=self.device_mesh)
 
         with init_context():
-<<<<<<< HEAD
             self.model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
                 local_model_path,
                 config=config,
-                torch_dtype=torch.float32,
+                torch_dtype=torch_dtype,
                 attn_implementation="flash_attention_2",
                 trust_remote_code=trust_remote_code,
             )
-||||||| parent of 0348e38 (SFT: support dtype, save/test_freq)
-            self.model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(local_model_path,
-                                                                               config=config,
-                                                                               torch_dtype=torch.float32,
-                                                                               attn_implementation='flash_attention_2',
-                                                                               trust_remote_code=trust_remote_code)
-=======
-            self.model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(local_model_path,
-                                                                               config=config,
-                                                                               torch_dtype=torch_dtype,
-                                                                               attn_implementation='flash_attention_2',
-                                                                               trust_remote_code=trust_remote_code)
->>>>>>> 0348e38 (SFT: support dtype, save/test_freq)
 
             if self.use_remove_padding or self.config.ulysses_sequence_parallel_size > 1:
                 from verl.models.transformers.monkey_patch import apply_monkey_patch
@@ -513,17 +485,7 @@ class FSDPSFTTrainer:
                     (is_last_step or  global_step % self.config.trainer.test_freq == 0):
                     val_metric = self._validate()
                     if rank == 0:
-<<<<<<< HEAD
-                        avg_val_loss = torch.mean(torch.stack(val_losses))
-                        metric = {"val/loss": avg_val_loss.detach().item()}
-                        tracking.log(data=metric, step=global_step)
-||||||| parent of 0348e38 (SFT: support dtype, save/test_freq)
-                        avg_val_loss = torch.mean(torch.stack(val_losses))
-                        metric = {'val/loss': avg_val_loss.detach().item()}
-                        tracking.log(data=metric, step=global_step)
-=======
                         tracking.log(data=val_metric, step=global_step)
->>>>>>> 0348e38 (SFT: support dtype, save/test_freq)
                     torch.distributed.barrier()
 
                 if self.config.trainer.save_freq > 0 and ( is_last_step or \
@@ -534,40 +496,6 @@ class FSDPSFTTrainer:
                     print(f'Final validation metrics: {val_metric}')
                     return
 
-<<<<<<< HEAD
-            # validation
-            val_losses = []
-            for data in self.val_dataloader:
-                data = TensorDict(data, batch_size=self.config.data.micro_batch_size_per_gpu).cuda()
-                val_loss = self.validation_step(data)
-                val_losses.append(val_loss)
-            if rank == 0:
-                val_loss = torch.mean(torch.stack(val_losses))
-                metric = {"val/loss": val_loss.detach().item()}
-                tracking.log(data=metric, step=global_step)
-            torch.distributed.barrier()
-
-            # save checkpoint
-            self.save_checkpoint(step=global_step)
-
-||||||| parent of 0348e38 (SFT: support dtype, save/test_freq)
-            # validation
-            val_losses = []
-            for data in self.val_dataloader:
-                data = TensorDict(data, batch_size=self.config.data.micro_batch_size_per_gpu).cuda()
-                val_loss = self.validation_step(data)
-                val_losses.append(val_loss)
-            if rank == 0:
-                val_loss = torch.mean(torch.stack(val_losses))
-                metric = {'val/loss': val_loss.detach().item()}
-                tracking.log(data=metric, step=global_step)
-            torch.distributed.barrier()
-
-            # save checkpoint
-            self.save_checkpoint(step=global_step)
-
-=======
->>>>>>> 0348e38 (SFT: support dtype, save/test_freq)
 
 from verl.trainer.fsdp_sft_trainer import FSDPSFTTrainer
 import hydra


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

enable (dtype, save_freq, test_freq) config to sync SFTTrainer with PPOTrainer

### Specific Changes

1. add new config items
2. sync `defaul_local_dir`, `default_hdfs_dir` and `logger` with PPO config
```yaml
model:
  fsdp_config:
    model_dtype: fp32
trainer:
  save_freq: -1 # unit: iteration
  test_freq: -1
```

### Usage Example

Just works same as `main_ppo`

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
