### PR TITLE
Support multi-turn rollout with Qwen chat template

### DIFF
--- a/examples/sglang_multiturn/config/gsm8k_multiturn_grpo.yaml
+++ b/examples/sglang_multiturn/config/gsm8k_multiturn_grpo.yaml
@@ -19,4 +19,5 @@ actor_rollout_ref:
     multi_turn:
       enable: True
       max_turns: 5
+      format: qwen
       # tool_config_path: "./config/tool_config/gsm8k_tool_config.yaml"

--- a/verl/workers/rollout/sglang_rollout/async_sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_rollout.py
@@ -457,8 +457,8 @@ class AsyncSGLangRollout(BaseRollout):
                             for tool_call in parsed_tool_calls
                         ]
                     )
-                    for tool_call, (resp, reward, metrics) in zip(parsed_tool_calls, tool_call_results):
-                        _req.add_tool_response_message(self.tokenizer, resp, format=self.config.multi_turn.format)
+                    for i, (tool_call, (resp, reward, metrics)) in enumerate(zip(parsed_tool_calls, tool_call_results)):
+                        _req.add_tool_response_message(self.tokenizer, resp, (i == len(parsed_tool_calls) - 1), format=self.config.multi_turn.format)
                         if len(_req.input_ids) >= self.config.max_model_len:
                             break
                     if len(_req.input_ids) >= self.config.max_model_len:


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Support multi-turn rollout with Qwen chat template

### Specific Changes

Currently, Verl's multi-turn rollout only supports ChatML-style messages. However, Qwen uses a different chat formatting template with the following key differences:

1. Qwen uses the `user` role tag to wrap tool responses.
2. Qwen merges consecutive tool responses into a single message.

**For example**, for parallel tool calls, ChatML renders consecutive tool responses like this:
```
<|im_start|>tool
tool response content 1<|im_end|>
<|im_start|>tool
tool response content 2<|im_end|>
```
In contrast, the Qwen chat template renders them as:
```
<|im_start|>user
<tool_response>
tool response content 1
</tool_response>
<tool_response>
tool response content 2
</tool_response><|im_end|>
```

This PR introduces a new `qwen` format option in the config to support this tool message style.

### Usage Example

Set the multi-turn format to `qwen`:
```
multi_turn:
    enable: True
    max_turns: 5
    format: qwen
```

### Test

Verified the rendered messages via print output to ensure:
1. ChatML format remains unchanged.
2. Qwen format aligns with the Qwen chat template as defined in its HuggingFace tokenizer config.

Tested across the following scenarios:
1. Assistant message without tool calls.
2. Assistant message with one tool call + one tool response message.
3. Assistant message with parallel tool calls + multiple consecutive tool response messages.

### Additional Info.
- **Inference**: SGLang

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
