### PR TITLE
[doc] Add TTS model GRPO tuning project with verl on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ verl is inspired by the design of Nemo-Aligner, Deepspeed-chat and OpenRLHF. The
 - [LUFFY](https://arxiv.org/pdf/2504.14945): Learning to Reason under Off-Policy Guidance![GitHub Repo stars](https://img.shields.io/github/stars/ElliottYan/LUFFY)
 - [verl-tool](https://github.com/TIGER-AI-Lab/verl-tool): An unified and easy-to-extend tool-agent training framework based on verl![GitHub Repo stars](https://img.shields.io/github/stars/TIGER-AI-Lab/verl-tool)
 - [DeepMath](https://github.com/zwhe99/DeepMath): DeepMath-103K data and series models for math reasoning![GitHub Repo stars](https://img.shields.io/github/stars/zwhe99/DeepMath)
-- [LLaSA-TTS-GRPO](ch-tts-llasa-rl-grpo): TTS fine-tuning with GRPO optimization based on LLASA models [GitHub Repo stars]([https://img.shields.io/github/stars/zwhe99/DeepMath](https://github.com/channel-io/ch-tts-llasa-rl-grpo))
+- [LLaSA-TTS-GRPO](ch-tts-llasa-rl-grpo): TTS fine-tuning with GRPO optimization based on LLASA models ![GitHub Repo stars]([https://img.shields.io/github/stars/zwhe99/DeepMath](https://github.com/channel-io/ch-tts-llasa-rl-grpo))
 
 and many more awesome work listed in [recipe](recipe/README.md).
 ## Contribution Guide

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ verl is inspired by the design of Nemo-Aligner, Deepspeed-chat and OpenRLHF. The
 - [LUFFY](https://arxiv.org/pdf/2504.14945): Learning to Reason under Off-Policy Guidance![GitHub Repo stars](https://img.shields.io/github/stars/ElliottYan/LUFFY)
 - [verl-tool](https://github.com/TIGER-AI-Lab/verl-tool): An unified and easy-to-extend tool-agent training framework based on verl![GitHub Repo stars](https://img.shields.io/github/stars/TIGER-AI-Lab/verl-tool)
 - [DeepMath](https://github.com/zwhe99/DeepMath): DeepMath-103K data and series models for math reasoning![GitHub Repo stars](https://img.shields.io/github/stars/zwhe99/DeepMath)
+- [LLaSA-TTS-GRPO](ch-tts-llasa-rl-grpo): TTS fine-tuning with GRPO optimization based on LLASA models [GitHub Repo stars]([https://img.shields.io/github/stars/zwhe99/DeepMath](https://github.com/channel-io/ch-tts-llasa-rl-grpo))
 
 and many more awesome work listed in [recipe](recipe/README.md).
 ## Contribution Guide

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ verl is inspired by the design of Nemo-Aligner, Deepspeed-chat and OpenRLHF. The
 - [LUFFY](https://arxiv.org/pdf/2504.14945): Learning to Reason under Off-Policy Guidance![GitHub Repo stars](https://img.shields.io/github/stars/ElliottYan/LUFFY)
 - [verl-tool](https://github.com/TIGER-AI-Lab/verl-tool): An unified and easy-to-extend tool-agent training framework based on verl![GitHub Repo stars](https://img.shields.io/github/stars/TIGER-AI-Lab/verl-tool)
 - [DeepMath](https://github.com/zwhe99/DeepMath): DeepMath-103K data and series models for math reasoning![GitHub Repo stars](https://img.shields.io/github/stars/zwhe99/DeepMath)
-- [LLaSA-TTS-GRPO](ch-tts-llasa-rl-grpo): TTS fine-tuning with GRPO optimization based on LLASA models ![GitHub Repo stars](https://img.shields.io/github/stars/channel-io/ch-tts-llasa-rl-grpo)
+- [LLaSA-TTS-GRPO](https://github.com/channel-io/ch-tts-llasa-rl-grpo): TTS fine-tuning with GRPO optimization based on LLASA models ![GitHub Repo stars](https://img.shields.io/github/stars/channel-io/ch-tts-llasa-rl-grpo)
 
 and many more awesome work listed in [recipe](recipe/README.md).
 ## Contribution Guide

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ verl is inspired by the design of Nemo-Aligner, Deepspeed-chat and OpenRLHF. The
 - [LUFFY](https://arxiv.org/pdf/2504.14945): Learning to Reason under Off-Policy Guidance![GitHub Repo stars](https://img.shields.io/github/stars/ElliottYan/LUFFY)
 - [verl-tool](https://github.com/TIGER-AI-Lab/verl-tool): An unified and easy-to-extend tool-agent training framework based on verl![GitHub Repo stars](https://img.shields.io/github/stars/TIGER-AI-Lab/verl-tool)
 - [DeepMath](https://github.com/zwhe99/DeepMath): DeepMath-103K data and series models for math reasoning![GitHub Repo stars](https://img.shields.io/github/stars/zwhe99/DeepMath)
-- [LLaSA-TTS-GRPO](ch-tts-llasa-rl-grpo): TTS fine-tuning with GRPO optimization based on LLASA models ![GitHub Repo stars]([https://img.shields.io/github/stars/zwhe99/DeepMath](https://github.com/channel-io/ch-tts-llasa-rl-grpo))
+- [LLaSA-TTS-GRPO](ch-tts-llasa-rl-grpo): TTS fine-tuning with GRPO optimization based on LLASA models ![GitHub Repo stars](https://img.shields.io/github/stars/channel-io/ch-tts-llasa-rl-grpo)
 
 and many more awesome work listed in [recipe](recipe/README.md).
 ## Contribution Guide


### PR DESCRIPTION
### Checklist Before Starting

* [x] Search for similar PR(s).

### What does this PR do?

> Integrates Korean TTS fine-tuning using GRPO optimization based on LLASA-1B models, significantly improving synthesis quality by reducing Character Error Rate (CER).

### High-Level Design

> This PR enhances the existing TTS model training pipeline by introducing a reinforcement learning optimization (GRPO) step using Whisper's NLL and CER metrics.

### Specific Changes

* Adds GRPO reward calculation based on Character Error Rate (CER) and Negative Log-Likelihood (NLL).
* Implements a Whisper server to compute NLL metrics efficiently.
* Provides scripts for training (`run_llasa_tts_grpo.sh`) and data preprocessing (`tts.py`).

### API

> No changes to existing public APIs. Internal additions only.

### Usage Example

```bash
CUDA_VISIBLE_DEVICES=2 python3 tts/whisper_server.py --port 8001 --model large-v3

WHISPER_SERVER=http://localhost:8001 nohup bash ./examples/grpo_trainer/run_llasa_tts_grpo.sh > verl_grpo_1b.log 2>&1 &
```

### Test

> Evaluated on internal dataset:

* LLasa1B + 15K Korean dataset baseline CER = 0.0266
* LLasa1B + 15K Korean dataset + GRPO optimization CER = 0.0204

The reduction in CER demonstrates the effectiveness of the GRPO optimization.

### Additional Info.

* **Issue Number**: N/A
* **Training**: FSDP, Megatron (as relevant)
* **Inference**: vLLM, SGLang (as relevant)

### Checklist Before Submitting

* [ ] Read the [[Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide)](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
* [ ] Apply [[pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting)](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
* [ ] Add `[BREAKING]` to the PR title if it breaks any API.
* [ ] Update the documentation about your changes in the [[docs](https://github.com/volcengine/verl/tree/main/docs)](https://github.com/volcengine/verl/tree/main/docs).
* [ ] New CI unit test(s) are added to cover the code path.
* [ ] Rely on existing unit tests on CI that covers the code path.