### PR TITLE
Fix assert fail when nodes have different numbers of processes

### DIFF
--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -327,9 +327,8 @@ class RayWorkerGroup(WorkerGroup):
         num_gpus = 1 / resource_pool.max_colocate_count
 
         rank = -1
-        local_world_size = resource_pool.store[0]
         for pg_idx, pg in enumerate(sort_placement_group_by_node_ip(pgs)):
-            assert local_world_size <= pg.bundle_count, f"when generating for {self.name_prefix}, for the "
+            local_world_size = pg.bundle_count
             for local_rank in range(local_world_size):
                 rank += 1
 


### PR DESCRIPTION
For the current implementation `local_world_size = resource_pool.store[0]`, if different logical nodes have different numbers of processes, it may lead to `assert local_world_size <= pg.bundle_count` failure. For example, the following test code:

```py
import ray

from verl.single_controller.base.worker import Worker
from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup

@ray.remote
class TestActor(Worker):
    def __init__(self) -> None:
        super().__init__()


if __name__ == "__main__":
    ray.init()

    resource_pool = RayResourcePool([4, 2], use_gpu=False, max_colocate_count=1)
    class_with_args = RayClassWithInitArgs(cls=TestActor)
    worker_group = RayWorkerGroup(resource_pool, class_with_args)

    ray.shutdown()
```
---
I found that current code comes from https://github.com/volcengine/verl/pull/500, and I think there is a difficult problem here: **How to ensure that the ranks on each node are fixed or consistent when creating placement groups multiple times on the same cluster**. If logical nodes has the same number of processes, everything is fine. On the contrary, it may lead to errors. For example, for `RayResourcePool([2,3])`, suppose:
* When creating worker group for the first time, PG1 is scheduled to node1 with `ranks=[0,1]`, and PG2 is scheduled to node2 with `ranks=[2,3,4]`.  When creating worker group for the second time, PG1 is scheduled to node2 with `ranks=[3,4]`, and PG2 is scheduled to node1 with `ranks=[0,1,2]`. 
* As can be seen, **rank2 is located on different nodes during the two executions**. in some scenarios, errors will occur. For example, during the second execution, rank2 located in node1 cannot retrieve the ckpt file stored in node2 during the first execution.

In summary, my fix allows different logical nodes to have different numbers of processes, but the rank consistency issue still exists. Since ray does not seem to support scheduling placement groups to specified nodes, I believe that if users want rank consistency, they must ensure that logical nodes have the same number of processes themselves.


