### PR TITLE
Fix Typos in Documentation Files

### DIFF
--- a/docs/advance/checkpoint.rst
+++ b/docs/advance/checkpoint.rst
@@ -37,7 +37,7 @@ So the inner checkpoint structure of **FSDP** is like:
     │   └── critic_huggingface
     └── latest_checkpointed_iteration.txt
 
-All model shards, optimizers and extra states are stored togather, in a sharded and distributed way.
+All model shards, optimizers and extra states are stored together, in a sharded and distributed way.
 
 While **Megatron** current checkpoint structure is:
 

--- a/docs/faq/faq.rst
+++ b/docs/faq/faq.rst
@@ -155,7 +155,7 @@ https://excalidraw.com/#json=pfhkRmiLm1jnnRli9VFhb,Ut4E8peALlgAUpr7E5pPCA
 
 .. image:: https://github.com/user-attachments/assets/16aebad1-0da6-4eb3-806d-54a74e712c2d
 
-How to generate ray timeline to analyse performance of a trainning job?
+How to generate ray timeline to analyse performance of a training job?
 ------------------------------------------------------------------------------------------
 
 To generate the ray timeline file, you can set the config term ``ray_init.timeline_file`` to a json file path.


### PR DESCRIPTION


Description:  
This pull request corrects several typographical errors in the documentation:

- In docs/advance/checkpoint.rst, the word "togather" has been corrected to "together".
- In docs/faq/faq.rst, the word "trainning" has been corrected to "training".

These changes improve the clarity and professionalism of the documentation. No functional code changes are included.