### PR TITLE
fix: pass param_offload flag to sharding manager

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -457,6 +457,7 @@ class ActorRolloutRefWorker(Worker):
                 model_config=self.actor_model_config,
                 full_params="hf" in self.config.rollout.load_format,
                 device_mesh=rollout_device_mesh,
+                offload_param=self._is_offload_param,
             )
             log_gpu_memory_usage("After building sharding manager", logger=None)
 


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Fix for 'sglang_async' error:

```
  File "verl/verl/workers/sharding_manager/fsdp_sglang.py", line 108, in __enter__
    params = self.module.state_dict()
             ^^^^^^^^^^^^^^^^^^^^^^^^
...
  File "verl/.venv/lib/python3.12/site-packages/torch/distributed/utils.py", line 172, in _p_assert
    raise AssertionError(s)
AssertionError: Expects tensor to be on the compute device cuda:0, was on CPU
```
The error occurs because `self._is_offload_param` is not passed to `FSDPAsyncSGLangShardingManager`

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if neccessary.
