### PR TITLE
[feat] custom rollout config

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -17,8 +17,8 @@ data:
   image_key: images
   video_key: videos
   custom_cls:
-      path: null
-      name: null
+    path: null
+    name: null
 
 actor_rollout_ref:
   hybrid_engine: True
@@ -132,6 +132,10 @@ actor_rollout_ref:
       max_turns: null  # null for no limit (default max_length // 3)
       tool_config_path: null  # null for no tool
       format: chatml  # chatml, more formats will be supported in the future
+    custom_cls:
+      path: null
+      rollout_name: null
+      sharding_manager_name: null
 
 critic:
   rollout_n: ${actor_rollout_ref.rollout.n}

--- a/verl/workers/rollout/hf_rollout.py
+++ b/verl/workers/rollout/hf_rollout.py
@@ -36,10 +36,10 @@ __all__ = ["HFRollout"]
 
 
 class HFRollout(BaseRollout):
-    def __init__(self, module: nn.Module, config):
+    def __init__(self, actor_module: nn.Module, config):
         super().__init__()
         self.config = config
-        self.module = module
+        self.module = actor_module
 
     def generate_sequences(self, prompts: DataProto) -> DataProto:
         batch_size = prompts.batch.batch_size[0]

--- a/verl/workers/rollout/sglang_rollout/async_sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_rollout.py
@@ -166,7 +166,7 @@ class AsyncSGLangRollout(BaseRollout):
 
         if not self.config.get("max_model_len", None):
             self.config.max_model_len = self.config.prompt_length + self.config.response_length
-        assert self.config.max_model_len >= self.config.prompt_length + self.config.response_length, f"""max_model_len should be greater than total sequence length (prompt_length + response_length): 
+        assert self.config.max_model_len >= self.config.prompt_length + self.config.response_length, f"""max_model_len should be greater than total sequence length (prompt_length + response_length):
             {self.config.max_model_len} >= {self.config.prompt_length} + {self.config.response_length}"""
         assert model_hf_config.max_position_embeddings >= self.config.max_model_len, "model context length should be greater than total sequence length"
         # currently max_turns stand for max number of tool calls
@@ -266,6 +266,10 @@ class AsyncSGLangRollout(BaseRollout):
 
         self.tokenizer = tokenizer
         self.pad_token_id = tokenizer.pad_token_id
+
+    @property
+    def inference_engine(self) -> Engine:
+        return self._engine
 
     @contextmanager
     def update_sampling_params(self, **kwargs):
@@ -605,7 +609,7 @@ class AsyncSGLangRollout(BaseRollout):
         reward_scores = []
         for req in sorted_output_req_list:
             assert req.state == AsyncRolloutRequestStateEnum.COMPLETED, f"Request {req.request_id} is not completed"
-            assert len(req.input_ids) == len(req.attention_mask) == len(req.position_ids) == len(req.loss_mask), f"""Request {req.request_id} has different length of 
+            assert len(req.input_ids) == len(req.attention_mask) == len(req.position_ids) == len(req.loss_mask), f"""Request {req.request_id} has different length of
                 {len(req.input_ids)=}, {len(req.attention_mask)=}, {len(req.position_ids)=}, {len(req.loss_mask)=}"""
             error_message_lines = [
                 f"""Request {req.request_id} has input_ids length {len(req.input_ids)}
@@ -623,7 +627,7 @@ class AsyncSGLangRollout(BaseRollout):
             response_ids.append(torch.tensor(req.response_ids, dtype=torch.int, device=tgt_device))
             if len(req.response_ids) > self.config.response_length:
                 print(
-                    f"""{req.request_id=} has response_ids length {len(req.response_ids)} 
+                    f"""{req.request_id=} has response_ids length {len(req.response_ids)}
                     greater than max_response_len {self.config.response_length},\n{req=}"""
                 )
             prompt_attention_mask.append(torch.tensor(req.prompt_attention_mask, dtype=torch.int, device=tgt_device))

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -46,14 +46,14 @@ class FSDPVLLMShardingManager(BaseShardingManager):
     @check_cuda_is_available()
     def __init__(
         self,
-        module: FSDP,
+        actor_module: FSDP,
         inference_engine: LLM,
         model_config,
         full_params: bool = False,
         device_mesh: DeviceMesh = None,
         offload_param: bool = False,
     ):
-        self.module = module
+        self.module = actor_module
         # For AsyncLLM, inference_engine and model_runner are defer intialized in vLLMAsyncRollout.load_model
         self.inference_engine = inference_engine
         # self.model_runner = inference_engine.llm_engine.model_executor.driver_worker.worker.model_runner if inference_engine else None


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Adds option to use custom rollout class for data scientists to do experimental agent workflow.

Sometimes the process of using agents will be extremely complex. Maybe vLLM/SGLang can't support newer models like Qwen2-omni or tMRoPE correctly. So it's necessary to hack the rollout process.

### High-Level Design

Not necessary

### Specific Changes

- Adds the custom_cls option for rollout classes.

### API

The user has to implement a custom rollout class with a similar signature to vLLMRollout and SGLangRollout.
A sharding manager class is also needed although reusing the sharding manager of vLLM / SGLang is also usually possible.

### Usage Example

```python
# /path/to/custom_rollout.py

from verl.workers.rollout.vllm_rollout import vLLMRollout
from verl.workers.sharding_manager.fsdp_vllm import FSDPVLLMShardingManager

class CustomRollout(vLLMRollout):
    def generate_sequences(self, prompts: DataProto, **kwargs) -> DataProto:
        # Custom generate_sequences code here
        ...
```

```sh
actor_rollout_ref.rollout.custom_cls.path=/path/to/custom_rollout.py
actor_rollout_ref.rollout.custom_cls.rollout_name=CustomRollout
actor_rollout_ref.rollout.custom_cls.sharding_manager_name=FSDPVLLMShardingManager
```

### Test

Not necessary

### Additional Info.

Not relevant

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if neccessary.
