### PR TITLE
[docs] Add linux-arm64 platform tensordict package version problem handle FAQ

### DIFF
--- a/docs/faq/faq.rst
+++ b/docs/faq/faq.rst
@@ -55,6 +55,48 @@ Please note that Slurm cluster setup may vary. If you encounter any issues, plea
 
 If you changed Slurm resource specifications, please make sure to update the environment variables in the job script if necessary.
 
+
+Install related
+------------------------
+
+NotImplementedError: TensorDict does not support membership checks with the `in` keyword. 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Detail error information: 
+
+.. code:: bash
+
+    NotImplementedError: TensorDict does not support membership checks with the `in` keyword. If you want to check if a particular key is in your TensorDict, please use `key in tensordict.keys()` instead.
+
+Cause of the problem: There is no suitable version of tensordict package for the linux-arm64 platform. The confirmation method is as follows:
+
+.. code:: bash
+
+    pip install tensordict==0.6.2
+
+Output example:
+
+.. code:: bash
+
+    ERROR: Could not find a version that satisfies the requirement tensordict==0.6.2 (from versions: 0.0.1a0, 0.0.1b0, 0.0.1rc0, 0.0.2a0, 0.0.2b0, 0.0.3, 0.1.0, 0.1.1, 0.1.2, 0.8.0, 0.8.1, 0.8.2, 0.8.3)
+    ERROR: No matching distribution found for tensordict==0.6.2
+
+Solution 1st:
+  Install tensordict from source code:
+
+.. code:: bash
+
+    pip uninstall tensordict
+    git clone https://github.com/pytorch/tensordict.git
+    cd tensordict/
+    git checkout v0.6.2
+    python setup.py develop
+    pip install -v -e .
+
+Solution 2nd:
+  Temperally modify the error takeplace codes: tensordict_var -> tensordict_var.keys()
+
+
 Illegal memory access
 ---------------------------------
 


### PR DESCRIPTION
### What does this PR do?
> Add linux-arm64 platform tensordict package version problem handle FAQ. 
> Besides me, there are other people in the community who have encountered this problem(issue #919 )

### Detailed reason for change:
The Linux-arm64 platform does not have a suitable version of the tensordict package. The verl requirement for tensordict is <=0.6.2.0. The version that can be installed on the Linux-arm64 platform is 0.1.2, but the `"key" in tensordict_var ` syntax is not supported by 0.1.2, so error take place. The error message is as follows:
```
  File "/home/mnj/models/code/verl/verl/verl/trainer/main_ppo.py", line 191, in run
    trainer.fit()
  File "/home/mnj/models/code/verl/verl/verl/trainer/ppo/ray_trainer.py", line 1043, in fit
    old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
  File "/home/mnj/models/code/verl/verl/verl/single_controller/ray/base.py", line 50, in func
    output = ray.get(output)
ray.exceptions.RayTaskError(NotImplementedError): ray::WorkerDict.actor_rollout_compute_log_prob() (pid=152918, ip=172.17.0.5, actor_id=64244f99243c810c9e882f3101000000, repr=<verl.single_controller.ray.base.WorkerDict object at 0xfffc41ca44c0>)
  File "/home/mnj/models/code/verl/verl/verl/single_controller/ray/base.py", line 635, in func
    return getattr(self.worker_dict[key], name)(*args, **kwargs)
  File "/home/mnj/models/code/verl/verl/verl/single_controller/base/decorator.py", line 534, in inner
    return func(*args, **kwargs)
  File "/home/mnj/models/code/verl/verl/verl/workers/fsdp_workers.py", line 739, in compute_log_prob
    output, entropys = self.actor.compute_log_prob(data=data, calculate_entropy=True)
  File "/home/mnj/models/code/verl/verl/verl/utils/debug/performance.py", line 80, in f
    return self.log(decorated_function, *args, **kwargs)
  File "/home/mnj/models/code/verl/verl/verl/utils/debug/performance.py", line 90, in log
    output = func(*args, **kwargs)
  File "/home/mnj/models/code/verl/verl/verl/workers/actor/dp_actor.py", line 289, in compute_log_prob
    entropy, log_probs = self._forward_micro_batch(micro_batch, temperature=temperature, calculate_entropy=calculate_entropy)
  File "/home/mnj/models/code/verl/verl/verl/workers/actor/dp_actor.py", line 83, in _forward_micro_batch
    if "multi_modal_inputs" in micro_batch:
  File "/usr/local/python3.10.17/lib/python3.10/site-packages/tensordict/tensordict.py", line 2932, in __contains__
    raise NotImplementedError(
NotImplementedError: TensorDict does not support membership checks with the `in` keyword. If you want to check if a particular key is in your TensorDict, please use `key in tensordict.keys()` instead.
```

### Platform linux-arm64 available version listing  as follows:
`pip install tensordict==0.6.2`

Output information:
```
ERROR: Could not find a version that satisfies the requirement tensordict==0.6.2 (from versions: 0.0.1a0, 0.0.1b0, 0.0.1rc0, 0.0.2a0, 0.0.2b0, 0.0.3, 0.1.0, 0.1.1, 0.1.2, 0.8.0, 0.8.1, 0.8.2, 0.8.3)
ERROR: No matching distribution found for tensordict==0.6.2
```