### PR TITLE
remove redundant 'get_custom_reward_fn' function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ ENV/
 logs
 log
 outputs
+.history

--- a/recipe/dapo/main_dapo.py
+++ b/recipe/dapo/main_dapo.py
@@ -20,36 +20,10 @@ import os
 import hydra
 import ray
 
-from .dapo_ray_trainer import RayDAPOTrainer
+from verl.trainer.ppo.reward import get_custom_reward_fn
 from verl.utils.device import is_cuda_available
 
-
-def get_custom_reward_fn(config):
-    import importlib.util
-
-    reward_fn_config = config.get("custom_reward_function") or {}
-    file_path = reward_fn_config.get("path")
-    if not file_path:
-        return None
-
-    if not os.path.exists(file_path):
-        raise FileNotFoundError(f"Reward function file '{file_path}' not found.")
-
-    spec = importlib.util.spec_from_file_location("custom_module", file_path)
-    module = importlib.util.module_from_spec(spec)
-    try:
-        spec.loader.exec_module(module)
-    except Exception as e:
-        raise RuntimeError(f"Error loading module from '{file_path}'") from e
-
-    function_name = reward_fn_config.get("name")
-
-    if not hasattr(module, function_name):
-        raise AttributeError(f"Reward function '{function_name}' not found in '{file_path}'.")
-
-    print(f"using customized reward function '{function_name}' from '{file_path}'")
-
-    return getattr(module, function_name)
+from .dapo_ray_trainer import RayDAPOTrainer
 
 
 @hydra.main(config_path="config", config_name="dapo_trainer", version_base=None)

--- a/recipe/r1/main_eval.py
+++ b/recipe/r1/main_eval.py
@@ -25,36 +25,8 @@ import pandas as pd
 import ray
 from tqdm import tqdm
 
+from verl.trainer.ppo.reward import get_custom_reward_fn
 from verl.utils.fs import copy_to_local
-
-
-def get_custom_reward_fn(config):
-    import importlib.util
-    import os
-
-    reward_fn_config = config.get("custom_reward_function") or {}
-    file_path = reward_fn_config.get("path")
-    if not file_path:
-        return None
-
-    if not os.path.exists(file_path):
-        raise FileNotFoundError(f"Reward function file '{file_path}' not found.")
-
-    spec = importlib.util.spec_from_file_location("custom_module", file_path)
-    module = importlib.util.module_from_spec(spec)
-    try:
-        spec.loader.exec_module(module)
-    except Exception as e:
-        raise RuntimeError(f"Error loading module from '{file_path}'") from e
-
-    function_name = reward_fn_config.get("name")
-
-    if not hasattr(module, function_name):
-        raise AttributeError(f"Reward function '{function_name}' not found in '{file_path}'.")
-
-    print(f"using customized reward function '{function_name}' from '{file_path}'")
-
-    return getattr(module, function_name)
 
 
 @ray.remote

--- a/verl/trainer/main_eval.py
+++ b/verl/trainer/main_eval.py
@@ -25,43 +25,8 @@ import pandas as pd
 import ray
 from tqdm import tqdm
 
+from verl.trainer.ppo.reward import get_custom_reward_fn
 from verl.utils.fs import copy_to_local
-
-
-def get_custom_reward_fn(config):
-    import importlib.util
-    import os
-    import sys
-
-    reward_fn_config = config.get("custom_reward_function") or {}
-    file_path = reward_fn_config.get("path")
-    if not file_path:
-        return None
-
-    if not os.path.exists(file_path):
-        raise FileNotFoundError(f"Reward function file '{file_path}' not found.")
-
-    spec = importlib.util.spec_from_file_location("custom_module", file_path)
-    module = importlib.util.module_from_spec(spec)
-    try:
-        sys.modules["custom_module"] = module
-        spec.loader.exec_module(module)
-    except Exception as e:
-        raise RuntimeError(f"Error loading module from '{file_path}'") from e
-
-    function_name = reward_fn_config.get("name")
-    if not hasattr(module, function_name):
-        raise AttributeError(f"Reward function '{function_name}' not found in '{file_path}'.")
-
-    print(f"using customized reward function '{function_name}' from '{file_path}'")
-    raw_fn = getattr(module, function_name)
-
-    reward_kwargs = dict(reward_fn_config.get("reward_kwargs", {}))
-
-    def wrapped_fn(*args, **kwargs):
-        return raw_fn(*args, **kwargs, **reward_kwargs)
-
-    return wrapped_fn
 
 
 @ray.remote


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

> remove redundant 'get_custom_reward_fn' function. 

### High-Level Design

> None.

### Specific Changes

> "from verl.trainer.ppo.reward import get_custom_reward_fn" instead of  'get_custom_reward_fn' function in verl/recipe/dapo/main_dapo.py verl/recipe/r1/main_eval.py verl/recipe/spin/main_spin.py verl/verl/trainer/main_eval.py verl/verl/trainer/main_eval.py
> remove 'get_custom_reward_fn' function in verl/verl/trainer/main_ppo.py

### Additional Info.

- **[Issue Number](https://github.com/volcengine/verl/issues/1716)**: Fixes issue # or discussion # if any.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
