### PR TITLE
fix sglang e2e_sppo test

### DIFF
--- a/.github/workflows/e2e_sppo.yml
+++ b/.github/workflows/e2e_sppo.yml
@@ -44,7 +44,7 @@ jobs:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
     container:
-      image: ocss884/verl-sglang:ngc-th2.6.0-cu126-sglang0.4.5.post3
+      image: whatcanyousee/verl:ngc-cu124-vllm0.8.5-sglang0.4.6.post5-mcore0.12.0-te2.3
       options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### Checklist Before Starting

- [done] Search for similar PR(s).

### What does this PR do?

Fix error in e2e_sppo  CI test

Exception: sgl-kernel is installed with version 0.0.9.post2, which is less than the minimum required version 0.1.1. Please reinstall the latest version with `pip install sgl-kernel --force-reinstall`

For example:
https://github.com/volcengine/verl/actions/runs/15431843178/job/43430980736?pr=1769
