### PR TITLE
Disable fused kernels in prime

### DIFF
--- a/recipe/prime/config/prime_trainer.yaml
+++ b/recipe/prime/config/prime_trainer.yaml
@@ -32,7 +32,7 @@ reward_model:
   model:
     ref_path: ${reward_model.model.path}
     use_remove_padding:  True
-    use_fused_kernels: True
+    use_fused_kernels: False
     tokenizer_path: ${actor_rollout_ref.model.path}
     enable_gradient_checkpointing: ${actor_rollout_ref.model.enable_gradient_checkpointing}
     ref_type: freeze


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?
Currently, the `e2e_prime` test encounters the error` AttributeError: 'NoneType' object has no attribute 'squeeze'`, which is caused by [ #1212].

In PR [#1568], the parameter `use_fused_kernel` in `ppo_trainer.yaml` was set to `false`, but the corresponding parameter in `prime_trainer.yaml` was not updated. This is preventing the CI from passing.  Before the root cause of `use_fused_kernel` is fully resolved , I guess we should temporarily set `use_fused_kernel` to `false` in `prime_trainer.yaml`
### High-Level Design

Not needed

### Specific Changes

- Default use_fused_kernels = False

### API

Not needed

### Usage Example

Not needed

### Test

Not needed

### Additional Info.

Not needed

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if necessary.
