### PR TITLE
[feat] add_dataset_weight

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -1,6 +1,7 @@
 data:
   tokenizer: null
   use_shm: False
+  train_weights: null
   train_files: ~/data/rlhf/gsm8k/train.parquet
   val_files: ~/data/rlhf/gsm8k/test.parquet
   prompt_key: prompt

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -213,9 +213,7 @@ def create_rl_sampler(data_config, dataset):
         train_dataloader_generator = torch.Generator()
         train_dataloader_generator.manual_seed(data_config.get("seed", 1))
         sampler = RandomSampler(data_source=dataset, generator=train_dataloader_generator)
-    else:
-        sampler = SequentialSampler(data_source=dataset)
-    if data_config.train_weights:
+    elif data_config.train_weights:
         assert (len(data_config.train_weights) == len(data_config.train_files), 
                 "The size of `train_weight` must be the same as the size of `train_files`.")
         train_weights = data_config.train_weights
@@ -226,6 +224,8 @@ def create_rl_sampler(data_config, dataset):
         for prob, length in zip(sample_weight, dataset.data_len_list):
             weights.extend([prob / length] * length)
         sampler = WeightedRandomSampler(weights, num_samples=len(dataset), replacement=True)
+    else:
+        sampler = SequentialSampler(data_source=dataset)
     return sampler
 
 

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -139,13 +139,15 @@ class RLHFDataset(Dataset):
         if self.filter_overlong_prompts:
             tokenizer = self.tokenizer
             prompt_key = self.prompt_key
-            self.dataframe = self.dataframe.filter(
+            dataframes = [dataframe.filter(
                 lambda doc: len(tokenizer.apply_chat_template(doc[prompt_key], add_generation_prompt=True)) <= self.max_prompt_length,
                 num_proc=self.num_workers,
                 desc=f"Filtering prompts longer than {self.max_prompt_length} tokens",
-            )
+            ) for dataframe in dataframes]
+            self.dataframe: datasets.Dataset = datasets.concatenate_datasets(dataframes)
 
             print(f"filter dataset len: {len(self.dataframe)}")
+        self.data_len_list = [len(dataframe) for dataframe in dataframes]
 
     def resume_dataset_state(self):
         self.serialize_dataset = not hasattr(self, "original_data_files")


### PR DESCRIPTION


### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

> Add support for weighted sampling over different training datasets, allowing users to specify sampling probabilities per dataset for more flexible and effective multi-source training.

### High-Level Design

> Based on the existing design, we extend the sampler by implementing a `WeightedRandomSampler` that assigns sampling weights to each dataset according to the number of prompts after filtering. This ensures that datasets with more usable prompts are sampled more frequently, improving training efficiency and balance.


### Specific Changes

> `verl/verl/trainer/main_ppo.py`: modified function `create_rl_sampler()`
> `verl/verl/trainer/config/ppo_trainer.yaml`: add `train_weights in data config
> `verl/verl/utils/dataset/rl_dataset.py`: modified the `__init__` of class `RLHFDataset`

### Usage Example

> If `train_weights` is provided, it should be the same size of `train_files`, and train_files must be a list with more than one dataset.
```
python3 -m verl.trainer.main_ppo \
        algorithm.adv_estimator=grpo \
        data.train_files=['dataset1', 'dataset2`] \
        data.train_weights=['0.5','1'] \
        data.val_files=/data/aime24/aime24.parquet \
        data.train_batch_size=128 \
...
```
The sum of `train_weights` does not need to be 1 as it will be normalized atuomatically.

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API. (not needed)
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] New CI unit test(s) are added to cover the code path.
- [x] Rely on existing unit tests on CI that covers the code path.
