### PR TITLE
[Feat] Add GenRM for verify answer during training and validation

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -1,6 +1,7 @@
 data:
   tokenizer: null
   use_shm: False
+  train_weights: null
   train_files: ~/data/rlhf/gsm8k/train.parquet
   val_files: ~/data/rlhf/gsm8k/test.parquet
   prompt_key: prompt

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -228,6 +228,57 @@ custom_reward_function:
   path: null
   name: compute_score
 
+gen_reward_model:
+  enable: False
+  strategy: fsdp
+  mode: sync # sync: LLM, async: AsyncLLM
+  name: vllm
+  temperature: 1.0
+  top_k: -1 # 0 for hf rollout, -1 for vllm rollout
+  top_p: 1
+  use_fire_sampling: False # https://arxiv.org/abs/2410.21236
+  prompt_length: ${data.max_prompt_length}  # not use for opensource
+  response_length: ${data.max_response_length}
+  model:
+    path: ~/models/deepseek-llm-7b-chat
+    external_lib: null
+    override_config: { }
+    enable_gradient_checkpointing: True 
+    use_remove_padding: False
+    use_liger: False
+  fsdp_config:
+      wrap_policy:
+        # transformer_layer_cls_to_wrap: None
+        min_num_params: 0
+      param_offload: False
+      optimizer_offload: False
+      fsdp_size: -1
+  # for vllm rollout
+  dtype: bfloat16 # should align with FSDP
+  gpu_memory_utilization: 0.5
+  ignore_eos: False
+  enforce_eager: True
+  free_cache_engine: True
+  load_format: dummy_dtensor
+  tensor_model_parallel_size: 1
+  max_num_batched_tokens: 32768 #8192
+  max_model_len: null
+  max_num_seqs: 1024
+  log_prob_micro_batch_size: null # will be deprecated, use log_prob_micro_batch_size_per_gpu
+  log_prob_micro_batch_size_per_gpu: null
+  log_prob_use_dynamic_bsz: ${actor_rollout_ref.actor.use_dynamic_bsz}
+  log_prob_max_token_len_per_gpu: ${actor_rollout_ref.actor.ppo_max_token_len_per_gpu}
+  disable_log_stats: True
+  enable_chunked_prefill: True # may get higher throughput when set to True. When activated, Please increase max_num_batched_tokens or decrease max_model_len.
+  # for hf rollout
+  do_sample: True
+  # number of responses (i.e. num sample times)
+  n: 1 # > 1 for grpo
+  engine_kwargs: # inference engine parameters
+    swap_space: null # null means "use the engine default value" (usually 4 GB), setting it to, e.g., 32 means 32 GB
+  truncation: error
+  ulysses_sequence_parallel_size: 1 # sp size
+
 algorithm:
   gamma: 1.0
   lam: 1.0

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -139,13 +139,15 @@ class RLHFDataset(Dataset):
         if self.filter_overlong_prompts:
             tokenizer = self.tokenizer
             prompt_key = self.prompt_key
-            self.dataframe = self.dataframe.filter(
+            dataframes = [dataframe.filter(
                 lambda doc: len(tokenizer.apply_chat_template(doc[prompt_key], add_generation_prompt=True)) <= self.max_prompt_length,
                 num_proc=self.num_workers,
                 desc=f"Filtering prompts longer than {self.max_prompt_length} tokens",
-            )
+            ) for dataframe in dataframes]
+            self.dataframe: datasets.Dataset = datasets.concatenate_datasets(dataframes)
 
             print(f"filter dataset len: {len(self.dataframe)}")
