### PR TITLE
[config] feat: Hardcode moe_router_load_balancing_type to none

### DIFF
--- a/verl/models/mcore/config_converter.py
+++ b/verl/models/mcore/config_converter.py
@@ -109,7 +109,7 @@ def hf_to_mcore_config_qwen2moe(hf_config: PretrainedConfig, dtype: torch.dtype,
         moe_shared_expert_intermediate_size=hf_config.shared_expert_intermediate_size,
         moe_aux_loss_coeff=hf_config.router_aux_loss_coef,
         # moe_aux_loss_coeff=0.0,
-        moe_router_load_balancing_type="aux_loss",
+        moe_router_load_balancing_type="none",  # turn off aux_loss as it hurts perf in RL
         moe_shared_expert_overlap=True,
         moe_grouped_gemm=True,
         moe_router_score_function="softmax",
@@ -137,7 +137,7 @@ def hf_to_mcore_config_mixtral(hf_config: PretrainedConfig, dtype: torch.dtype, 
         moe_aux_loss_coeff=hf_config.router_aux_loss_coef,
         moe_router_topk=hf_config.num_experts_per_tok,
         moe_router_pre_softmax=True,
-        moe_router_load_balancing_type="aux_loss",
+        moe_router_load_balancing_type="none",  # turn off aux_loss as it hurts perf in RL
         moe_router_score_function="softmax",
         moe_shared_expert_intermediate_size=None,  # mixtral has no shared expert
         moe_shared_expert_overlap=False,  # mixtral has no shared expert
@@ -169,7 +169,7 @@ def hf_to_mcore_config_qwen3moe(hf_config: PretrainedConfig, dtype: torch.dtype,
         num_moe_experts=hf_config.num_experts,
         moe_aux_loss_coeff=hf_config.router_aux_loss_coef,
         # moe_aux_loss_coeff=0.0,
-        moe_router_load_balancing_type="aux_loss",
+        moe_router_load_balancing_type="none",  # turn off aux_loss as it hurts perf in RL
         moe_grouped_gemm=True,
         moe_router_score_function="softmax",
         # Other optimizations


### PR DESCRIPTION
### Checklist Before Starting

- [ ] Search for similar PR(s).

### What does this PR do?

- Hardcode moe_router_load_balancing_type to none as it hurts perf in QWen3MoE
- We can provide a config to set it

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
