### PR TITLE
[BREAKING][rollout] feat: concurrency control and refactor for ChatCompletionScheduler

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -148,6 +148,9 @@ Actor/Rollout/Reference Policy
       ulysses_sequence_parallel_size: ${actor_rollout_ref.actor.ulysses_sequence_parallel_size} # sp size
     rollout:
       name: vllm
+      mode: sync # sync -> LLM, async -> AsyncLLM
+      chat_scheduler: null # async chat scheduler, e.g examples.ppo_trainer.naive_chat_scheduler.NaiveChatCompletionScheduler
+      max_concurrent_requests_per_server: 16 # for chat scheduler
       temperature: 1.0
       top_k: -1 # 0 for hf rollout, -1 for vllm rollout
       top_p: 1
@@ -286,6 +289,12 @@ Reference model will be enabled when ``actor.use_kl_loss`` or/and ``algorithm.us
 **Rollout Model**
 
 - ``actor_rollout_ref.rollout.name``: hf/vllm/sglang.
+
+- ``actor_rollout_ref.rollout.mode``: Use ``sync`` for synchronous rollout and ``async`` for asynchronous rollout; 
+
+- ``actor_rollout_ref.rollout.chat_scheduler``: The chat completion scheduler to be used, e.g. ``examples.ppo_trainer.naive_chat_scheduler.NaiveChatCompletionScheduler``. The scheduler **must** implement ``generate_sequences`` method.
+
+- ``actor_rollout_ref.rollout.max_concurrent_requests_per_server``: The maximum number of concurrent requests per server.
 
 - Rollout (Auto-regressive) parameters. The key should be equal to the
   property name in vLLM's ``SamplingParams``.

--- a/tests/workers/rollout/test_vllm_tool_calling.py
+++ b/tests/workers/rollout/test_vllm_tool_calling.py
@@ -146,7 +146,7 @@ class ToolChatCompletionScheduler(NaiveChatCompletionScheduler):
 
         max_turns = 3
 
-        async def callback(completions: ChatCompletion, info: Dict[str, Any], exception: Exception):
+        async def callback(completions: ChatCompletion, info: Dict[str, Any], server_address: str, exception: Exception):
             batch_conversations, batch_index, turn = (
                 info["batch_conversations"],
                 info["batch_index"],
@@ -180,17 +180,15 @@ class ToolChatCompletionScheduler(NaiveChatCompletionScheduler):
             print(f"[id={completions.id},turn={turn}] Code block executed, continue...")
 
             # STEP 4: resubmit chat completions with code block output
-            extra_headers = {"x-request-id": completions.id}
-            await self.submit_chat_completions(
+            await self.submit_single_chat_completion(
                 callback=callback,
                 callback_additional_info={
                     "batch_conversations": batch_conversations,
                     "batch_index": batch_index,
                     "turn": turn + 1,
                 },
-                model=self.model_name,
+                server_address=server_address,
                 messages=batch_conversations[batch_index],
-                extra_headers=extra_headers,
                 **kwargs,
             )
 
@@ -207,7 +205,6 @@ class ToolChatCompletionScheduler(NaiveChatCompletionScheduler):
                             "batch_index": batch_index,
                             "turn": 1,
                         },
-                        model=self.model_name,
                         messages=batch_conversations[batch_index],
                         **kwargs,
                     )

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -121,6 +121,8 @@ actor_rollout_ref:
   rollout:
     name: vllm
     mode: sync # sync: LLM, async: AsyncLLM
+    chat_scheduler: null # async chat scheduler, e.g examples.ppo_trainer.naive_chat_scheduler.NaiveChatCompletionScheduler
+    max_concurrent_requests_per_server: 16 # for chat scheduler
     temperature: 1.0
     top_k: -1 # 0 for hf rollout, -1 for vllm rollout
     top_p: 1

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -93,6 +93,7 @@ actor_rollout_ref:
     name: vllm
     mode: sync # sync: LLM, async: AsyncLLM
     chat_scheduler: null # async chat scheduler, e.g examples.ppo_trainer.naive_chat_scheduler.NaiveChatCompletionScheduler
+    max_concurrent_requests_per_server: 16 # for chat scheduler
     temperature: 1.0
     top_k: -1 # 0 for hf rollout, -1 for vllm rollout
     top_p: 1


