### PR TITLE
[SGLang Async Rollout] Add `monkey_patch_torch_reductions()` for `AsyncSGLangRollout`

### DIFF
--- a/verl/workers/rollout/sglang_rollout/async_sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_rollout.py
@@ -30,6 +30,7 @@ from omegaconf import DictConfig
 from sglang.srt.entrypoints.engine import Engine
 from sglang.srt.function_call_parser import FunctionCallParser
 from sglang.srt.openai_api.protocol import Tool
+from sglang.srt.patch_torch import monkey_patch_torch_reductions
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.utils import get_ip, get_open_port
 from tensordict import TensorDict
@@ -93,6 +94,7 @@ class AsyncSGLangRollout(BaseRollout):
             **kwargs: train_tp, for Megatron Backend to initialize hybrid engine (zero redundancy) process group
         """
         super().__init__()
+        monkey_patch_torch_reductions()
         self.config = config
         self._device_mesh_cpu = device_mesh
         os.environ.setdefault("SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK", "true")


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

This PR adds the `monkey_patch_torch_reductions()` patch for `AsyncSGLangRollout`.

Note that while `SGLangRollout` uses `VerlEngine` (where this patch was previously added in [SGLang PR #4565](https://github.com/sgl-project/sglang/pull/4565)), `AsyncSGLangRollout` uses the default `Engine` without this patch.

After testing on both A100 and AMD MI300X:

- The A100 runs `AsyncSGLangRollout` correctly without the patch
- The MI300X requires this patch to avoid device-related errors

### Additional Info.

- **Inference**: [SGLang]

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
