### PR TITLE
[Bug] Remove deprecated val_batch_size from ppo ray_trainer

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -469,13 +469,9 @@ class RayPPOTrainer:
             sampler=train_sampler,
         )
 
-        val_batch_size = self.config.data.val_batch_size  # Prefer config value if set
-        if val_batch_size is None:
-            val_batch_size = len(self.val_dataset)
-
         self.val_dataloader = StatefulDataLoader(
             dataset=self.val_dataset,
-            batch_size=val_batch_size,
+            batch_size=len(self.val_dataset),
             num_workers=self.config.data.get("dataloader_num_workers", 8),
             shuffle=False,
             drop_last=False,


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

> Add one-line overview of what this PR aims to achieve or accomplish. 

This PR removes deprecated configuration field from code.

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

This PR is a simple bugfix PR.

### Specific Changes

> List the specific changes.

Remove the usage of deprecated field, `val_batch_size` from `verl/trainer/ppo/ray_trainer.py`.

### API

> Demonstrate how the API changes if any.

None

### Usage Example

> Provide usage example(s) for easier usage.

No changes is usage.

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if neccessary.
