### PR TITLE
Expose `engine_kwargs` from SGLang to Verl configuration

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -170,6 +170,7 @@ Actor/Rollout/Reference Policy
       do_sample: True
       engine_kwargs: # inference engine parameters
         swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
+        attention_backend: fa3 # null means use the engine default value, available options: flashinfer, triton, flashmla
       # number of responses (i.e. num sample times)
       n: 1 # > 1 for grpo, rloo
       val_kwargs:
@@ -322,6 +323,12 @@ Reference model will be enabled when ``actor.use_kl_loss`` or/and ``algorithm.us
 - ``actor_rollout_ref.rollout.engine_kwargs.swap_space``: swap space in GB used by the inference engine.
   - ``null``: means not setting and using the engine default value (usually, e.g., 4 GB for vLLM)
   - Positive integer, e.g., ``32`` means 32 GB.
+
+- ``actor_rollout_ref.rollout.engine_kwargs.attention_backend``: The attention backend to use for the inference engine.
+  - ``null``: means not setting and using the engine default value (usually, e.g., ``fa3`` for SGLang)
+  - ``flashinfer``: Use flashinfer attention backend.
+  - ``triton``: Use triton attention backend.
+  - ``flashmla``: Use flashmla attention backend.
 
 - ``actor_rollout_ref.rollout.ignore_eos``: Whether to ignore the EOS
   token and continue generating tokens after the EOS token is generated.

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -148,6 +148,7 @@ actor_rollout_ref:
     n: 1
     engine_kwargs: # inference engine parameters
       swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
+      attention_backend: fa3 # null means use the engine default value, available options: flashinfer, triton, flashmla
     val_kwargs:
       # sampling parameters for validation
       top_k: -1 # 0 for hf rollout, -1 for vllm rollout

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -121,7 +121,7 @@ actor_rollout_ref:
     n: 1 # > 1 for grpo
     engine_kwargs: # inference engine parameters
       swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
-      attention_backend: fa3 # null means use the engine default value, available options: flashinfer, triton, flashmla
+      attention_backend: null # null means use the engine default value, available options: fa3, flashinfer, triton, flashmla
     val_kwargs:
       # sampling parameters for validation
       top_k: -1 # 0 for hf rollout, -1 for vllm rollout

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -121,6 +121,7 @@ actor_rollout_ref:
     n: 1 # > 1 for grpo
     engine_kwargs: # inference engine parameters
       swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
+      attention_backend: fa3 # null means use the engine default value, available options: flashinfer, triton, flashmla
     val_kwargs:
       # sampling parameters for validation
       top_k: -1 # 0 for hf rollout, -1 for vllm rollout


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Expose `engine_kwargs` from SGLang to Verl configuration

This PR enables RL users to configure `engine_kwargs` directly through Verl, providing more control and flexibility over inference behavior.



### High-Level Design

One key motivation is the choice of attention backend, which can significantly affect rollout performance. The SGLang team has observed that different attention backends perform better in different phases:

FA3 tends to be more efficient during the prefill stage.

FlashInfer or Triton generally offer better performance during decode.

Moreover, the optimal backend may change across versions of SGLang. By exposing these parameters, we allow users to tune their setup based on the specific use case and version, ultimately improving performance and adaptability.
> Add one-line overview of what this PR aims to achieve or accomplish. 

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

In my setup about QWen 2.5 7B Instruct on H200:
```
timing_s/step:106.761 (flash infer)
timing_s/step:100.520 （fa3)
timing_s/step:100.364 (triton)
```

Hence, I would suggest our team to use fa3 or triton for now.

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
