### PR TITLE
[Bug] Fix the problem of long inference timeouts when using Async rollout

### DIFF
--- a/verl/workers/rollout/async_server.py
+++ b/verl/workers/rollout/async_server.py
@@ -196,6 +196,8 @@ class ChatCompletionScheduler:
         client = AsyncOpenAI(
             base_url=f"http://{address}/v1",
             api_key="token-abc123",
+            timeout=None,
+            max_retries=0
         )
         return await client.chat.completions.create(**chat_complete_request)
 


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

In Async rollout, `AsyncOpenAI` has a default 600-second timeout, which can lead to timeouts during longer inference. See details at https://github.com/volcengine/verl/pull/1138#issuecomment-2869686490.

### High-Level Design

See details at https://github.com/volcengine/verl/pull/1138#issuecomment-2869686490.

### Specific Changes

See details at https://github.com/volcengine/verl/pull/1138#issuecomment-2869686490.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if neccessary.
