### PR TITLE
[BREAKING][Refactor] Support multi `chat_scheduler` to reduce event loop blocking

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -93,6 +93,7 @@ actor_rollout_ref:
     name: vllm
     mode: sync # sync: LLM, async: AsyncLLM
     chat_scheduler: null # async chat scheduler, e.g examples.ppo_trainer.naive_chat_scheduler.NaiveChatCompletionScheduler
+    chat_scheduler_num: 1
     temperature: 1.0
     top_k: -1 # 0 for hf rollout, -1 for vllm rollout
     top_p: 1


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

> support multi `chat_scheduler` to reduce event loop blocking. 

### High-Level Design

> 
- In origin `async_vLLM` design, there exsits only one `chat_scheduler`(event loop) run in one thread, when multi-turn tool-calling has heavy cpu post-postprocess, this will cause event loop blocking, which lead to low gpu usage.

- We seperate the `chat_scheduler` from `AsyncLLMServerManager` and use ray woker group to define multiple chat_scheduler, which can run multiple event loop from different process.


### Additional Info.
- **Training**: none
- **Inference**: vLLM

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if necessary.
