### PR TITLE
Bump to sglang 0.4.6.post4 & unified generate sequences ability between sgl and sgl async

### DIFF
--- a/.github/workflows/e2e_ppo_trainer.yml
+++ b/.github/workflows/e2e_ppo_trainer.yml
@@ -194,7 +194,7 @@ jobs:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1
+      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4
       options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -223,7 +223,7 @@ jobs:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1
+      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4
       options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -252,7 +252,7 @@ jobs:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1
+      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4
       options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -281,7 +281,7 @@ jobs:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1
+      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4
       options: --gpus all --shm-size=50g # Visual dataloader requires large memory
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/sgl.yml
+++ b/.github/workflows/sgl.yml
@@ -56,7 +56,7 @@ jobs:
       HF_HUB_ENABLE_HF_TRANSFER: 1
       SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK: "True"
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1
+      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4
       options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -6,7 +6,7 @@
 # Support - Traing: fsdp; Inference: vllm
 # FROM rocm/vllm:rocm6.2_mi300_ubuntu20.04_py3.9_vllm_0.6.4
 # Support - Traing: fsdp; Inference: vllm, sglang
-FROM lmsysorg/sglang:v0.4.6.post1-rocm630
+FROM lmsysorg/sglang:v0.4.6.post4-rocm630
 
 # Set working directory
 # WORKDIR $PWD/app

--- a/docker/Dockerfile.sglang
+++ b/docker/Dockerfile.sglang
@@ -37,7 +37,7 @@ RUN pip config set global.index-url "${PIP_INDEX}" && \
     python -m pip install --upgrade pip
 
 # Install sglang-0.4.6.post1 and torch-memory-saver
-RUN pip install "sglang[all]==0.4.6.post1" --no-cache-dir --find-links https://flashinfer.ai/whl/cu124/torch2.6/flashinfer-python && pip install torch-memory-saver --no-cache-dir
+RUN pip install "sglang[all]==0.4.6.post4" --no-cache-dir --find-links https://flashinfer.ai/whl/cu124/torch2.6/flashinfer-python && pip install torch-memory-saver --no-cache-dir
 
 # Install torch-2.6.0
 RUN pip install --no-cache-dir torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 tensordict torchdata \

--- a/docker/Dockerfile.sglang
+++ b/docker/Dockerfile.sglang
@@ -36,7 +36,7 @@ RUN pip config set global.index-url "${PIP_INDEX}" && \
     pip config set global.extra-index-url "${PIP_INDEX}" && \
     python -m pip install --upgrade pip
 
-# Install sglang-0.4.6.post1 and torch-memory-saver
+# Install sglang-0.4.6.post4 and torch-memory-saver
 RUN pip install "sglang[all]==0.4.6.post4" --no-cache-dir --find-links https://flashinfer.ai/whl/cu124/torch2.6/flashinfer-python && pip install torch-memory-saver --no-cache-dir
 
 # Install torch-2.6.0

--- a/docker/Dockerfile.vllm.sglang.megatron
+++ b/docker/Dockerfile.vllm.sglang.megatron
@@ -81,7 +81,7 @@ RUN pip uninstall -y pynvml nvidia-ml-py && \
     pip install --no-cache-dir --upgrade "nvidia-ml-py>=12.560.30" "fastapi[standard]>=0.115.0" "optree>=0.13.0" "pydantic>=2.9" "grpcio>=1.62.1"
 
 # Install Sglang
-RUN pip install --no-deps "sglang[all]>=0.4.6.post4"
+RUN pip uninstall -y cuda-python && pip install --no-deps "sglang[all]>=0.4.6.post4"
 
 # Install cudnn
 RUN aria2c --max-tries=9999 https://developer.download.nvidia.com/compute/cudnn/9.8.0/local_installers/cudnn-local-repo-ubuntu2204-9.8.0_1.0-1_amd64.deb && \

--- a/docs/amd_tutorial/amd_build_dockerfile_page.rst
+++ b/docs/amd_tutorial/amd_build_dockerfile_page.rst
@@ -22,7 +22,7 @@ docker/Dockerfile.rocm
     # Support - Traing: fsdp; Inference: vllm
     # FROM rocm/vllm:rocm6.2_mi300_ubuntu20.04_py3.9_vllm_0.6.4
     # Support - Traing: fsdp; Inference: vllm, sglang
-    FROM lmsysorg/sglang:v0.4.6.post1-rocm630
+    FROM lmsysorg/sglang:v0.4.6.post4-rocm630
 
     # Set working directory
     # WORKDIR $PWD/app

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -42,7 +42,7 @@ For vLLM with Megatron or FSDP, please use the stable version of image ``whatcan
 
 For latest vLLM with FSDP, please refer to ``hiyouga/verl:ngc-th2.6.0-cu126-vllm0.8.4-flashinfer0.2.2-cxx11abi0``.
 
