### PR TITLE
[PRIME]bug fix: reward scoring hangs after progress reaches 100%

### DIFF
--- a/verl/workers/reward_manager/prime.py
+++ b/verl/workers/reward_manager/prime.py
@@ -16,7 +16,7 @@ import asyncio
 from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 from typing import Callable, Optional
-
+import psutil
 import torch
 from transformers import PreTrainedTokenizer
 
@@ -24,56 +24,76 @@ from verl import DataProto
 from verl.utils.reward_score import _default_compute_score
 
 
-async def single_compute_score(evaluation_func, completion, reference, task, task_extra_info, executor, timeout=300.0):
+async def single_compute_score(evaluation_func, completion, reference, task, task_extra_info, executor, timeout):
     loop = asyncio.get_running_loop()
     try:
         # Ensure process_completion is called properly
-        tasks = [
-            asyncio.wait_for(
-                loop.run_in_executor(
-                    executor,
-                    partial(evaluation_func, task, completion, reference, task_extra_info),  # Ensure synchronous
-                ),
-                timeout=timeout,
-            )
-        ]
-        return await asyncio.gather(*tasks)
+        future = loop.run_in_executor(
+            executor,
+            partial(evaluation_func, task, completion, reference, task_extra_info)
+        )
+        return await asyncio.wait_for(future, timeout=timeout)
     except asyncio.TimeoutError:
-        print(f"Timeout occurred for completion: {completion}")
+        print(f"[Timeout] Task timeout: {completion[:80]}")
         return None  # Default value for timed-out rows
     except Exception as e:
-        print(f"Error processing completion: {completion[:10]}, Error: {e}")
+        print(f"[Error] Task failed: {e}, completion: {completion[:80]}")
         return None  # Default value for failed rows
 
 
-async def parallel_compute_score_async(evaluation_func, completions, references, tasks, extra_info=None, num_processes=64):
+async def parallel_compute_score_async(evaluation_func, completions, references, tasks, extra_info, num_processes, timeout):
     scores = []
     with ProcessPoolExecutor(max_workers=num_processes) as executor:
-        if extra_info is None:
-            extra_info = [None] * len(tasks)
-        # Create tasks for all rows
-        tasks_async = [single_compute_score(evaluation_func, completion, reference, task, task_extra_info, executor, timeout=300.0) for completion, reference, task, task_extra_info in zip(completions, references, tasks, extra_info)]
         # to prevent very occasional starvation caused by some anomalous programs ( like infinite loop ), the exceptions in async programs will instantly halt the evaluation, and all summoned processes will be killed.
         try:
+            # Create tasks for all rows
+            tasks_async = [
+                single_compute_score(evaluation_func, c, r, t, ei, executor, timeout)
+                for c, r, t, ei in zip(completions, references, tasks, extra_info)
+            ]
             results = await asyncio.gather(*tasks_async, return_exceptions=False)
-        except:
+        except Exception as e:
+            print(f"[Exception] async gather failed: {e}")
+            raise
+        finally:
+            terminated_count = 0
             for pid, proc in executor._processes.items():
                 try:
-                    proc.kill()
-                except Exception as kill_err:
-                    print("shut down failed: " + str(kill_err))
-            raise
+                    p = psutil.Process(pid)
+                    p.terminate()
+                    try:
+                        p.wait(timeout=5)
+                    except psutil.TimeoutExpired:
+                        p.kill()
+                    terminated_count += 1
+                except Exception:
+                    pass
+            print(f"[Shutdown] {terminated_count} subprocess(es) terminated.")
 
     # Process results
     for result, completion, reference, task in zip(results, completions, references, tasks):
         if isinstance(result, Exception) or result is None:
             # Handle failed or timed-out tasks
             scores.append(0.0)
-        elif isinstance(result[0], (int, float, bool)):
-            scores.append(float(result[0]))
+        elif isinstance(result, (int, float, bool)):
+            scores.append(float(result))
         else:
-            scores.append(float(result[0][0]))
+            scores.append(float(result[0]))
     return scores
+
+def run_reward_scoring(evaluation_func, completions, references, tasks, extra_info=None, num_processes=64, timeout=300.0):
+    if extra_info is None:
+        extra_info = [None] * len(tasks)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(parallel_compute_score_async(
+            evaluation_func, completions, references, tasks, extra_info, 
+            num_processes, timeout
+        ))
+    finally:
+        loop.close()
 
 
 class PrimeRewardManager:
@@ -108,21 +128,20 @@ class PrimeRewardManager:
 
         assert len(sequences_str) == len(ground_truth) == len(data_sources)
         try:
-            scores = asyncio.run(
-                parallel_compute_score_async(
-                    self.compute_score,
-                    sequences_str,
-                    ground_truth,
-                    data_sources,
-                    extra_info=extra_info,
-                    num_processes=64,
-                )
+            scores = run_reward_scoring(
+                self.compute_score,
+                completions=sequences_str,
+                references=ground_truth,
+                tasks=data_sources,
+                extra_info=extra_info,
+                num_processes=64,
+                timeout=300.,
             )
         except asyncio.TimeoutError:
-            print("Global timeout in reward computing! Setting all as 0.")
+            print("[Timeout] Global reward scoring timed out. Setting all as 0.")
             scores = [0.0 for _ in range(len(sequences_str))]
         except Exception as e:
-            print(f"Unexpected error in batched reward computing. Setting all as 0.: {e}")
+            print(f"[Error] Unexpected error during scoring. Setting all as 0. {e}")
             scores = [0.0 for _ in range(len(sequences_str))]
         data.batch["acc"] = torch.tensor(scores, dtype=torch.float32, device=prompt_ids.device)
         return scores


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

>  Fixes a hang issue during reward scoring where the progress bar reaches 100% but the program does not continue. Adds robust support for asynchronous reward computation with subprocess cleanup.

### High-Level Design

> This PR refactors the reward scoring pipeline (`PRIMERewardManager`) to: Adds forced cleanup of lingering subprocesses using psutil to avoid deadlocks.


### Specific Changes

- Replaces `asyncio.run()` inside `verify()` with an external event loop using `new_event_loop()` for better compatibility with Ray and training frameworks.
- Replaces `proc.kill()` with `psutil.terminate()` and `.wait()`, and move from `exception` to `finally` to clean up worker subprocesses safely and avoid zombie processes.

### Additional Info.

- **Issue Number**: #288(maybe)
- **Training**: none
- **Inference**: none

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if neccessary.
