### PR TITLE
[Refactor] Add middle truncation

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -235,6 +235,10 @@ class RLHFDataset(Dataset):
                 raw_prompt_ids = raw_prompt_ids[-self.max_prompt_length :]
             elif self.truncation == "right":
                 raw_prompt_ids = raw_prompt_ids[: self.max_prompt_length]
+            elif self.truncation == "middle":
+                left_half = raw_prompt_ids[: self.max_prompt_length // 2]
+                right_half = raw_prompt_ids[-self.max_prompt_length // 2 :]
+                raw_prompt_ids = left_half + right_half
             elif self.truncation == "error":
                 raise RuntimeError(f"Prompt length {len(raw_prompt_ids)} is longer than {self.max_prompt_length}.")
 

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -236,9 +236,9 @@ class RLHFDataset(Dataset):
             elif self.truncation == "right":
                 raw_prompt_ids = raw_prompt_ids[: self.max_prompt_length]
             elif self.truncation == "middle":
-                left_half = raw_prompt_ids[: self.max_prompt_length // 2]
-                right_half = raw_prompt_ids[-self.max_prompt_length // 2 :]
-                raw_prompt_ids = left_half + right_half
+                left_half = self.max_prompt_length // 2
+                right_half = self.max_prompt_length - left_half
+                raw_prompt_ids = raw_prompt_ids[:left_half] + raw_prompt_ids[-right_half:]
             elif self.truncation == "error":
                 raise RuntimeError(f"Prompt length {len(raw_prompt_ids)} is longer than {self.max_prompt_length}.")
 

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -266,7 +266,7 @@ def postprocess_data(
     """
     input_data is the output from tokenizer.
     """
-    assert truncation in ["left", "right", "error"]
+    assert truncation in ["left", "right", "middle", "error"]
     assert input_ids.ndim == 2
 
     sequence_length = input_ids.shape[-1]
@@ -281,6 +281,11 @@ def postprocess_data(
         elif truncation == "right":
             input_ids = input_ids[:, :max_length]
             attention_mask = attention_mask[:, :max_length]
+        elif truncation == "middle":
+            left_half = max_length // 2
+            right_half = max_length - left_half
+            input_ids = torch.cat([input_ids[:, :left_half], input_ids[:, -right_half:]], dim=-1)
+            attention_mask = torch.cat([attention_mask[:, :left_half], attention_mask[:, -right_half:]], dim=-1)
         elif truncation == "error":
             raise NotImplementedError(f"{sequence_length=} is larger than {max_length=}")
         else:


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

This PR adds support for a new truncation mode, **middle**, for loading datasets. It enables data that exceed the `max_prompt_length` to retain both the beginning and the end of the prompt, instead of truncating content only from the left or only from the right.

### High-Level Design

The implementation introduces a `"middle"` option, alongside the existing truncation modes, making changes in both `rl_dataset.py` and `torch_functional.py`. When selected, the logic splits the allowed max length roughly in half and keeps the head and tail of the sequence, effectively discarding the middle section.

### Specific Changes

**In `verl/utils/dataset/rl_dataset.py`:**  
- Added support for `self.truncation == "middle"` at line ~233.
- Performs symmetric truncation from both ends of the prompt:
```python
elif self.truncation == "middle":
    left_half = raw_prompt_ids[: self.max_prompt_length // 2]
    right_half = raw_prompt_ids[-self.max_prompt_length // 2 :]
    raw_prompt_ids = left_half + right_half
```

**In `verl/utils/torch_functional.py`:**  
- Added support for `"middle"` truncation mode in the `postprocess_data` function.
- Updated truncation assertion to include `"middle"`:
```python
assert truncation in ["left", "right", "middle", "error"]
```
- Implemented middle truncation logic:
```python
elif truncation == "middle":
    left_half = max_length // 2
    right_half = max_length - left_half
    input_ids = torch.cat([input_ids[:, :left_half], input_ids[:, -right_half:]], dim=-1)
    attention_mask = torch.cat([attention_mask[:, :left_half], attention_mask[:, -right_half:]], dim=-1)
```

### API

- Adds `"middle"` as a valid option to the `truncation` argument in the API.

### Usage Example

```python
# Example usage when loading prompts with middle truncation
from verl.utils.dataset.rl_dataset import RLDataset

# Assume tokenizer and other necessary args are already initialized
rl_dataset = RLDataset(
    ...,  # other args
    truncation="middle"
)
```

### Test

This change aligns with precedents from long-context evaluation benchmarks, where *middle truncation* is the default/preferred method for handling overly long inputs:

- [LongBench implementation](https://github.com/THUDM/LongBench/blob/2e00731f8d0bff23dc4325161044d0ed8af94c1e/LongBench/pred.py#L56) ([paper](https://arxiv.org/pdf/2308.14508))
- [InfiniteBench implementation](https://github.com/OpenBMB/InfiniteBench/blob/51d9b37b0f1790ead936df2243abbf7f0420e439/src/eval_utils.py#L413) ([paper](https://arxiv.org/pdf/2402.13718))

Both benchmarks favor middle truncation for long inputs, as it better preserves relevant context information from both the beginning and end of the sequence.

### Additional Info.

- **Issue Number**: N/A (no linked issue yet)
- **Training**: None affected
- **Inference**: None affected

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
