### PR TITLE
[Bug] Bump SGLang version to 0.4.6.post4; Fix AsyncSGLangRollout

### DIFF
--- a/.github/workflows/e2e_ppo_trainer.yml
+++ b/.github/workflows/e2e_ppo_trainer.yml
@@ -186,7 +186,7 @@ jobs:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1
+      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4
       options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -215,7 +215,7 @@ jobs:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1
+      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4
       options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -244,7 +244,7 @@ jobs:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1
+      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4
       options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -273,7 +273,7 @@ jobs:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1
+      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4
       options: --gpus all --shm-size=50g # Visual dataloader requires large memory
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/sgl.yml
+++ b/.github/workflows/sgl.yml
@@ -56,7 +56,7 @@ jobs:
       HF_HUB_ENABLE_HF_TRANSFER: 1
       SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK: "True"
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1
+      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4
       options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -6,7 +6,7 @@
 # Support - Traing: fsdp; Inference: vllm
 # FROM rocm/vllm:rocm6.2_mi300_ubuntu20.04_py3.9_vllm_0.6.4
 # Support - Traing: fsdp; Inference: vllm, sglang
-FROM lmsysorg/sglang:v0.4.6.post1-rocm630
+FROM lmsysorg/sglang:v0.4.6.post4-rocm630
 
 # Set working directory
 # WORKDIR $PWD/app

--- a/docker/Dockerfile.sglang
+++ b/docker/Dockerfile.sglang
@@ -36,8 +36,8 @@ RUN pip config set global.index-url "${PIP_INDEX}" && \
     pip config set global.extra-index-url "${PIP_INDEX}" && \
     python -m pip install --upgrade pip
 
-# Install sglang-0.4.6.post1 and torch-memory-saver
-RUN pip install "sglang[all]==0.4.6.post1" --no-cache-dir --find-links https://flashinfer.ai/whl/cu124/torch2.6/flashinfer-python && pip install torch-memory-saver --no-cache-dir
+# Install sglang-0.4.6.post4 and torch-memory-saver
+RUN pip install "sglang[all]==0.4.6.post4" --no-cache-dir --find-links https://flashinfer.ai/whl/cu124/torch2.6/flashinfer-python && pip install torch-memory-saver --no-cache-dir
 
 # Install torch-2.6.0
 RUN pip install --no-cache-dir torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 tensordict torchdata \

--- a/docker/Dockerfile.vllm.sglang.megatron
+++ b/docker/Dockerfile.vllm.sglang.megatron
@@ -81,7 +81,7 @@ RUN pip uninstall -y pynvml nvidia-ml-py && \
     pip install --no-cache-dir --upgrade "nvidia-ml-py>=12.560.30" "fastapi[standard]>=0.115.0" "optree>=0.13.0" "pydantic>=2.9" "grpcio>=1.62.1"
 
 # Install Sglang
-RUN pip install --no-deps "sglang[all]>=0.4.5.post3"
+RUN pip install --no-deps "sglang[all]>=0.4.6.post3"
 
 # Install cudnn
 RUN aria2c --max-tries=9999 https://developer.download.nvidia.com/compute/cudnn/9.8.0/local_installers/cudnn-local-repo-ubuntu2204-9.8.0_1.0-1_amd64.deb && \

--- a/docs/amd_tutorial/amd_build_dockerfile_page.rst
+++ b/docs/amd_tutorial/amd_build_dockerfile_page.rst
@@ -22,7 +22,7 @@ docker/Dockerfile.rocm
     # Support - Traing: fsdp; Inference: vllm
     # FROM rocm/vllm:rocm6.2_mi300_ubuntu20.04_py3.9_vllm_0.6.4
     # Support - Traing: fsdp; Inference: vllm, sglang
-    FROM lmsysorg/sglang:v0.4.6.post1-rocm630
+    FROM lmsysorg/sglang:v0.4.6.post4-rocm630
 
     # Set working directory
     # WORKDIR $PWD/app

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -42,7 +42,7 @@ For vLLM with Megatron or FSDP, please use the stable version of image ``whatcan
 
 For latest vLLM with FSDP, please refer to ``hiyouga/verl:ngc-th2.6.0-cu126-vllm0.8.4-flashinfer0.2.2-cxx11abi0``.
 
-For SGLang with FSDP, please use ``ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1`` which is provided by SGLang RL Group.
+For SGLang with FSDP, please use ``ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4`` which is provided by SGLang RL Group.
 
 See files under ``docker/`` for NGC-based image or if you want to build your own.
 

--- a/docs/workers/sglang_worker.rst
+++ b/docs/workers/sglang_worker.rst
@@ -20,7 +20,7 @@ Please always follow the following command to install SGLang with verl.
 
 .. code-block:: bash
     pip install --upgrade pip
-    # Currently 0.4.6.post1, subject to updates at any time, please refer to the latest version specified in `setup.py`
+    # Currently 0.4.6.post4, subject to updates at any time, please refer to the latest version specified in `setup.py`
     pip install -e ".[sglang]"
 
 Using SGLang as the Inference Backend for PPO Training on a Single Machine

--- a/requirements_sglang.txt
+++ b/requirements_sglang.txt
@@ -17,5 +17,5 @@ torchdata
 torchvision
 transformers
 wandb
-sglang[all]==0.4.4.post4
+sglang[all]==0.4.6.post4
 torch-memory-saver>=0.0.5

--- a/scripts/install_vllm_sglang_mcore.sh
+++ b/scripts/install_vllm_sglang_mcore.sh
@@ -8,7 +8,7 @@ export MAX_JOBS=32
 echo "1. install inference frameworks and pytorch they need"
 pip install --no-cache-dir "vllm==0.8.4" "torch==2.6.0" "torchvision==0.21.0" "torchaudio==2.6.0" "tensordict==0.6.2" torchdata
 if [ $USE_SGLANG -eq 1 ]; then
-    pip install --no-deps "sglang[all]>=0.4.5.post3"
+    pip install --no-deps "sglang[all]>=0.4.6.post3"
 fi
 
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ MATH_REQUIRES = ["math-verify"]  # Add math-verify as an optional dependency
 VLLM_REQUIRES = ["tensordict<=0.6.2", "vllm<=0.8.5"]
 SGLANG_REQUIRES = [
     "tensordict<=0.6.2",
-    "sglang[srt,openai]==0.4.6.post1",
+    "sglang[srt,openai]==0.4.6.post4",
     "torch-memory-saver>=0.0.5",
 ]
 


### PR DESCRIPTION


### Checklist Before Starting

- [X] Search for similar PR(s).

### What does this PR do?

Similar to https://github.com/sgl-project/sglang/pull/5997

### High-Level Design

In the PP PR https://github.com/sgl-project/sglang/pull/5724 broadcast_pyobj function changed its condition from judging rank==0 (if rank is local rank 0 of the passing ProcessGroup) to rank==src (if rank is global rank src), which breaks VerlEngine's broadcast logic when dp>1 and tp>1.

### Additional Info.

- **Issue Number**: none
- **Training**: both
- **Inference**: SGLang

### Checklist Before Submitting

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [X] Add `[BREAKING]` to the PR title if it breaks any API.
- [X] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add CI test(s) if neccessary.