-For SGLang with FSDP, please use ``ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post1`` which is provided by SGLang RL Group.
+For SGLang with FSDP, please use ``ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.6.post4`` which is provided by SGLang RL Group.
 
 See files under ``docker/`` for NGC-based image or if you want to build your own.
 

--- a/docs/workers/sglang_worker.rst
+++ b/docs/workers/sglang_worker.rst
@@ -20,8 +20,18 @@ Please always follow the following command to install SGLang with verl.
 
 .. code-block:: bash
     pip install --upgrade pip
-    # Currently 0.4.6.post1, subject to updates at any time, please refer to the latest version specified in `setup.py`
+    # Currently 0.4.6.post4, subject to updates at any time, please refer to the latest version specified in `setup.py`
     pip install -e ".[sglang]"
+
+You can check the following dependencies are in your environment:
+
+.. note::
+
+    - **PyTorch**: 2.6.0+cu124
+    - **CUDA**: 12.4
+    - **flashinfer-python**: 0.2.5+cu124torch2.6
+    - **sgLang**: 0.4.6.post4
+    - **sgl-kernel**: 0.1.2.post1
 
 Using SGLang as the Inference Backend for PPO Training on a Single Machine
 -------------------------------------------------------------------------

--- a/requirements_sglang.txt
+++ b/requirements_sglang.txt
@@ -17,5 +17,5 @@ torchdata
 torchvision
 transformers
 wandb
-sglang[all]==0.4.4.post4
+sglang[all]==0.4.6.post4
 torch-memory-saver>=0.0.5

--- a/setup.py
+++ b/setup.py
@@ -49,11 +49,7 @@ GEO_REQUIRES = ["mathruler"]
 GPU_REQUIRES = ["liger-kernel", "flash-attn"]
 MATH_REQUIRES = ["math-verify"]  # Add math-verify as an optional dependency
 VLLM_REQUIRES = ["tensordict<=0.6.2", "vllm<=0.8.5"]
-SGLANG_REQUIRES = [
-    "tensordict<=0.6.2",
-    "sglang[srt,openai]==0.4.6.post1",
-    "torch-memory-saver>=0.0.5",
-]
+SGLANG_REQUIRES = ["tensordict<=0.6.2", "sglang[srt,openai]==0.4.6.post4", "torch-memory-saver>=0.0.5", "torch==2.6.0"]
 
 extras_require = {
     "test": TEST_REQUIRES,

--- a/verl/workers/rollout/sglang_rollout/utils.py
+++ b/verl/workers/rollout/sglang_rollout/utils.py
@@ -1,0 +1,66 @@
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 ModelBest Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pickle
+from typing import Any, List, Optional
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+
+def broadcast_pyobj(
+    data: List[Any],
+    rank: int,
+    dist_group: Optional[torch.distributed.ProcessGroup] = None,
+    src: int = 0,
+    force_cpu_device: bool = False,
+):
+    """from https://github.com/sgl-project/sglang/blob/844e2f227ab0cce6ef818a719170ce37b9eb1e1b/python/sglang/srt/utils.py#L905
+
+    Broadcast inputs from src rank to all other ranks with torch.dist backend.
+    The `rank` here refer to the source rank on global process group (regardless
+    of dist_group argument).
+    """
+    device = torch.device("cuda" if torch.cuda.is_available() and not force_cpu_device else "cpu")
+
+    if rank == src:
+        if len(data) == 0:
+            tensor_size = torch.tensor([0], dtype=torch.long, device=device)
+            dist.broadcast(tensor_size, src=src, group=dist_group)
+        else:
+            serialized_data = pickle.dumps(data)
+            size = len(serialized_data)
+
+            tensor_data = torch.ByteTensor(np.frombuffer(serialized_data, dtype=np.uint8)).to(device)
+            tensor_size = torch.tensor([size], dtype=torch.long, device=device)
+
+            dist.broadcast(tensor_size, src=src, group=dist_group)
+            dist.broadcast(tensor_data, src=src, group=dist_group)
+        return data
+    else:
+        tensor_size = torch.tensor([0], dtype=torch.long, device=device)
+        dist.broadcast(tensor_size, src=src, group=dist_group)
+        size = tensor_size.item()
+
+        if size == 0:
+            return []
+
+        tensor_data = torch.empty(size, dtype=torch.uint8, device=device)
+        dist.broadcast(tensor_data, src=src, group=dist_group)
+
+        serialized_data = bytes(tensor_data.cpu().numpy())
+        data = pickle.loads(serialized_data)
+        return data


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).
- Thanks to:
  - close #1558 due to mix of prs
  - close #1449 due to partial fix sgl new version issue
  - close #1300 which is part of current pr
- This pr is co-authored with @ocss884 

### What does this PR do?

> Add one-line overview of what this PR aims to achieve or accomplish. 

- bump sglang to 0.4.6.post4
- unified sglang and sglang_async `generate_sequences` api behavior, e.g. image support
- fix warning for cuda barrier at start of fsdp_workers

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if necessary.
