### PR TITLE
[Feat]: Implement partial rollout

### DIFF
--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -34,9 +34,9 @@ from packaging import version
 from tensordict import TensorDict
 from torch.utils.data import DataLoader
 
+from verl.utils.device import get_torch_device
 from verl.utils.py_functional import union_two_dict
 from verl.utils.torch_functional import allgather_dict_tensors
-from verl.utils.device import get_torch_device
 
 __all__ = ["DataProto", "union_tensor_dict"]
 
@@ -750,6 +750,34 @@ class DataProto:
             non_tensor_batch=repeated_non_tensor_batch,
             meta_info=self.meta_info,
         )
+
+    @staticmethod
+    def split(data_proto: "DataProto", filter_mask) -> tuple["DataProto", "DataProto"]:
+        """
+        Split a DataProto into two based on a boolean mask.
+
+        Args:
+            data_proto: The DataProto to split
+            filter_mask: Boolean tensor/array where True values go to the first DataProto
+
+        Returns:
+            Tuple[DataProto, DataProto]: First DataProto with items where mask is True,
+                                        Second DataProto with items where mask is False
+        """
+        # Convert to tensor if it's a list or numpy array
+        if isinstance(filter_mask, list):
+            filter_mask = torch.tensor(filter_mask, dtype=torch.bool)
+        elif isinstance(filter_mask, np.ndarray):
+            filter_mask = torch.from_numpy(filter_mask)
+
+        # Create inverse mask
+        inverse_mask = ~filter_mask
+
+        # Split into two DataProtos
+        first_proto = data_proto.select_idxs(filter_mask)
+        second_proto = data_proto.select_idxs(inverse_mask)
+
+        return first_proto, second_proto
 
 
 @dataclass

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -129,6 +129,7 @@ actor_rollout_ref:
     top_p: 1
     prompt_length: ${data.max_prompt_length}  # for xperf_gpt
     response_length: ${data.max_response_length}
+    partial_rollout_max_split: ${algorithm.partial_rollout_max_split}
     # for vllm rollout
     dtype: bfloat16 # should align with FSDP
     gpu_memory_utilization: 0.5
@@ -273,6 +274,7 @@ algorithm:
   norm_adv_by_std_in_grpo: True
   use_kl_in_reward: False
   kl_penalty: kl  # how to estimate kl divergence
+  partial_rollout_max_split: 1  # max rounds of rollout before the prompt is forced finished, 1 means no partial rollout
   kl_ctrl:
     type: fixed
     kl_coef: 0.001

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -99,6 +99,7 @@ actor_rollout_ref:
     use_fire_sampling: False # https://arxiv.org/abs/2410.21236
     prompt_length: ${data.max_prompt_length}  # not use for opensource
     response_length: ${data.max_response_length}
+    partial_rollout_max_split: ${algorithm.partial_rollout_max_split}
     # for vllm rollout
     dtype: bfloat16 # should align with FSDP
     gpu_memory_utilization: 0.5
@@ -221,6 +222,7 @@ algorithm:
   norm_adv_by_std_in_grpo: True
   use_kl_in_reward: False
   kl_penalty: kl  # how to estimate kl divergence
+  partial_rollout_max_split: 1  # max rounds of rollout before the prompt is forced finished, 1 means no partial rollout
   kl_ctrl:
     type: fixed
     kl_coef: 0.001


### PR DESCRIPTION
# partial rollout PR draft

### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Supporting the partial rollout feature: Set vllm's maximum output length to an integer fraction of `config.response_length`. If one model response is not completed in the current round, its generation can continue in the next iteration with updated weights. This trick unlocked significant rollout time reduction without sacrifacing model performance.

partial rollout with 4K max response length, compared to baseline:
![image](https://github.com/user-attachments/assets/ea72dab3-e7b4-4879-bf94-ee4cb2d3210b)
![image](https://github.com/user-attachments/assets/6d250dbc-723d-4e83-b891-f5a6e71c29b9)
![image](https://github.com/user-attachments/assets/fe25f90f-df4b-47a6-a686-d78eb680c8e2)
Note on the 3rd plot: We didn't enable testing on 2GPU baseline runs because they were already so slowly. We will update the 4GPU baseline runs after it finishes in a few hours.


### High-Level Design

![image](https://github.com/user-attachments/assets/39faa911-e40b-4236-82a4-89a5bca4b143)

### Specific Changes

- Add buffer pool and filter logic in the `fit` function
- Concat partial responses to prompt inputs in the `vLLMRollout` class
- Add `split` method to `DataProto`
- Add configuration entry

### API

There are mainly two areas where compatibility is potentially tricky:
1.  In the original architecture, the main loop sends only one copy of each prompt to vllm, and vllm uses the `SamplingParams.n` parameter to generate multiple responses before returning them. In our implementation, we must duplicate the prompts in the main loop and send multiple copies to vllm.
2.  The `fit` function in verl takes a batch from the dataloader in each iteration and continuously adds keys to it. In our implementation, there's a step where the `partial_batch` (partially generated by vllm) needs to be merged with the initial `batch` taken from the dataloader.

### Usage Example

```python
    algorithm.partial_rollout_max_split=2
```

### Test

Setup: qwen3 0.6b base; MATH dataset; batch size 1024; rollout n = 5; max response length 4K; 2 H100 GPUs; Megatron trainer

We run:
- Partial rollout 4K 2 split
- Partial rollout 4K 4 split
- Baseline 4K
- Baseline 2K: max response length reduced to 2k, for reference
- Baseline 1K 
- Baseline 4K 4GPU

Results, partial rollout 4K 2 split compared to baseline 4K:
* Overall experiment speed (16h vs 48h) and generation speed (estimated at 20%) significantly improved; Both are even faster than `baseline 2K` and `baseline 4K 4GPU`.
* Reward curves are basically consistent after around 15 steps (out of 105 steps in total). (No discernible difference among baseline 4K, 2K, 1K, and partial 4K, etc.)
* In the early stages of training, the reward increase of `partial 4K 2 split` lags behind the baseline by about 1.5 steps, and `partial 4K 4 split` lags even more.
* In the middle and late stages of training, the mean response length of `partial 4K` and `baseline_4096_4GPU` show an upward trend, while other baselines tend to stabilize.

![image](https://github.com/user-attachments/assets/9b1c4952-f93a-4763-937e-3f9c90d06d3e)


We also tested these settings
qwen3 0.6b base, dataset is gsm8k; batch size 1024; rollout n = 5; max prompt length 512; 2 GPUs; FSDP trainer
3 experiments:
`baseline_512`
`partial_512`
`baseline_256` max response length 256
In these experiments, the speed gain is about 30% overall and 50% in gen. the aforementioned two problems in training dynamics are less visible.
![image](https://github.com/user-attachments/assets/5a143626-acbf-48f3-b942-b3b1c60b0077)
![image](https://github.com/user-attachments/assets/a02e4036-69f8-41a2-8d91-186c370fae3b)
![image](https://github.com/user-attachments/assets/599f840f-c30b-4fad-bf39-3b1eb924f84a)
![image](https://github.com/user-attachments/assets/3d1359de-1811-44a9-9a6e-5b239dae8dab)


### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: none
- **Inference**: vLLM

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
