### PR TITLE
[BUG] Fix silent bug of using dtype from previous loop scope in build_memory_reference_from_module()

### DIFF
--- a/verl/utils/memory_buffer.py
+++ b/verl/utils/memory_buffer.py
@@ -104,7 +104,7 @@ def build_memory_reference_from_module(module: torch.nn.Module, memory_buffers: 
         memory_buffer = memory_buffers[param.dtype]
         buffer = memory_buffer.get(shape=param.shape, start_index=start_index[param.dtype])
         # need to increment start_index
-        start_index[param.dtype] += calc_padded_numel(param.shape, dtype)
+        start_index[param.dtype] += calc_padded_numel(param.shape, param.dtype)
         if maintain_weight:
             buffer.copy_(param.data)
         param.data = buffer


### PR DESCRIPTION
This pull request includes a minor fix in the `build_memory_reference_from_module` function within `verl/utils/memory_buffer.py`. The change ensures that the correct data type is passed when calculating the padded number of elements.

* **Bug Fix**:
  - Updated the `calc_padded_numel` function call to use `param.dtype` instead of `dtype`, ensuring compatibility with the parameter's actual data type. (`[verl/utils/memory_buffer.pyL107-R107](diffhunk://#diff-77d53102508293685e0b9a1281dbacf7720fb8070db73157aa90157d516004a4L107-R107)`)

### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

> Add one-line overview of what this PR aims to achieve or accomplish. 

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if neccessary.
