### PR TITLE
[mics][fix] Deprecate legacy `_default_compute_score` API and fix ray utils test

### DIFF
--- a/tests/ray_cpu/test_ray_utils.py
+++ b/tests/ray_cpu/test_ray_utils.py
@@ -36,8 +36,8 @@ def test_parallel_put_basic(init_ray):
 
 def test_parallel_put_empty(init_ray):
     data = []
-    refs = parallel_put(data)
-    assert len(refs) == 0
+    with pytest.raises(AssertionError):
+        _ = parallel_put(data)
 
 
 def test_parallel_put_workers(init_ray):

--- a/verl/utils/ray_utils.py
+++ b/verl/utils/ray_utils.py
@@ -34,6 +34,7 @@ def parallel_put(data_list: List[Any], max_workers: Optional[int] = None):
         List[ray.ObjectRef]: A list of Ray object references corresponding to the input data_list,
                              maintaining the original order.
     """
+    assert len(data_list) > 0, "data_list must not be empty"
 
     def put_data(index, data):
         return index, ray.put(data)

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # from . import gsm8k, math, prime_math, prime_code
 
+from verl.utils.import_utils import deprecated
+
 
 def default_compute_score(data_source, solution_str, ground_truth, extra_info=None, sandbox_fusion_url=None, concurrent_semaphore=None):
     """Compute the score for a given solution based on the data source.
@@ -88,4 +90,12 @@ def default_compute_score(data_source, solution_str, ground_truth, extra_info=No
         return float(res[0])
 
 
-__all__ = ["default_compute_score"]
+@deprecated("verl.utils.reward_score.default_compute_score")
+def _default_compute_score(data_source, solution_str, ground_truth, extra_info=None, sandbox_fusion_url=None, concurrent_semaphore=None):
+    """
+    Legacy function API to be deprecated. Please use `default_compute_score` instead.
+    """
+    return default_compute_score(data_source, solution_str, ground_truth, extra_info, sandbox_fusion_url, concurrent_semaphore)
+
+
+__all__ = ["default_compute_score", "_default_compute_score"]

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -98,4 +98,4 @@ def _default_compute_score(data_source, solution_str, ground_truth, extra_info=N
     return default_compute_score(data_source, solution_str, ground_truth, extra_info, sandbox_fusion_url, concurrent_semaphore)
 
 
-__all__ = ["default_compute_score", "_default_compute_score"]
+__all__ = ["default_compute_score"]


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Handle comments after #1397 being merged:

1. Add back `_default_compute_score` API and mark it as deprecated;
2. Fix a broken ci test `ray_utils_test` on `parallel_put`;

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
