### PR TITLE
[megatron] moonlight fix per_tensor_generator

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -738,17 +738,29 @@ def per_tensor_generator(actor_module, model_config, weight_converter, transform
 
     def tensor_generator():
         for scan_vpp_idx in range(vpp_size):
-            for name, param in actor_module[scan_vpp_idx].state_dict().items():
-                if "_extra_state" in name:
-                    continue
+            existing_keys = set()
+            model = unwrap_model(actor_module[scan_vpp_idx])
+            for name, param in model.named_parameters():
+                existing_keys.add(name)
                 yield name, param
+            # note
+            # there is a bug in megatron GPTModel
+            # decoder.layers[n].mlp.router.expert_bias" in GPTModel is not registered in named_parameter, but in state_dict().
+            # for now we patch it by adding those keys to extra_keys.
+            extra_keys = [x for x in model.state_dict().keys() if "_extra_state" not in x and x not in existing_keys]
+            for name in extra_keys:
+                yield name, model.state_dict()[name].to(torch.cuda.current_device())
 
     # we need first make all rank get full model information
     meta_info = []
     for scan_vpp_idx in range(vpp_size):
-        for idx, (name, _) in enumerate(actor_module[scan_vpp_idx].state_dict().items()):
-            if "_extra_state" in name:
-                continue
+        existing_keys = set()
+        model = unwrap_model(actor_module[scan_vpp_idx])
+        for idx, (name, _) in enumerate(model.named_parameters()):
+            existing_keys.add(name)
+            meta_info.append((pp_rank, scan_vpp_idx, idx, name))
+        extra_keys = [x for x in model.state_dict().keys() if "_extra_state" not in x and x not in existing_keys]
+        for name in extra_keys:
             meta_info.append((pp_rank, scan_vpp_idx, idx, name))
 
     obj_spec_output = [None] * mpu.get_pipeline_model_parallel_world_size()

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -738,12 +738,17 @@ def per_tensor_generator(actor_module, model_config, weight_converter, transform
 
     def tensor_generator():
         for scan_vpp_idx in range(vpp_size):
-            yield from actor_module[scan_vpp_idx].named_parameters()
+            for name, param in actor_module[scan_vpp_idx].state_dict().items():
+                if "_extra_state" in name:
+                    continue
+                yield name, param
 
     # we need first make all rank get full model information
     meta_info = []
     for scan_vpp_idx in range(vpp_size):
-        for idx, (name, _) in enumerate(actor_module[scan_vpp_idx].named_parameters()):
+        for idx, (name, _) in enumerate(actor_module[scan_vpp_idx].state_dict().items()):
+            if "_extra_state" in name:
+                continue
             meta_info.append((pp_rank, scan_vpp_idx, idx, name))
 
     obj_spec_output = [None] * mpu.get_pipeline_model_parallel_world_size()


### PR DESCRIPTION
### Checklist Before Starting

- [ ] Search for similar PR(s).

### What does this PR do?

there is a tricky bug in per_tensor_generator with model.named_parameter().
"decoder.layers[n].mlp.router.expert_bias" in GPTModel is not registered in named_parameter, but in state_dict(). Before this fix, the router_bias or `model.layers.{layer_number}.mlp.gate.e_score_correction_bias` is not transfered from m-core to infer engine.





> Add one-line overview of what this PR aims to achieve or accomplish. 

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
