### PR TITLE
[fix] Adding a default value for `RayWorkerGroup.from_detached(name_prefix=None)`

### DIFF
--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -406,7 +406,7 @@ class RayWorkerGroup(WorkerGroup):
     @classmethod
     def from_detached(
         cls,
-        name_prefix,
+        name_prefix=None,
         worker_names=None,
         worker_handles=None,
         ray_cls_with_init=None,


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

In #1443, a new argument `name_prefix` was introduced for function `from_detached` without setting a default value. This PR sets its default value as `None`, in which case, `RayWorkerGroup` will generate a random string as the prefix. This fix makes the API compatible with existing usage, and the users don't need to worry about this new args when a `name_prefix` is not not context necessary.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] New CI unit test(s) are added to cover the code path.
- [x] Rely on existing unit tests on CI that covers the code path.