+        self.data_len_list = [len(dataframe) for dataframe in dataframes]
 
     def resume_dataset_state(self):
         self.serialize_dataset = not hasattr(self, "original_data_files")

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -149,7 +149,7 @@ class vLLMRollout(BaseRollout):
         engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
         self.inference_engine = LLM(
             model=model_path,
-            enable_sleep_mode=True,
+            enable_sleep_mode=False,
             tensor_parallel_size=tensor_parallel_size,
             distributed_executor_backend="external_launcher",
             dtype=config.dtype,
@@ -233,7 +233,6 @@ class vLLMRollout(BaseRollout):
         eos_token_id = prompts.meta_info["eos_token_id"]
 
         batch_size = idx.size(0)
-
         non_tensor_batch = prompts.non_tensor_batch
         if "raw_prompt_ids" not in non_tensor_batch:
             non_tensor_batch["raw_prompt_ids"] = np.array([_pre_process_inputs(self.pad_token_id, idx[i]) for i in range(batch_size)], dtype=object)
@@ -316,8 +315,8 @@ class vLLMRollout(BaseRollout):
                 position_ids = _repeat_interleave(position_ids, self.sampling_params.n)
                 batch_size = batch_size * self.sampling_params.n
                 # NOTE(linjunrong): for multi-turn https://github.com/volcengine/verl/pull/1037
-                if "tools_kwargs" in non_tensor_batch.keys():
-                    non_tensor_batch["tools_kwargs"] = _repeat_interleave(non_tensor_batch["tools_kwargs"], self.sampling_params.n)
+                for key in non_tensor_batch.keys():
+                    non_tensor_batch[key] = _repeat_interleave(non_tensor_batch[key], self.sampling_params.n)
 
             seq = torch.cat([idx, response], dim=-1)
 


### PR DESCRIPTION

### Checklist Before Starting

- [x] Searched for similar PR(s)

---

### What does this PR do?

> Adds `GenRewardModelWorker` for verifying rollout answers during training and validation.

---

### High-Level Design

> This PR introduces a new `GenRewardModelWorker` class modeled after the `ActorRolloutRefWorker`’s rollout logic.  

> It is compatible with the VLLM backend.  

> `GenRewardModelWorker` can replace the previous reward function mechanism to judge rollout results by transforming the GenRM output into binary values (0/1).

---

### Specific Changes

- `verl/trainer/config/ppo_trainer.yaml`: Added configuration options for `gen_reward_model`.
- `verl/workers/fsdp_workers.py`: Initialized GenRM.
- `verl/trainer/main_ppo.py`, `verl/trainer/ppo/ray_trainer.py`: Integrated GenRM invocation.
- `verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py`: 
  - Disabled sleep mode (`enable_sleep_mode: False`) to allow multiple VLLM instances in a single process.
  - Fixed a bug in `generate_sequences()` when using VLLM > 0.6.3 to resolve tensor shape mismatches (`non_tensor_batch` alignment issues).

---

### API Changes

> No changes to the public API.

---

### Usage Example

```bash
# Disclaimer: The model path below is for academic demonstration purposes only.
set -x

export HYDRA_FULL_ERROR=1
export VLLM_ATTENTION_BACKEND=XFORMERS  # flash_attn has known issues with qwen2-7b

train_files=/examples/data/math/train.parquet
test_files=/data/aime24/test_aime24_modefied_box.parquet

python3 -m verl.trainer.main_ppo \
    algorithm.adv_estimator=grpo \
    data.train_files="$train_files" \
    data.val_files="$test_files" \
    data.train_batch_size=16 \
    data.max_prompt_length=1024 \
    data.max_response_length=512 \
    data.filter_overlong_prompts=True \
    data.truncation='error' \
    data.return_raw_chat=True \
    actor_rollout_ref.model.path="/models/Qwen/Qwen2.5-0.5B" \
    actor_rollout_ref.model.use_remove_padding=True \
    actor_rollout_ref.actor.optim.lr=1e-6 \
    actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.1 \
    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=16 \
    actor_rollout_ref.actor.use_kl_loss=False \
    actor_rollout_ref.model.enable_gradient_checkpointing=True \
    actor_rollout_ref.actor.fsdp_config.param_offload=False \
    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=16 \
    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
    actor_rollout_ref.rollout.name=vllm \
    actor_rollout_ref.rollout.n=8 \
    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
    gen_reward_model.model.path="/models/IAAR-Shanghai/xVerify-0.5B-I" \
    gen_reward_model.model.use_remove_padding=True \
    gen_reward_model.model.enable_gradient_checkpointing=True \
    gen_reward_model.prompt_length=32704 \
    gen_reward_model.response_length=64 \
    gen_reward_model.truncation='error' \
    gen_reward_model.enable=True \
    gen_reward_model.log_prob_micro_batch_size_per_gpu=16 \
    algorithm.use_kl_in_reward=False \
    trainer.critic_warmup=0 \
    trainer.logger=['console','wandb'] \
    trainer.project_name='math_rl' \
    trainer.experiment_name='qwen2_5_math_7b_instruct_grpo' \
    trainer.val_before_train=True \
    trainer.n_gpus_per_node=8 \
    trainer.nnodes=1 \
    trainer.save_freq=20 \
    trainer.test_freq=5 \
    trainer.total_epochs=15 $@
