### PR TITLE
[feat] support custom label for specific devices

### DIFF
--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -90,6 +90,7 @@ class RayResourcePool(ResourcePool):
         name_prefix: str = "",
         max_colocate_count: int = 10,
         detached=False,
+        device_label: Optional[str] = None,
     ) -> None:
         super().__init__(process_on_nodes, max_colocate_count)
         self.use_gpu = use_gpu
@@ -97,6 +98,7 @@ class RayResourcePool(ResourcePool):
         self.name_prefix = name_prefix
         self.pgs = None
         self.detached = detached
+        self.device_label = device_label
 
     def get_placement_groups(self, strategy="STRICT_PACK", name=None, device_name="cuda"):
         if self.pgs is not None:
@@ -108,7 +110,13 @@ class RayResourcePool(ResourcePool):
             device_name = "NPU"
         elif device_name == "cuda":
             device_name = "GPU"
-        pg_scheme = [[{"CPU": self.max_colocate_count, device_name: 1} if self.use_gpu else {"CPU": self.max_colocate_count} for _ in range(process_count)] for process_count in self._store]
+
+        bundle = {"CPU": self.max_colocate_count}
+        if self.use_gpu:
+            bundle[device_name] = 1
+            if self.device_label is not None:
+                bundle[self.device_label] = 1e-4
+        pg_scheme = [[bundle.copy() for _ in range(process_count)] for process_count in self._store]
 
         lifetime = "detached" if self.detached else None
 


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Place `worker_group` in specific devices when using heterogeneous GPUs in a ray cluster.

### Specific Changes

Add `device_label` in `RayResourcePool` to set custom label in bundle to identify specific devices.
Refer to https://docs.ray.io/en/latest/ray-core/scheduling/resources.html#custom-resources

### API

> Demonstrate how the API changes if any.


### Usage Example

1. set custom label when start ray cluster
```bash
# H20 Node
ray start --head --port 6379 --resources='{"H20": 1}'
# 4090 Node
ray start --address='<master_ip>:6379' --resources='{"4090": 1}'
```
2. specify the device label when creating RayResourcePool
```python
pool_h20 = RayResourcePool([4], use_gpu=True, device_label='H20')
pool_4090 = RayResourcePool([4], use_gpu=True, device_label='4090')
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