### PR DESCRIPTION
 ### Checklist Before Starting

  - [x] Search for similar PR(s).

  ### What does this PR do?

  * Add concurrency control support for `ChatCompletionScheduler`
  * Refactoring `ChatCompletionScheduler` (e.g. fix the bug of least requests load balancing)

  ### High-Level Design

  * Split `submit_chat_completions` into `submit_chat_completions` and `submit_single_chat_completion`. The former now serves as the entry and exit point for a chain of multi-turn rollouts.
  * No more pass `model` and `extra_headers` manually in callback. Straightforwardly pass 'server_address' instead.
  * Control per-server concurrency without keeping tracking of per-server concurrency

  ### Specific Changes

  * load balancing:

    * The original implementation cannot decrease the load count because it lacks the ability to handle **cleanup tasks** after a chain of multi-turn dialogues within `submit_chat_completions`. Therefore, we differentiate the APIs for the lifecycle management of multi-turn dialogues and for a single request.

  * per-server concurrency control:

    * with self.semaphore, we can control the total concurrency across all servers (`self.max_concurrent_requests = len(server_addresses) * config.max_concurrent_requests_per_server`). Since we always select the least-loaded server to handle a new chat and stick the following turns to this server, obviously no server's concurrency can exceed `config.max_concurrent_requests_per_server`, and we can make the most of prefix-caching.

  * Simpler callback for users

    * There's no need for users to manually construct and pass `extra_headers`(request_id) and `model_name` , since:

      * request_id is for

        * implementing HTTP headers at the router level for performance . See [[this](https://docs.vllm.ai/en/v0.8.3/serving/openai_compatible_server.html#extra-http-headers)]
      
        * getting the server address. However, this original design (depicted in the following diagram) brings about too much unnecessary operations, like the extraction of request-id and maintenance of `LRUCache`. Directly passing the address is more straight-forward.

          ```mermaid
            flowchart LR
            	Z[ChatCompletionScheduler]-->A
                A[generate_sequences] --> B[submit_chat_completions]
                B --> C{round 0?}
                C -- Yes --> D[await self._chat\_<br>completions_aiohttp]
                C -- No --> E[request_id -> address]
                D --> F[x-request-id from server]
                F --> G[extract request-id]
                G --> E
                E --> H[ **new** request-id <br>and callback]
                H --> B
          
          ```

       * model_name is an attribute of `ChatCompletionScheduler`, so no need to pass it manually.

    * Therefore, users can focus on their own logics.

  ### API

  * per-server concurrency: `config.actor_rollout_ref.rollout.max_concurrent_requests_per_server`
  * start a chain of conversations: `ChatCompletionScheduler`.`submit_chat_completions`
  * submit a single request in callback: `ChatCompletionScheduler`.`submit_single_chat_completion`

  ### Usage Example

  > * start chatting: # the same as before
  >
  >   ```python
  >   tasks.append(
  >                   asyncio.create_task(
  >                       self.submit_chat_completions(
  >                           callback=callback,
  >                           callback_additional_info={
  >                               "batch_conversations": batch_conversations,
  >                               "batch_index": batch_index,
  >                               "turn": 1,
  >                           },
  >                           messages=batch_conversations[batch_index],
  >                           **kwargs,
  >                       )
  >                   )
  >               )
  >   ```
  >
  > * submit subsequent requests in `callback`:
  >
  >   ```python
  >   async def callback(completions: ChatCompletion, info: Dict[str, Any], server_address: str, exception: Exception):
  >       #.....
  >       await self.submit_single_chat_completion(
  >                   callback=callback,
  >                   callback_additional_info={
  >                       "batch_conversations": batch_conversations,
  >                       "batch_index": batch_index,
  >                       "turn": turn + 1,
  >                   },
  >           	# users don't have to tackle with server_address. Directly pass it.
  >                   server_address=server_address,
  >                   messages=batch_conversations[batch_index],
  >                   **kwargs,
  >               )
  >   ```
  >
 
  ### Checklist Before Submitting

  - [x] Read the [[Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide)](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
  - [x] Apply [[pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting)](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
  - [x] Add `[BREAKING]` to the PR title if it breaks any API.
  - [x] Update the documentation about your changes in the [[docs](https://github.com/volcengine/verl/tree/main/docs)](https://github.com/volcengine/verl/tree/main/docs).
  - [x] Add CI test(s) if necessary.