### PR TITLE
[ci][fix] Fix `doc_test`ci workflow pipeline

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -49,4 +49,8 @@ jobs:
         run: |
           cd docs 
           make clean
-          make html
+          make html SPHINXOPTS="--keep-going -w _build/sphinx.log"
+          if grep -q ": ERROR:" _build/sphinx.log; then
+            echo "🚨 Sphinx doc build contained ERRORs - see _build/sphinx.log"
+            exit 1
+          fi


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

The existing doc test ci won't fail, because `SPHINX` doc system only raise on `fatal`, Error and Warning won't block the doc build process. 

This PR tries to fix the problem by grep `Error` messages in the building log.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
