### PR TITLE
Fix copy_to_local function calls with incorrect argument usage

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -563,7 +563,7 @@ class ActorRolloutRefWorker(Worker):
                 optim_config = None
                 fsdp_config = OmegaConf.create()
 
-            local_path = copy_to_local(self.config.model.path, use_shm)
+            local_path = copy_to_local(self.config.model.path, use_shm=use_shm)
             (
                 self.actor_module_fsdp,
                 self.actor_optimizer,
@@ -606,7 +606,7 @@ class ActorRolloutRefWorker(Worker):
             self.rollout, self.rollout_sharding_manager = self._build_rollout(trust_remote_code=self.config.model.get("trust_remote_code", False))
 
         if self._is_ref:
-            local_path = copy_to_local(self.config.model.path, use_shm)
+            local_path = copy_to_local(self.config.model.path, use_shm=use_shm)
             self.ref_module_fsdp = self._build_model_optimizer(
                 model_path=local_path,
                 fsdp_config=self.config.ref.fsdp_config,


### PR DESCRIPTION
- Fixed two copy_to_local calls where use_shm was passed as positional argument
- Changed to use keyword argument use_shm=use_shm to prevent TypeError
- This resolves the 'expected str, bytes or os.PathLike object, not bool' error
- Affects lines 566 and 607 in verl/workers/fsdp_workers.py

### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Changed `copy_to_local(self.config.model.path, use_shm)` to `copy_to_local(self.config.model.path, use_shm=use_shm)`

### Specific Changes

Problem:
The `copy_to_local` function was being called with `use_shm` as a positional argument instead of a keyword argument, causing `cache_dir` to receive a boolean value instead of a string path. This resulted in:

```
TypeError: expected str, bytes or os.PathLike object, not bool
```

Solution:
- Changed `copy_to_local(self.config.model.path, use_shm)` to `copy_to_local(self.config.model.path, use_shm=use_shm)`
- Fixed two instances in `verl/workers/fsdp_workers.py` (lines 566 and 607)

Testing:
- Error no longer occurs during model initialization
- Function calls now correctly pass parameters according to the function signature

Files Changed:
- `verl/workers/fsdp_workers.py`
```
