### PR TITLE
[rollout] perf: replace AsyncOpenAI to aiohttp client in ChatCompletionScheduler

### DIFF
--- a/examples/ppo_trainer/naive_chat_scheduler.py
+++ b/examples/ppo_trainer/naive_chat_scheduler.py
@@ -46,6 +46,7 @@ class NaiveChatCompletionScheduler(ChatCompletionScheduler):
         print(f"[NaiveChatCompletionScheduler] generate_sequences sampling params: {kwargs}")
 
         async def callback(completions: ChatCompletion, info: Dict[str, Any], exception: Exception):
+            assert exception is None, f"exception: {exception}"
             conversation, batch_conversations, batch_index = (
                 info["conversation"],
                 info["batch_conversations"],
@@ -77,7 +78,7 @@ class NaiveChatCompletionScheduler(ChatCompletionScheduler):
                             "conversation": list(conversation),
                         },
                         model=self.model_name,
-                        messages=conversation,
+                        messages=conversation.tolist(),
                         **kwargs,
                     )
                 )

--- a/tests/workers/rollout/test_vllm_tool_calling.py
+++ b/tests/workers/rollout/test_vllm_tool_calling.py
@@ -32,7 +32,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from examples.ppo_trainer.naive_chat_scheduler import NaiveChatCompletionScheduler
-from tests.rollout.async_rollout_utils import init_async_rollout_manager
+from tests.workers.rollout.async_rollout_utils import init_async_rollout_manager
 from verl.protocol import DataProto
 
 
@@ -257,7 +257,7 @@ def test_vllm_tool_calling():
     config = OmegaConf.load("verl/trainer/config/ppo_trainer.yaml")
     config.actor_rollout_ref.model.path = "Qwen/Qwen2-7B-Instruct"
     config.actor_rollout_ref.rollout.mode = "async"
-    config.actor_rollout_ref.rollout.chat_scheduler = "tests.rollout.test_vllm_tool_calling.ToolChatCompletionScheduler"
+    config.actor_rollout_ref.rollout.chat_scheduler = "tests.workers.rollout.test_vllm_tool_calling.ToolChatCompletionScheduler"
     config.actor_rollout_ref.rollout.prompt_length = 8192
     config.actor_rollout_ref.rollout.response_length = 8192
 

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -94,6 +94,7 @@ class ExternalRayDistributedExecutor(Executor):
             sent_method = cloudpickle.dumps(method)
         del method
 
+        # ~3ms overhead per schedule step due to SchedulerOutput/ModelRunnerOutput serialization/deserialization.
         outputs = ray.get([worker.execute_method.remote(sent_method, *args, **(kwargs or {})) for worker in self.workers])
         return outputs
 


### PR DESCRIPTION
### Checklist Before Starting

- [ ] Search for similar PR(s).

### What does this PR do?

AsyncOpenAI has very severe performance issue due to httpx, replace it to aiohttp client. For train_batch_size=1024, AsyncOpenAI introduces ~25s per generation phase.

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
