### PR TITLE
 Add log_generations_to_tensorboard Function

### DIFF
--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -20,7 +20,7 @@ from enum import Enum
 from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Union
-
+import os
 
 class Tracking:
     """A unified tracking interface for logging experiment data to multiple backends.
@@ -268,8 +268,10 @@ class ValidationGenerationsLogger:
             self.log_generations_to_mlflow(samples, step)
 
         if "clearml" in loggers:
-            self.log_generation_to_clearml(samples, step)
-
+            self.log_generations_to_clearml(samples, step)
+        if "tensorboard" in loggers:
+            self.log_generations_to_tensorboard(samples, step)
+            
     def log_generations_to_wandb(self, samples, step):
         """Log samples to wandb as a table"""
         import wandb
@@ -341,7 +343,7 @@ class ValidationGenerationsLogger:
         except Exception as e:
             print(f"WARNING: save validation generation file to mlflow failed with error {e}")
 
-    def log_generation_to_clearml(self, samples, step):
+    def log_generations_to_clearml(self, samples, step):
         """Log validation generation to clearml as table"""
 
         import clearml
@@ -368,3 +370,36 @@ class ValidationGenerationsLogger:
             table_plot=pd.DataFrame.from_records(table),
             iteration=step,
         )
+ 
+    def log_generations_to_tensorboard(self, samples, step):
+        """Log samples to tensorboard as text"""
+        # Initialize tensorboard writer if not exists
+        if not hasattr(self, "writer"):
+            from torch.utils.tensorboard import SummaryWriter
+            tensorboard_dir = os.environ.get("TENSORBOARD_DIR", "tensorboard_log")
+            os.makedirs(tensorboard_dir, exist_ok=True)
+            self.writer = SummaryWriter(log_dir=tensorboard_dir)
+        
+        # Format the samples data into readable text
+        text_content = f"**Generation Results - Step {step}**\n\n"
+        
+        for i, sample in enumerate(samples):
+            text_content += f"### Sample {i + 1}\n"
+            
+            # Assuming sample contains [input, output, score] based on your wandb code
+            if len(sample) >= 3:
+                input_text, output_text, score = sample[0], sample[1], sample[2]
+                
+                text_content += f"**Input:** {input_text}\n\n"
+                text_content += f"**Output:** {output_text}\n\n"
+                text_content += f"**Score:** {score}\n\n"
+            else:
+                # Handle cases where sample format might be different
+                text_content += f"**Data:** {sample}\n\n"
+            
+            text_content += "---\n\n"
+        
+        # Log to tensorboard as text
+        self.writer.add_text('val/generations', text_content, step)
+        # Flush to ensure data is written
+        self.writer.flush()


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

- This PR introduces the `log_generations_to_tensorboard` function. When` trainer.log_val_generations` is greater than 0 and `tensorboard` is selected in` trainer.logger,` the function writes the generations to`generations/text_summary` in TensorBoard.
- I have already tested this in the experiment, and the resulting TensorBoard is shown in the image below:
<img width="1652" alt="WeChatWorkScreenshot_d6ac53ed-253e-44a1-b641-4542f3eb1db0" src="https://github.com/user-attachments/assets/78dcb226-0ada-4af6-9231-f40c558eb3d5" />

- The training scripts is shown below:

```
set -x
model_path=$MODEL_PATH 
python3 -m verl.trainer.main_ppo \
    algorithm.adv_estimator=grpo \
    data.train_files=/data/gsm8k/train.parquet \
    data.val_files=/data/gsm8kest.parquet \
    data.train_batch_size=1024 \
    data.max_prompt_length=512 \
    data.max_response_length=256 \
    data.filter_overlong_prompts=True \
    data.truncation='left' \
    actor_rollout_ref.model.path=$model_path \
    actor_rollout_ref.actor.optim.lr=1e-6 \
    actor_rollout_ref.model.use_remove_padding=True \
    actor_rollout_ref.actor.ppo_mini_batch_size=256 \
    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=64 \
    actor_rollout_ref.actor.use_kl_loss=True \
    actor_rollout_ref.actor.kl_loss_coef=0.001 \
    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
    actor_rollout_ref.actor.entropy_coeff=0 \
    actor_rollout_ref.model.enable_gradient_checkpointing=True \
    actor_rollout_ref.actor.fsdp_config.param_offload=False \
    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=128 \
    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
    actor_rollout_ref.rollout.name=vllm \
    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
    actor_rollout_ref.rollout.n=6 \
    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=64 \
    actor_rollout_ref.ref.fsdp_config.param_offload=True \
    algorithm.use_kl_in_reward=False \
    trainer.critic_warmup=0 \
    trainer.log_val_generations=10 \
    trainer.logger=['console','tensorboard'] \
    trainer.project_name='verl_grpo_example_gsm8k' \
    trainer.experiment_name='qwen2_7b_function_rm' \
    trainer.n_gpus_per_node=8 \
    trainer.nnodes=1 \
    trainer.save_freq=20 \
    trainer.test_freq=5 \
    trainer.total_epochs=15 $@
```