### PR TITLE
 Fix Configuration for Micro Batch Size in Megatron's Ref Policy

### DIFF
--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -131,9 +131,18 @@ class ActorRolloutRefWorker(MegatronWorker):
             self._is_offload_grad = self.config.actor.megatron.get("grad_offload", False)
             self._is_offload_optimizer = self.config.actor.megatron.get("optimizer_offload", False)
         elif self._is_ref:
-            if self.config.ref.get("ppo_micro_batch_size", None):
+            if self.config.ref.get("log_prob_micro_batch_size", None):
                 self.config.ref.log_prob_micro_batch_size //= mpu.get_data_parallel_world_size()
-                self.config.ref.ppo_micro_batch_size_per_gpu = self.config.ref.ppo_micro_batch_size
+                self.config.ref.log_prob_micro_batch_size_per_gpu = self.config.ref.log_prob_micro_batch_size
+                self.config.ref.ppo_micro_batch_size_per_gpu = self.config.ref.log_prob_micro_batch_size
+            else:
+                if self.config.ref.get("log_prob_micro_batch_size_per_gpu", None):
+                    self.config.ref.ppo_micro_batch_size_per_gpu = self.config.ref.log_prob_micro_batch_size_per_gpu
+                elif self.config.ref.get("ppo_micro_batch_size_per_gpu", None):
+                    self.config.ref.log_prob_micro_batch_size_per_gpu = self.config.ref.ppo_micro_batch_size_per_gpu
+                else:
+                    raise ValueError("Note that for the ref policy, `log_prob_micro_batch_size_per_gpu` and `ppo_micro_batch_size_per_gpu` should not be None at the same time.")
+            print("Please note that in the ref policy configuration, `log_prob_micro_batch_size_per_gpu` and `ppo_micro_batch_size_per_gpu` have the same meaning.")
             self._ref_is_offload_param = self.config.ref.megatron.get("param_offload", False)
 
     def _build_model_optimizer(self, model_path, optim_config, override_model_config, override_transformer_config):


### PR DESCRIPTION

### What does this PR do?

 Fix Configuration for Micro Batch Size in Megatron's Ref Policy

### High-Level Design
This pull request addresses an issue with the micro batch size configuration in the ref policy of Megatron. The default ppo_megatron_trainer.yaml only includes two configurations: log_prob_micro_batch_size and log_prob_micro_batch_size_per_gpu. 
https://github.com/volcengine/verl/blob/54c9b7364c2d188b2ba4107404cfa3c2b446df19/verl/trainer/config/ppo_megatron_trainer.yaml#L119-L120
However, in `megatron_workers.py`, the required configuration is ref.log_prob_micro_batch_size_per_gpu 
https://github.com/volcengine/verl/blob/54c9b7364c2d188b2ba4107404cfa3c2b446df19/verl/workers/megatron_workers.py#L517-L518
or in `megatron_actor.py ` the required configuration is  ref.ppo_micro_batch_size_per_gpu, 
https://github.com/volcengine/verl/blob/54c9b7364c2d188b2ba4107404cfa3c2b446df19/verl/workers/actor/megatron_actor.py#L271-L274

which are not directly related to ppo_micro_batch_size.

To resolve this, I have made modifications to the configuration calculations and added raise ValueError statements to ensure that the necessary parameters are correctly defined. 

This update ensures that the required parameters are properly handled, preventing runtime errors and improving the overall robustness of the training process.

### Changes Made:

- Modified the configuration calculations in megatron_workers.py.

- Added raise ValueError statements to check for the presence of log_prob_micro_batch_size_per_gpu and ppo_micro_batch_size_per_gpu. 
