### PR TITLE
[misc] use lazy import on megatron utils components

### DIFF
--- a/verl/utils/megatron/tensor_parallel.py
+++ b/verl/utils/megatron/tensor_parallel.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from megatron.core import ModelParallelConfig
 
 
-def update_kwargs_with_config(dictionary: Dict, config: ModelParallelConfig):
+def update_kwargs_with_config(dictionary: Dict, config: "ModelParallelConfig"):
     dictionary["config"] = config
     return dictionary
 

--- a/verl/utils/megatron/tensor_parallel.py
+++ b/verl/utils/megatron/tensor_parallel.py
@@ -16,13 +16,15 @@
 Utilities for using tensor_parallel in megatron
 """
 
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
 import torch
 import torch.distributed as dist
-from megatron.core import ModelParallelConfig, tensor_parallel
 from megatron.core import parallel_state as mpu
 from torch.nn import init
+
+if TYPE_CHECKING:
+    from megatron.core import ModelParallelConfig
 
 
 def update_kwargs_with_config(dictionary: Dict, config: ModelParallelConfig):
@@ -42,6 +44,8 @@ def get_default_kwargs_for_model_parallel_config():
 
 
 def get_default_model_parallel_config():
+    from megatron.core import ModelParallelConfig
+
     return ModelParallelConfig(**get_default_kwargs_for_model_parallel_config())
 
 
@@ -57,6 +61,8 @@ def get_common_default_kwargs_for_parallel_linear():
 
 
 def get_default_kwargs_for_column_parallel_linear():
+    from megatron.core import ModelParallelConfig
+
     model_parallel_config_kwargs = get_default_kwargs_for_model_parallel_config()
     column_parallel_config_kwargs = {
         "async_tensor_model_parallel_allreduce": False,
@@ -76,6 +82,8 @@ def get_default_kwargs_for_row_parallel_linear():
 
 
 def get_default_kwargs_for_parallel_embedding():
+    from megatron.core import ModelParallelConfig
+
     model_parallel_config_kwargs = get_default_kwargs_for_model_parallel_config()
     embedding_default_kwargs = {
         "init_method": init.xavier_normal_,
@@ -145,6 +153,8 @@ def vocab_parallel_entropy(vocab_parallel_logits: torch.Tensor) -> torch.Tensor:
 
 def vocab_parallel_log_probs_from_logits(logits, labels):
     """TODO(zhangchi.usc1992): We may change the implementation later"""
+    from megatron.core import tensor_parallel
+
     return -tensor_parallel.vocab_parallel_cross_entropy(vocab_parallel_logits=logits, target=labels)
 
 


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

This PR moves the `from megatron.core import ModelParallelConfig, tensor_parallel` into lazy import, so that when utilities who don't use these modules are imported, we don't always import `megatron.core.xxx` by default.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if neccessary.
