### PR TITLE
[BUG] fix inconsistent type in SFT Dataset

### DIFF
--- a/verl/utils/dataset/sft_dataset.py
+++ b/verl/utils/dataset/sft_dataset.py
@@ -96,6 +96,23 @@ class SFTDataset(Dataset):
             except Exception:
                 print(f"self.prompts={self.prompts}")
                 raise
+        
+        # Ensure self.prompts is a pandas Series before converting to list. It may happen when user does not specify prompt_dict_keys.
+        if isinstance(self.prompts, pd.DataFrame):
+            # Check if accessing nested dictionary keys was unnecessary. Otherwise, it should be dealed in the preceding loop.
+            assert len(self.prompt_dict_keys) == 0, (
+                "self.prompts is a DataFrame, but self.prompt_dict_keys is not empty. "
+                "This indicates that accessing nested dictionary keys was attempted, "
+                "but resulted in a DataFrame instead of a Series."
+            )
+            # Check if the DataFrame has exactly one column
+            assert len(self.prompts.columns) == 1, (
+                "self.prompts is a DataFrame with multiple columns. "
+                f"Expected 1 column, got {len(self.prompts.columns)}. "
+                "Columns: {self.prompts.columns.tolist()}"
+            )
+            self.prompts = self.prompts.iloc[:, 0]
+        
         self.prompts = self.prompts.tolist()
         self.responses = self.dataframe[self.response_key]
         for key in self.response_dict_keys:


### PR DESCRIPTION

### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

> Add one-line overview of what this PR aims to achieve or accomplish. 
Fix inconsistent type of `self.prompts` and `self.responses` in SFT Dataset when user does not specific `prompt_dict_keys` or `response_dict_keys` in config.

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if neccessary.
