### PR TITLE
[refactor] update func generator implementation to improve its observability

### DIFF
--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -42,22 +42,24 @@ def get_random_string(length: int) -> str:
 
 
 def func_generator(self, method_name, dispatch_fn, collect_fn, execute_fn, blocking):
-    def func(*args, **kwargs):
-        args, kwargs = dispatch_fn(self, *args, **kwargs)
-        padding_count = kwargs.pop(_padding_size_key, 0)
-        output = execute_fn(method_name, *args, **kwargs)
-        if blocking:
-            output = ray.get(output)
-        output = collect_fn(self, output)
-        if padding_count > 0:
-            if isinstance(output, DataProto):
-                indices = [i for i in range(len(output))][:-padding_count]
-                output = output.select_idxs(indices)
-            elif isinstance(output, list):
-                output = output[:-padding_count]
-        return output
+    class Functor:
+        def __call__(this, *args, **kwargs):
+            args, kwargs = dispatch_fn(self, *args, **kwargs)
+            padding_count = kwargs.pop(_padding_size_key, 0)
+            output = execute_fn(method_name, *args, **kwargs)
+            if blocking:
+                output = ray.get(output)
+            output = collect_fn(self, output)
+            if padding_count > 0:
+                if isinstance(output, DataProto):
+                    indices = [i for i in range(len(output))][:-padding_count]
+                    output = output.select_idxs(indices)
+                elif isinstance(output, list):
+                    output = output[:-padding_count]
+            return output
 
-    return func
+    # use class type to pass the method_name to get a better observability
+    return type(method_name, (Functor,), {})()
 
 
 def sort_placement_group_by_node_ip(pgs: List[PlacementGroup]) -> List[PlacementGroup]:


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Making the `func_generator` return type as a subclass of `Functor` with `__call__` method, whose name is `method_name`. Comparing to the previous implementation. This PR will makes the log record the `method_name` explicitly, instead of the previous `<class 'function'>`

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
