### PR TITLE
[Refactor] fused kernel in forward

### DIFF
--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -233,11 +233,12 @@ def llama_attn_forward(
 
 
 @dataclass
-class CausalLMOutputWithoutLogits(CausalLMOutputWithPast):
-    last_hidden_state: Optional[torch.FloatTensor] = None
+class CausalLMOutputForPPO(CausalLMOutputWithPast):
+    log_probs: Optional[torch.FloatTensor] = None
+    entropy: Optional[torch.FloatTensor] = None
 
 
-def forward_without_logits(
+def forward_for_ppo(
     self,
     input_ids: torch.LongTensor = None,
     attention_mask: Optional[torch.Tensor] = None,
@@ -251,14 +252,17 @@ def forward_without_logits(
     return_dict: Optional[bool] = None,
     cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
+    temperature: float = 1.0,
     **loss_kwargs,
-) -> Union[Tuple, CausalLMOutputWithoutLogits]:
+) -> Union[Tuple, CausalLMOutputForPPO]:
     r"""
     Copy paste LLaMa's forward
     https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/model/llama.py
 
     This function should be generic enough for all pure text models.
     ```"""
+    from verl.utils.experimental.torch_functional import FusedLinearForPPO
+
     output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
     output_hidden_states = (
         output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -281,13 +285,29 @@ def forward_without_logits(
 
     hidden_states = outputs[0]
 
-    if labels is not None:
-        raise NotImplementedError("forward_without_logits does not support labels")
     if not return_dict:
-        raise NotImplementedError("forward_without_logits has to return_dict")
+        raise NotImplementedError("forward_for_ppo has to return_dict")
 
-    return CausalLMOutputWithoutLogits(
-        last_hidden_state=hidden_states,
+    # Loss calculations
+    rolled_hidden_states = hidden_states[..., :-1, :]
+    if labels is not None:
+        rolled_labels = labels[..., 1:]
+    elif input_ids is not None:
+        rolled_labels = input_ids[..., 1:]
+    else:
+        raise RuntimeError("To use forward_for_ppo, either labels or input_ids must be provided.")
+
+    fused_linear_for_ppo = FusedLinearForPPO()
+    log_probs, entropy = fused_linear_for_ppo.forward(
+        hidden_states=rolled_hidden_states,
+        vocab_weights=self.lm_head.weight,
+        input_ids=rolled_labels,
+        temperature=temperature,
+    )
+
+    return CausalLMOutputForPPO(
+        log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,

--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -289,17 +289,16 @@ def forward_for_ppo(
         raise NotImplementedError("forward_for_ppo has to return_dict")
 
     # Loss calculations
-    rolled_hidden_states = hidden_states[..., :-1, :]
     if labels is not None:
-        rolled_labels = labels[..., 1:]
+        rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
-        rolled_labels = input_ids[..., 1:]
+        rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)
     else:
         raise RuntimeError("To use forward_for_ppo, either labels or input_ids must be provided.")
 
     fused_linear_for_ppo = FusedLinearForPPO()
     log_probs, entropy = fused_linear_for_ppo.forward(
-        hidden_states=rolled_hidden_states,
+        hidden_states=hidden_states,
         vocab_weights=self.lm_head.weight,
         input_ids=rolled_labels,
         temperature=temperature,

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -25,6 +25,7 @@ from packaging import version
 from transformers.modeling_flash_attention_utils import _flash_attention_forward
 from transformers.modeling_utils import PreTrainedModel
 
+from verl.models.transformers.llama import forward_for_ppo
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
     gather_seq_scatter_heads,
@@ -134,9 +135,9 @@ def apply_monkey_patch(
             print("Monkey patch FlashAttention2.forward in Qwen2.5VL")
 
         if use_fused_kernels:
-            from verl.models.transformers.qwen2_5_vl import forward_without_logits
+            from verl.models.transformers.qwen2_5_vl import forward_for_ppo
 
-            Qwen2_5_VLForConditionalGeneration.forward = forward_without_logits
+            Qwen2_5_VLForConditionalGeneration.forward = forward_for_ppo
 
         return
 
@@ -153,9 +154,9 @@ def apply_monkey_patch(
             print("Monkey patch FlashAttention2.forward in Qwen2VL")
 
         if use_fused_kernels:
-            from verl.models.transformers.qwen2_vl import forward_without_logits
+            from verl.models.transformers.qwen2_vl import forward_for_ppo
 
-            Qwen2VLForConditionalGeneration.forward = forward_without_logits
+            Qwen2VLForConditionalGeneration.forward = forward_for_ppo
 
         return
 
@@ -172,9 +173,9 @@ def apply_monkey_patch(
             print(f"Monkey patch _flash_attention_forward in {flash_attention.__name__}")
 
     if use_fused_kernels:
-        from verl.models.transformers.llama import forward_without_logits
+        from verl.models.transformers.llama import forward_for_ppo
 
-        model.__class__.forward = forward_without_logits
+        model.__class__.forward = forward_for_ppo
 
 
 @lru_cache

--- a/verl/models/transformers/qwen2_5_vl.py
+++ b/verl/models/transformers/qwen2_5_vl.py
@@ -23,11 +23,12 @@ from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
 
 
 @dataclass
-class Qwen2_5_VLCausalLMOutputWithoutLogits(Qwen2_5_VLCausalLMOutputWithPast):
-    last_hidden_state: Optional[torch.FloatTensor] = None
+class Qwen2_5_VLCausalLMOutputForPPO(Qwen2_5_VLCausalLMOutputWithPast):
+    log_probs: Optional[torch.FloatTensor] = None
+    entropy: Optional[torch.FloatTensor] = None
 
 
-def forward_without_logits(
+def forward_for_ppo(
     self: Qwen2_5_VLForConditionalGeneration,
     input_ids: torch.LongTensor = None,
     attention_mask: Optional[torch.Tensor] = None,
@@ -46,12 +47,15 @@ def forward_without_logits(
     rope_deltas: Optional[torch.LongTensor] = None,
     cache_position: Optional[torch.LongTensor] = None,
     second_per_grid_ts: Optional[torch.Tensor] = None,
+    temperature: float = 1.0,
     **loss_kwargs,
-) -> Union[Tuple, Qwen2_5_VLCausalLMOutputWithoutLogits]:
+) -> Union[Tuple, Qwen2_5_VLCausalLMOutputForPPO]:
     r"""
     Copy paste Qwen2_5_VL's forward
     https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/model/qwen2_5_vl.py
     ```"""
+    from verl.utils.experimental.torch_functional import FusedLinearForPPO
+
     output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
     output_hidden_states = (
         output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -137,13 +141,29 @@ def forward_without_logits(
 
     hidden_states = outputs[0]
 
-    if labels is not None:
-        raise NotImplementedError("forward_without_logits does not support labels")
     if not return_dict:
-        raise NotImplementedError("forward_without_logits has to return_dict")
+        raise NotImplementedError("forward_for_ppo has to return_dict")
 
-    return Qwen2_5_VLCausalLMOutputWithoutLogits(
-        last_hidden_state=hidden_states,
+    # Loss calculations
+    rolled_hidden_states = hidden_states[..., :-1, :]
+    if labels is not None:
+        rolled_labels = labels[..., 1:]
+    elif input_ids is not None:
+        rolled_labels = input_ids[..., 1:]
+    else:
+        raise RuntimeError("To use forward_for_ppo, either labels or input_ids must be provided.")
+
+    fused_linear_for_ppo = FusedLinearForPPO()
+    log_probs, entropy = fused_linear_for_ppo.forward(
+        hidden_states=rolled_hidden_states,
+        vocab_weights=self.lm_head.weight,
+        input_ids=rolled_labels,
+        temperature=temperature,
+    )
+
+    return Qwen2_5_VLCausalLMOutputForPPO(
+        log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,

--- a/verl/models/transformers/qwen2_5_vl.py
+++ b/verl/models/transformers/qwen2_5_vl.py
@@ -145,17 +145,16 @@ def forward_for_ppo(
         raise NotImplementedError("forward_for_ppo has to return_dict")
 
     # Loss calculations
-    rolled_hidden_states = hidden_states[..., :-1, :]
     if labels is not None:
-        rolled_labels = labels[..., 1:]
+        rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
-        rolled_labels = input_ids[..., 1:]
+        rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)
     else:
         raise RuntimeError("To use forward_for_ppo, either labels or input_ids must be provided.")
 
     fused_linear_for_ppo = FusedLinearForPPO()
     log_probs, entropy = fused_linear_for_ppo.forward(
-        hidden_states=rolled_hidden_states,
+        hidden_states=hidden_states,
         vocab_weights=self.lm_head.weight,
         input_ids=rolled_labels,
         temperature=temperature,

--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -404,7 +404,7 @@ def forward_for_ppo(
     hidden_states = outputs[0]
 
     if not return_dict:
-        raise NotImplementedError("forward_without_logits has to return_dict")
+        raise NotImplementedError("forward_for_ppo has to return_dict")
 
     # Loss calculations
     rolled_hidden_states = hidden_states[..., :-1, :]

--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -407,17 +407,16 @@ def forward_for_ppo(
         raise NotImplementedError("forward_for_ppo has to return_dict")
 
     # Loss calculations
-    rolled_hidden_states = hidden_states[..., :-1, :]
     if labels is not None:
-        rolled_labels = labels[..., 1:]
+        rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
-        rolled_labels = input_ids[..., 1:]
+        rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)
     else:
         raise RuntimeError("To use forward_for_ppo, either labels or input_ids must be provided.")
 
     fused_linear_for_ppo = FusedLinearForPPO()
     log_probs, entropy = fused_linear_for_ppo.forward(
-        hidden_states=rolled_hidden_states,
+        hidden_states=hidden_states,
         vocab_weights=self.lm_head.weight,
         input_ids=rolled_labels,
         temperature=temperature,

--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -293,11 +293,12 @@ def ulysses_flash_attn_forward(
 
 
 @dataclass
-class Qwen2VLCausalLMOutputWithoutLogits(Qwen2VLCausalLMOutputWithPast):
-    last_hidden_state: Optional[torch.FloatTensor] = None
+class Qwen2VLCausalLMOutputForPPO(Qwen2VLCausalLMOutputWithPast):
+    log_probs: Optional[torch.FloatTensor] = None
+    entropy: Optional[torch.FloatTensor] = None
 
 
-def forward_without_logits(
+def forward_for_ppo(
     self: Qwen2VLForConditionalGeneration,
     input_ids: torch.LongTensor = None,
     attention_mask: Optional[torch.Tensor] = None,
@@ -315,12 +316,15 @@ def forward_without_logits(
     video_grid_thw: Optional[torch.LongTensor] = None,
     rope_deltas: Optional[torch.LongTensor] = None,
     cache_position: Optional[torch.LongTensor] = None,
+    temperature: float = 1.0,
     **loss_kwargs,
-) -> Union[Tuple, Qwen2VLCausalLMOutputWithoutLogits]:
+) -> Union[Tuple, Qwen2VLCausalLMOutputForPPO]:
     r"""
     Copy paste Qwen2VL's forward
     https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/model/qwen2_vl.py
     ```"""
+    from verl.utils.experimental.torch_functional import FusedLinearForPPO
+
     output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
     output_hidden_states = (
         output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -399,13 +403,29 @@ def forward_without_logits(
 
     hidden_states = outputs[0]
 
-    if labels is not None:
-        raise NotImplementedError("forward_without_logits does not support labels")
     if not return_dict:
         raise NotImplementedError("forward_without_logits has to return_dict")
 
-    return Qwen2VLCausalLMOutputWithoutLogits(
-        last_hidden_state=hidden_states,
+    # Loss calculations
+    rolled_hidden_states = hidden_states[..., :-1, :]
+    if labels is not None:
+        rolled_labels = labels[..., 1:]
+    elif input_ids is not None:
+        rolled_labels = input_ids[..., 1:]
+    else:
+        raise RuntimeError("To use forward_for_ppo, either labels or input_ids must be provided.")
+
+    fused_linear_for_ppo = FusedLinearForPPO()
+    log_probs, entropy = fused_linear_for_ppo.forward(
+        hidden_states=rolled_hidden_states,
+        vocab_weights=self.lm_head.weight,
+        input_ids=rolled_labels,
+        temperature=temperature,
+    )
+
+    return Qwen2VLCausalLMOutputForPPO(
+        log_probs=log_probs,
+        entropy=entropy,
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -65,15 +65,6 @@ class DataParallelPPOActor(BasePPOActor):
             else verl_F.entropy_from_logits
         )
 
-        if self.use_fused_kernels:
-            from verl.utils.experimental.torch_functional import FusedLinearForPPO
-
-            self.fused_linear_for_ppo = FusedLinearForPPO()
-
-            # FusedLinearForPPO has an error when compiled, disable for now
-            # if self.config.get("use_torch_compile", True):
-            #     self.fused_linear_for_ppo.compile(dynamic=True)
-
     def _forward_micro_batch(self, micro_batch, temperature, calculate_entropy=False) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Returns:
@@ -130,23 +121,15 @@ class DataParallelPPOActor(BasePPOActor):
                     position_ids=position_ids_rmpad,
                     **multi_modal_inputs,
                     use_cache=False,
+                    temperature=temperature,
                 )  # prevent model thinks we are generating
 
                 if self.use_fused_kernels:
-                    hidden_states = output.last_hidden_state
-                    vocab_weights = self.actor_module.lm_head.weight
-
-                    log_probs, entropy_rmpad = self.fused_linear_for_ppo(
-                        hidden_states=hidden_states.squeeze(0),
-                        vocab_weights=vocab_weights,
-                        input_ids=input_ids_rmpad_rolled,
-                        temperature=temperature,
-                    )
+                    log_probs = output.log_probs.squeeze(0)  # (total_nnz,)
+                    entropy_rmpad = output.entropy.squeeze(0)  # (total_nnz,)
 
                 else:
                     logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
-
-                    # logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
                     logits_rmpad.div_(temperature)
 
                     # if use_sp: ((total_nnz / sp) + pad) ; if not use_sp: (batch, seqlen)
@@ -206,18 +189,12 @@ class DataParallelPPOActor(BasePPOActor):
                     position_ids=position_ids,
                     **multi_modal_inputs,
                     use_cache=False,
+                    temperature=temperature,
                 )  # prevent model thinks we are generating
 
                 if self.use_fused_kernels:
-                    hidden_states = output.last_hidden_state
-                    vocab_weights = self.actor_module.lm_head.weight
-
-                    log_probs, entropy = self.fused_linear_for_ppo(
-                        hidden_states=hidden_states[:, -response_length - 1 : -1, :],
-                        vocab_weights=vocab_weights,
-                        input_ids=micro_batch["responses"],
-                        temperature=temperature,
-                    )
+                    log_probs = output.log_probs[:, -response_length - 1 : -1]
+                    entropy = output.entropy[:, -response_length - 1 : -1]  # (bsz, response_length)
 
                 else:
                     logits = output.logits


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Shifts fused_linear_for_ppo into model.forward for FSDP

### High-Level Design

Self explaining

### Specific Changes

- Update monkey patch to return log_probs and entropy instead of last_hidden_state.

### API

No changes

### Usage Example

```sh
actor_rollout_ref.model.use_fused_kernels=True
```

### Test

![image](https://github.com/user-attachments/assets/c6af68fb-0200-4aee-9596-0b445afdc562)


### Additional Info.

- This is to fix #1565 
- The original bug arises because we tried to access model.lm_head.weight from outside of the FSDP wrapped context.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if necessary.