### PR TITLE
Skip max_position_embeddings > sequence length check for vLLM rollouts if RoPE scaling is used

### DIFF
--- a/docs/advance/rope.rst
+++ b/docs/advance/rope.rst
@@ -1,0 +1,37 @@
+RoPE Scaling override
+=======================================
+
+Some models such as `Qwen/Qwen2.5-7B-Instruct <https://huggingface.co/Qwen/Qwen2.5-7B-Instruct#processing-long-texts>`_ support RoPE Scaling but don't have it defined in their config.json file.
+For example, this model supports this configuration:
+
+.. code:: python
+
+    {
+        ...,
+        "rope_scaling": {
+            "factor": 4.0,
+            "original_max_position_embeddings": 32768,
+            "type": "yarn"
+        }
+    }
+
+
+
+In order to support a longer context for such models, you must override the model configs when starting the trainer.
+
+PPO example:
+
+.. code:: bash
+
+    +actor_rollout_ref.model.override_config.rope_scaling.type=yarn \
+    +actor_rollout_ref.model.override_config.rope_scaling.factor=4.0 \
+    +actor_rollout_ref.model.override_config.rope_scaling.original_max_position_embeddings=32768 \
+
+
+And for the critic model
+
+.. code:: bash
+
+    +critic.model.override_config.rope_scaling.type=yarn \
+    +critic.model.override_config.rope_scaling.factor=4.0 \
+    +critic.model.override_config.rope_scaling.original_max_position_embeddings=32768 \

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,6 +93,7 @@ verl is fast with:
    advance/fsdp_extension
    advance/megatron_extension
    advance/checkpoint
+   advance/rope
    sglang_multiturn/multiturn.rst
 
 .. toctree::

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -96,7 +96,9 @@ class vLLMRollout(BaseRollout):
             ):
                 vllm_ps.initialize_parallel_state(tensor_model_parallel_size=tensor_parallel_size, num_tp_per_train_tp=num_tp_per_train_tp)
 
-        assert model_hf_config.max_position_embeddings >= config.prompt_length + config.response_length, "model context length should be greater than total sequence length"
+        rope_scaling_config = getattr(model_hf_config, 'rope_scaling', None)
+        if not rope_scaling_config:
+            assert model_hf_config.max_position_embeddings >= config.prompt_length + config.response_length, "model context length should be greater than total sequence length"
 
         max_model_len = self.config.max_model_len if self.config.max_model_len else config.prompt_length + config.response_length
         max_model_len = int(max_model_len)

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -107,7 +107,9 @@ class vLLMRollout(BaseRollout):
             else:
                 vllm_ps.initialize_model_parallel(tensor_model_parallel_size=tensor_parallel_size)
 
-        assert model_hf_config.max_position_embeddings >= config.prompt_length + config.response_length, "model context length should be greater than total sequence length"
+        rope_scaling_config = getattr(model_hf_config, 'rope_scaling', None)
+        if not rope_scaling_config:
+            assert model_hf_config.max_position_embeddings >= config.prompt_length + config.response_length, "model context length should be greater than total sequence length"
 
         max_model_len = int(config.max_model_len or config.prompt_length + config.response_length)
 


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Allow usage of sequence lengths longer than model's `max_position_embeddings` when RoPE scaling is used.

Added documentation on how to override RoPE scaling config for models that support RoPE scaling, but don't have it in its config.json file.


### Specific Changes

Skip context length greater than sequence length check for vLLM rollouts if RoPE scaling is used.


### API

No API changes

### Usage Example

Please see the updated docs for example usage.

### Test

I didn't capture any metrics, but I verified this works for my own training run with Qwen/Qwen2.5-7B-Instruct with long contexts.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**:  This affects vLLM, but I can also update SGLang. I've only tested vLLM for my use case 

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if neccessary.
