### PR TITLE
[fix][rollout][vllm] fix vllm engine default args config only support for multimodal model

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -175,6 +175,12 @@ Actor/Rollout/Reference Policy
       engine_kwargs: # inference engine parameters
         vllm:
           swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
+          engine_default_args:
+            enable_sleep_mode: True
+            disable_custom_all_reduce: True
+            disable_mm_preprocessor_cache: True
+            skip_tokenizer_init: False
+            enable_prefix_caching: True
         sglang:
           attention_backend: null # null means use the engine default value, available options: flashinfer, triton, flashmla
 
@@ -270,7 +276,7 @@ Actor/Rollout/Reference Policy
   - ``contents``: The contents to save in the checkpoint. By default, we save model, optimizer and extra information in the checkpoint.
     The extra information includes Rng states currently, FSDP supported lr_scheduler, and Megatron opt_param_scheduler will coming soon.
     We do not store hf_model in checkpoint by default, but we provide a tool in `scripts/model_merge.py` to convert checkpoint format to hf format.
-
+- ``actor_rollout_ref.rollout.engine_kwargs.vllm``: The configurations of rollout vllm engine, For specific information, please refer to the vllm engine_args page
 **Reference Model**
 
 Reference model will be enabled when ``actor.use_kl_loss`` or/and ``algorithm.use_kl_in_reward`` is/are True.

--- a/recipe/README.md
+++ b/recipe/README.md
@@ -8,7 +8,7 @@ The examples under `recipes/` are representative extensions to verl for specific
 - [Explore RL Data Scaling](https://arxiv.org/abs/2503.22230): Exploring Data Scaling Trends and Effects in Reinforcement Learning from Human Feedback
 - [FIRE](https://arxiv.org/abs/2410.21236): Flaming-hot initiation with regular execution sampling for large language models
 - [DQO](https://arxiv.org/abs/2410.09302): Enhancing multi-Step reasoning abilities of language models through direct Q-function optimization
-- [ProRL](https://arxiv.org/abs/2410.09302): Prolonged Reinforcement Learning Expands Reasoning Boundaries in Large Language Models
+- [ProRL](https://arxiv.org/abs/2505.24864): Prolonged Reinforcement Learning Expands Reasoning Boundaries in Large Language Models
 - [cognition-engineering](https://github.com/gair-nlp/cognition-engineering): Test time scaling drives cognition engineering. ![GitHub Repo stars](https://img.shields.io/github/stars/gair-nlp/cognition-engineering)
 - [Trust Region Preference Approximation](https://github.com/XueruiSu/Trust-Region-Preference-Approximation): A simple and stable **reinforcement learning algorithm** for LLM reasoning. ![GitHub Repo stars](https://img.shields.io/github/stars/XueruiSu/Trust-Region-Preference-Approximation)
 - [AdaRFT](https://github.com/uscnlp-lime/verl): Efficient Reinforcement Finetuning via **Adaptive Curriculum Learning** ![GitHub Repo stars](https://img.shields.io/github/stars/uscnlp-lime/verl)

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -130,6 +130,11 @@ actor_rollout_ref:
     engine_kwargs: # inference engine parameters
       vllm:
         swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
+        enable_sleep_mode: True
+        disable_custom_all_reduce: True
+        disable_mm_preprocessor_cache: True
+        skip_tokenizer_init: False
+        enable_prefix_caching: True
       sglang:
         attention_backend: null # null means use the engine default value, available options: flashinfer, triton, flashmla
     val_kwargs:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -159,26 +159,28 @@ class AsyncvLLMServer(AsyncServerBase):
         for k in config.keys():
             if hasattr(SamplingParams(), str(k)):
                 kwargs[k] = config.get(k)
+        engine_kwargs = config.engine_kwargs.vllm
+        engine_kwargs = engine_kwargs.pop("engine_kwargs", {})
         print(f"override_generation_config: {kwargs}")
 
         engine_args = AsyncEngineArgs(
             model=local_path,
-            enable_sleep_mode=True,
+            enable_sleep_mode=engine_kwargs.get("enable_sleep_mode"),
             override_generation_config=kwargs,
             tensor_parallel_size=tensor_parallel_size,
             distributed_executor_backend=ExternalRayDistributedExecutor,
             dtype=config.dtype,
             enforce_eager=config.enforce_eager,
             gpu_memory_utilization=config.gpu_memory_utilization,
-            disable_custom_all_reduce=True,
-            disable_mm_preprocessor_cache=True,
-            skip_tokenizer_init=False,
+            disable_custom_all_reduce=engine_kwargs.get("disable_custom_all_reduce"),
+            disable_mm_preprocessor_cache=engine_kwargs.get("disable_mm_preprocessor_cache"),
+            skip_tokenizer_init=engine_kwargs.get("skip_tokenizer_init"),
             max_model_len=max_model_len,
             load_format="auto",
             disable_log_stats=config.disable_log_stats,
             max_num_batched_tokens=max_num_batched_tokens,
             enable_chunked_prefill=config.enable_chunked_prefill,
-            enable_prefix_caching=True,
+            enable_prefix_caching=engine_kwargs.get("enable_prefix_caching"),
             trust_remote_code=trust_remote_code,
             seed=self.vllm_dp_rank,
         )


### PR DESCRIPTION
As bollow, the default vllm rollout config is only support multimodal model, and the  way to fix that problem need user use `engine_kwargs` config to cover default value, this approach is unfriendly to users who are not familiar with vllm. so, we’d better to give a clearly config to show how to cover vllm default value。
![bug](https://github.com/user-attachments/assets/337eff6e-eb43-4127-ad69-4e33c0629d39)

### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

> Fix doc about rollout vllm engine
> Adjust the rollout configuration to read the code

### High-Level Design

> None

### Specific Changes

> modified:   docs/examples/config.rst
        modified:   verl/trainer/config/ppo_trainer.yaml
        modified:   verl/workers/rollout/vllm_rollout/vllm_async_server.py
        modified:   verl/workers/rollout/vllm_rollout/vllm_rollout.py
        modified:   verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py


### API

> None

### Usage Example

>  config like:
    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 
    actor_rollout_ref.rollout.engine_kwargs.vllm.disable_mm_preprocessor_cache=False

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.
  no need

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] New CI unit test(s) are added to cover the code path.
- [x] Rely on existing unit tests on CI that covers the code path.
