### PR TITLE
fix a bug that Moe's GPU memory offload is not properly handled

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -247,19 +247,21 @@ def offload_megatron_model_to_cpu(models):
     """
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
-            for buffer in model_chunk.buffers:
-                # offload parameters
-                if buffer.param_data.storage().size() > 0:
-                    buffer.param_data.cpu_data = buffer.param_data.data.cpu().pin_memory()
-                    buffer.param_data_size = buffer.param_data.storage().size()
-                    buffer.param_data.storage().resize_(0)
+            model_chunk_all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
+            for buffers in model_chunk_all_buffers:
+                for buffer in buffers:
+                    # offload parameters
+                    if buffer.param_data.storage().size() > 0:
+                        buffer.param_data.cpu_data = buffer.param_data.data.cpu().pin_memory()
+                        buffer.param_data_size = buffer.param_data.storage().size()
+                        buffer.param_data.storage().resize_(0)
 
-                assert buffer.param_data_size == buffer.param_data.cpu_data.storage().size()
+                    assert buffer.param_data_size == buffer.param_data.cpu_data.storage().size()
 
-                if buffer.grad_data.storage().size() > 0:
-                    # if the grad_data size is already zero, we assume that it is already offloaded
-                    buffer.grad_data_size = buffer.grad_data.storage().size()
-                    buffer.grad_data.storage().resize_(0)
+                    if buffer.grad_data.storage().size() > 0:
+                        # if the grad_data size is already zero, we assume that it is already offloaded
+                        buffer.grad_data_size = buffer.grad_data.storage().size()
+                        buffer.grad_data.storage().resize_(0)
         else:
             # we need this for ref module
             for _, param in model_chunk.named_parameters():
@@ -274,16 +276,18 @@ def offload_megatron_model_to_cpu(models):
 def load_megatron_model_to_gpu(models, load_grad=True):
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
-            for buffer in model_chunk.buffers:
-                # sometimes, we don't want to load grad for pure inference
-                if load_grad:
-                    buffer.grad_data.storage().resize_(buffer.grad_data_size)
-                    buffer.grad_data.zero_()
+            model_chunk_all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
+            for buffers in model_chunk_all_buffers:
+                for buffer in buffers:
+                    # sometimes, we don't want to load grad for pure inference
+                    if load_grad:
+                        buffer.grad_data.storage().resize_(buffer.grad_data_size)
+                        buffer.grad_data.zero_()
 
-                if buffer.param_data.storage().size() == 0:
-                    buffer.param_data.storage().resize_(buffer.param_data_size)
-                    # copy data from cpu to cuda
-                    buffer.param_data.copy_(buffer.param_data.cpu_data, non_blocking=True)
+                    if buffer.param_data.storage().size() == 0:
+                        buffer.param_data.storage().resize_(buffer.param_data_size)
+                        # copy data from cpu to cuda
+                        buffer.param_data.copy_(buffer.param_data.cpu_data, non_blocking=True)
         else:
             # we need this for ref module
             device_id = torch.cuda.current_device()


### PR DESCRIPTION
### Checklist Before Starting

- [ ] Search for similar PR(s).

### What does this PR do?

This PR fixes the issue of improper memory offloading for Moe. When expert parallelism is enabled in Megatron's MoE, additional expert_parallel_buffers are used to store the buffers, which occupy a significant amount of GPU memory. The current code fails to offload and onload these expert_parallel_buffers, resulting in incomplete memory offloading of the model. This may lead to out-of-memory (OOM) problem.

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
