### PR TITLE
Fix: Add TensorBoard as a Default Dependency for Logger Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ install_requires = [
     "transformers",
     "wandb",
     "packaging>=20.0",
+    "tensorboard",
 ]
 
 TEST_REQUIRES = ["pytest", "pre-commit", "py-spy"]


### PR DESCRIPTION
### Checklist Before Starting

- [✅] Search for similar PR(s).

### What does this PR do?

> This PR adds `tensorboard` as a default dependency in `setup.py` to ensure that users can seamlessly use TensorBoard logging without manually installing it. See the former PR that add support for TensorBoard: https://github.com/volcengine/verl/pull/408

Now users are required to manually install `tensorboard`, which increases complexity and creates a poor user experience:
```
File "/path/to/trainer/main_ppo.py", line 184, in run
trainer.fit()
File "/path/to/trainer/ppo/ray_trainer.py", line 935, in fit
logger = Tracking(
File "/path/to/utils/tracking.py", line 116, in init
self.logger["tensorboard"] = _TensorboardAdapter()
File "/path/to/utils/tracking.py", line 199, in init
from torch.utils.tensorboard import SummaryWriter
File "/path/to/torch/utils/tensorboard/init .py", line 1, in <module>
import tensorboard
ModuleNotFoundError: No module named 'tensorboard'
```

### High-Level Design

> The change is straightforward: `tensorboard` is added to the `install_requires` list in `setup.py`. This ensures that all users who install `verl` will automatically have `tensorboard` available, aligning with the project's support for `tensorboard` as a logger option.


### Checklist Before Submitting

- [✅] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [✅] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [✅] Add `[BREAKING]` to the PR title if it breaks any API.
- [✅ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [✅] Add CI test(s) if necessary.
