### PR TITLE
[megatron] fix head_dim in GQA model when load from hf ckpt

### DIFF
--- a/verl/models/mcore/loader.py
+++ b/verl/models/mcore/loader.py
@@ -280,10 +280,10 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
             full_weight_k = state_dict[k_name]
             full_weight_v = state_dict[v_name]
 
-            hidden_size_per_head = config.hidden_size // config.num_attention_heads
+            hidden_size_per_head = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
 
             if config.num_key_value_heads >= tp_size:
-                q_size_tp = config.hidden_size // tp_size
+                q_size_tp = hidden_size_per_head * config.num_attention_heads // tp_size
                 kv_size_tp = hidden_size_per_head * config.num_key_value_heads // tp_size
                 total_size = q_size_tp + 2 * kv_size_tp
                 sizes = [total_size * tp_size]
@@ -304,7 +304,7 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
                         new_weight_qkv_this_tp[j * total_size_per_head : (j + 1) * total_size_per_head].copy_(torch.cat([q_part_per_head[j], k_part_per_head[j], v_part_per_head[j]], dim=0))
 
             else:
-                q_size_tp = config.hidden_size // tp_size
+                q_size_tp = hidden_size_per_head * config.num_attention_heads // tp_size
                 kv_size_tp = hidden_size_per_head
                 total_size = q_size_tp + 2 * kv_size_tp
                 sizes = [total_size * tp_size]

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -446,10 +446,10 @@ def convert_megatron_model_to_transformers_model(
         q_shard_list = []
         k_shard_list = []
         v_shard_list = []
-        hidden_size_per_head = config.hidden_size // config.num_attention_heads
+        hidden_size_per_head = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
 
         if config.num_key_value_heads >= tp_size:
-            q_size_tp = config.hidden_size // tp_size
+            q_size_tp = hidden_size_per_head * config.num_attention_heads // tp_size
             kv_size_tp = hidden_size_per_head * config.num_key_value_heads // tp_size
             total_size = q_size_tp + 2 * kv_size_tp
             for i in range(tp_size):
@@ -465,7 +465,7 @@ def convert_megatron_model_to_transformers_model(
                     k_shard_list.append(k_part)
                     v_shard_list.append(v_part)
         else:
-            q_size_tp = config.hidden_size // tp_size
+            q_size_tp = hidden_size_per_head * config.num_attention_heads // tp_size
             kv_size_tp = hidden_size_per_head
             total_size = q_size_tp + 2 * kv_size_tp
             for i in range(tp_size):
@@ -525,6 +525,8 @@ def convert_megatron_model_to_transformers_model(
                     )
                 else:
                     new_params[f"model.layers.{layer_number}.self_attn.qkv_proj.{param_type}"] = param
+        elif component == "q_layernorm" or component == "k_layernorm":
+            new_params[f"model.layers.{layer_number}.self_attn.{component.replace("layer", "")}.weight"] = param
         else:
             assert isinstance(param, list) and len(param) == 3
             assert param_type == "weight" or param_type == "bias"


### PR DESCRIPTION
### Checklist Before Starting

- [ ] Search for similar PR(s).

### What does this PR do?

fix head_dim in GQA model when load from hf ckpt

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

- Change the acquisition methods of q and kv head_dim to be compatible with GQA.
- Add the conversions of q_layernorm and k_layernorm in convert_megatron_model_to_transformers_model for Qwen3.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue #1510

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if neccessary.
