### PR TITLE
fix error when bind async method in create_colocated_worker

### DIFF
--- a/tests/ray_gpu/test_colocated_workers.py
+++ b/tests/ray_gpu/test_colocated_workers.py
@@ -43,7 +43,7 @@ class Critic(Worker):
         self.config = config
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
-    def sub(self, data: DataProto):
+    async def sub(self, data: DataProto):
         data.batch["a"] -= self.config["b"]
         return data
 

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import logging
 import os
 import time
@@ -633,7 +634,13 @@ def _bind_workers_method_to_parent(cls, key, user_defined_cls):
                     # dispatch to the actual worker
                     return getattr(self.worker_dict[key], name)(*args, **kwargs)
 
-                return func  # noqa: B023
+                async def async_func(self, *args, **kwargs):
+                    # dispatch to the actual worker
+                    return await getattr(self.worker_dict[key], name)(*args, **kwargs)
+
+                wrapper = async_func if inspect.iscoroutinefunction(method) else func  # noqa: B023
+
+                return wrapper
 
             func = generate_function(method_name)
             # pass MAGIC_ATTR for outer worker group


### PR DESCRIPTION
### Checklist Before Starting

- [ done ] Search for similar PR(s).

### What does this PR do?

fix a bug when register async method to fsdp worker

### High-Level Design

wrap async method if the original method is coroutine

### Specific Changes

changed _bind_workers_method_to_parent

### API

n\a

### Usage Example

tests/ray_gpu/test_colocated_workers.py


### Test

tests/ray_gpu/test_colocated_workers.py

### Additional Info.

- **Issue Number**:  required by https://github.com/volcengine/verl/issues/1721

### Checklist Before Submitting

- [done ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ done] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ done] Add `[BREAKING]` to the PR title if it breaks any API.
- [ done] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ done] Add CI test(s) if necessary.
