### PR TITLE
[hardware] refactor: refactor part of device management

### DIFF
--- a/examples/split_placement/main_ppo_split.py
+++ b/examples/split_placement/main_ppo_split.py
@@ -203,6 +203,7 @@ def main_task(config):
         ray_worker_group_cls=ray_worker_group_cls,
         reward_fn=reward_fn,
         val_reward_fn=val_reward_fn,
+        device_name=config.trainer.device,
     )
     trainer.init_workers()
     trainer.fit()

--- a/recipe/prime/main_prime.py
+++ b/recipe/prime/main_prime.py
@@ -140,6 +140,7 @@ def main_task(config, compute_score=None):
         ray_worker_group_cls=ray_worker_group_cls,
         reward_fn=reward_fn,
         val_reward_fn=val_reward_fn,
+        device_name=config.trainer.device,
     )
     trainer.init_workers()
     trainer.fit()

--- a/recipe/prime/prime_dp_rm.py
+++ b/recipe/prime/prime_dp_rm.py
@@ -28,6 +28,7 @@ from verl import DataProto
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.ulysses import gather_outpus_and_unpad, ulysses_pad_and_slice_inputs
+from verl.utils.device import get_device_name
 
 from .prime_core_algos import compute_ce_dpo_loss_rm, compute_detach_dpo_loss_rm
 
@@ -115,7 +116,7 @@ class DataParallelPRIMERewardModel:
 
         if self.ref_module is not None:
             # do not have to pad again
-            with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            with torch.no_grad(), torch.autocast(device_type=get_device_name(), dtype=torch.bfloat16):
                 if self.ulysses_sequence_parallel_size > 1 and self.use_remove_padding:
                     ref_output = self.ref_module(
                         input_ids=input_ids_rmpad,
@@ -291,7 +292,7 @@ class DataParallelPRIMERewardModel:
             self.reward_optimizer.zero_grad()
 
             for data in micro_batches:
-                data = data.cuda()
+                data = data.to(get_device_name())
                 attention_mask = data["attention_mask"]
                 acc = data["acc"]
 

--- a/recipe/prime/prime_dp_rm.py
+++ b/recipe/prime/prime_dp_rm.py
@@ -25,10 +25,10 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 import verl.utils.torch_functional as verl_F
 from verl import DataProto
+from verl.utils.device import get_device_name
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.ulysses import gather_outpus_and_unpad, ulysses_pad_and_slice_inputs
-from verl.utils.device import get_device_name
 
 from .prime_core_algos import compute_ce_dpo_loss_rm, compute_detach_dpo_loss_rm
 

--- a/recipe/prime/prime_fsdp_workers.py
+++ b/recipe/prime/prime_fsdp_workers.py
@@ -37,6 +37,7 @@ from verl.utils.fsdp_utils import (
     offload_fsdp_model_to_cpu,
     offload_fsdp_optimizer,
 )
+from verl.utils.device import get_device_name, get_device_id, get_nccl_backend
 from verl.utils.import_utils import import_external_libs
 from verl.workers.fsdp_workers import create_device_mesh, get_sharding_strategy
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
@@ -53,7 +54,7 @@ class PRIMERewardModelWorker(Worker):
         import torch.distributed
 
         if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend="nccl")
+            torch.distributed.init_process_group(backend=get_nccl_backend())
         self.config = config
 
         # build device mesh for Ulysses Sequence Parallel
@@ -66,7 +67,7 @@ class PRIMERewardModelWorker(Worker):
         self.ulysses_sequence_parallel_size = self.config.get("ulysses_sequence_parallel_size", 1)
         dp = world_size // self.ulysses_sequence_parallel_size
         if self.ulysses_sequence_parallel_size > 1:
-            self.ulysses_device_mesh = init_device_mesh("cuda", mesh_shape=(dp, self.ulysses_sequence_parallel_size), mesh_dim_names=["dp", "sp"])
+            self.ulysses_device_mesh = init_device_mesh(get_device_name(), mesh_shape=(dp, self.ulysses_sequence_parallel_size), mesh_dim_names=["dp", "sp"])
 
         self.ulysses_sharding_manager = FSDPUlyssesShardingManager(self.ulysses_device_mesh)
 
@@ -190,7 +191,7 @@ class PRIMERewardModelWorker(Worker):
             param_init_fn=init_fn,
             use_orig_params=False,
             auto_wrap_policy=auto_wrap_policy,
-            device_id=torch.cuda.current_device(),
+            device_id=get_device_id(),
             sharding_strategy=sharding_strategy,
             mixed_precision=mixed_precision,
             sync_module_states=True,
@@ -206,7 +207,7 @@ class PRIMERewardModelWorker(Worker):
             param_init_fn=init_fn,
             use_orig_params=False,
             auto_wrap_policy=auto_wrap_policy,
-            device_id=torch.cuda.current_device(),
+            device_id=get_device_id(),
             sharding_strategy=sharding_strategy,
             mixed_precision=mixed_precision,
             sync_module_states=True,
@@ -268,7 +269,7 @@ class PRIMERewardModelWorker(Worker):
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_rm_score(self, data: DataProto):
-        data = data.to("cuda")
+        data = data.to(get_device_name())
 
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.reward_module)
@@ -303,12 +304,12 @@ class PRIMERewardModelWorker(Worker):
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def update_rm(self, data: DataProto):
-        data = data.to("cuda")
+        data = data.to(get_device_name())
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.ref_module)
             load_fsdp_model_to_gpu(self.reward_module)
         if self._is_offload_optimizer:
-            load_fsdp_optimizer(optimizer=self.reward_optimizer, device_id=torch.cuda.current_device())
+            load_fsdp_optimizer(optimizer=self.reward_optimizer, device_id=get_device_id())
 
         # perform forward computation
         with self.ulysses_sharding_manager:

--- a/recipe/prime/prime_fsdp_workers.py
+++ b/recipe/prime/prime_fsdp_workers.py
@@ -26,6 +26,7 @@ from verl.single_controller.base.decorator import Dispatch, register
 from verl.utils import hf_tokenizer
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.utils.debug import log_gpu_memory_usage
+from verl.utils.device import get_device_id, get_device_name, get_nccl_backend
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.fs import copy_local_path_from_hdfs
 from verl.utils.fsdp_utils import (
@@ -37,7 +38,6 @@ from verl.utils.fsdp_utils import (
     offload_fsdp_model_to_cpu,
     offload_fsdp_optimizer,
 )
-from verl.utils.device import get_device_name, get_device_id, get_nccl_backend
 from verl.utils.import_utils import import_external_libs
 from verl.workers.fsdp_workers import create_device_mesh, get_sharding_strategy
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager

--- a/recipe/prime/prime_ray_trainer.py
+++ b/recipe/prime/prime_ray_trainer.py
@@ -151,8 +151,9 @@ class RayPRIMETrainer(RayPPOTrainer):
         ray_worker_group_cls: RayWorkerGroup = RayWorkerGroup,
         reward_fn=None,
         val_reward_fn=None,
+        device_name="cuda",
     ):
-        # assert torch.cuda.is_available(), 'cuda must be available on driver'
+        # assert get_torch_device().is_available(), 'cuda must be available on driver'
 
         super().__init__(
             config,
@@ -162,6 +163,7 @@ class RayPRIMETrainer(RayPPOTrainer):
             ray_worker_group_cls,
             reward_fn,
             val_reward_fn,
+            device_name=device_name,
         )
 
         self.use_critic = False

--- a/recipe/spin/dp_actor.py
+++ b/recipe/spin/dp_actor.py
@@ -24,6 +24,7 @@ import torch
 from recipe.spin.core_algos import compute_online_dpo_loss, get_batch_logps
 from verl import DataProto
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
+from verl.utils.device import get_device_name
 from verl.workers.actor import DataParallelPPOActor
 
 __all__ = ["DataParallelPPOActor"]
@@ -175,7 +176,7 @@ class SPINDataParallelPPOActor(DataParallelPPOActor):
             # Determine autocast dtype
             autocast_dtype = torch.bfloat16  # Or get dynamically from config/FSDP settings
             # --- Autocast Forward Pass ---
-            with torch.autocast(device_type="cuda", dtype=autocast_dtype):
+            with torch.autocast(device_type=get_device_name(), dtype=autocast_dtype):
                 # --- Step 1: Forward pass for CURRENT policy log probs (with grad) ---
                 policy_chosen_outputs = self.actor_module(**micro_batch_chosen_inputs, use_cache=False)
                 policy_rejected_outputs = self.actor_module(**micro_batch_rejected_inputs, use_cache=False)

--- a/recipe/spin/dp_actor.py
+++ b/recipe/spin/dp_actor.py
@@ -23,8 +23,8 @@ import torch
 
 from recipe.spin.core_algos import compute_online_dpo_loss, get_batch_logps
 from verl import DataProto
-from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.device import get_device_name
+from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.workers.actor import DataParallelPPOActor
 
 __all__ = ["DataParallelPPOActor"]

--- a/recipe/spin/fsdp_workers.py
+++ b/recipe/spin/fsdp_workers.py
@@ -32,12 +32,12 @@ from verl.single_controller.base.decorator import Dispatch, register
 from verl.utils import hf_tokenizer
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.utils.debug import log_gpu_memory_usage
+from verl.utils.device import get_device_id, get_device_name, get_nccl_backend, get_torch_device
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.fs import copy_to_local
 from verl.utils.fsdp_utils import get_fsdp_wrap_policy, get_init_weight_context_manager, init_fn, load_fsdp_model_to_gpu, load_fsdp_optimizer, offload_fsdp_model_to_cpu, offload_fsdp_optimizer
 from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
-from verl.utils.device import get_torch_device, get_device_name, get_device_id, get_nccl_backend
 from verl.workers.fsdp_workers import ActorRolloutRefWorker
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
 

--- a/recipe/spin/fsdp_workers.py
+++ b/recipe/spin/fsdp_workers.py
@@ -37,6 +37,7 @@ from verl.utils.fs import copy_to_local
 from verl.utils.fsdp_utils import get_fsdp_wrap_policy, get_init_weight_context_manager, init_fn, load_fsdp_model_to_gpu, load_fsdp_optimizer, offload_fsdp_model_to_cpu, offload_fsdp_optimizer
 from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
+from verl.utils.device import get_torch_device, get_device_name, get_device_id, get_nccl_backend
 from verl.workers.fsdp_workers import ActorRolloutRefWorker
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
 
@@ -46,9 +47,9 @@ logger.setLevel(os.getenv("VERL_PPO_LOGGING_LEVEL", "WARN"))
 
 def create_device_mesh(world_size, fsdp_size):
     if fsdp_size < 0 or fsdp_size >= world_size:
-        device_mesh = init_device_mesh("cuda", mesh_shape=(world_size,), mesh_dim_names=["fsdp"])
+        device_mesh = init_device_mesh(get_device_name(), mesh_shape=(world_size,), mesh_dim_names=["fsdp"])
     else:
-        device_mesh = init_device_mesh("cuda", mesh_shape=(world_size // fsdp_size, fsdp_size), mesh_dim_names=["ddp", "fsdp"])
+        device_mesh = init_device_mesh(get_device_name(), mesh_shape=(world_size // fsdp_size, fsdp_size), mesh_dim_names=["ddp", "fsdp"])
     return device_mesh
 
 
@@ -145,7 +146,7 @@ class SPINRolloutRefWorker(ActorRolloutRefWorker):
         assert self._is_ref
 
         # Support all hardwares
-        data = data.to(torch.cuda.current_device())
+        data = data.to(get_device_id())
 
         micro_batch_size = self.config.ref.log_prob_micro_batch_size_per_gpu
         data.meta_info["micro_batch_size"] = micro_batch_size
@@ -174,7 +175,7 @@ class SPINRolloutRefWorker(ActorRolloutRefWorker):
             load_fsdp_model_to_gpu(self.actor_module_fsdp)
 
         # Support all hardwares
-        data = data.to(torch.cuda.current_device())
+        data = data.to(get_device_id())
         # we should always recompute old_log_probs when it is HybridEngine
         data.meta_info["micro_batch_size"] = self.config.rollout.log_prob_micro_batch_size_per_gpu
         data.meta_info["max_token_len"] = self.config.rollout.log_prob_max_token_len_per_gpu
@@ -208,7 +209,7 @@ class SPINRolloutRefWorker(ActorRolloutRefWorker):
         on pre-calculated log probabilities.
         """
         # Support all hardwares
-        data = data.to(torch.cuda.current_device())
+        data = data.to(get_device_id())
 
         assert self._is_actor  # Make sure this worker has the actor role
         if self.actor is None:
@@ -218,7 +219,7 @@ class SPINRolloutRefWorker(ActorRolloutRefWorker):
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.actor_module_fsdp)
         if self._is_offload_optimizer:
-            load_fsdp_optimizer(optimizer=self.actor_optimizer, device_id=torch.cuda.current_device())
+            load_fsdp_optimizer(optimizer=self.actor_optimizer, device_id=get_device_id())
 
         log_gpu_memory_usage("Before update policy (DPO via PPO path)", logger=logger)
 
@@ -235,8 +236,8 @@ class SPINRolloutRefWorker(ActorRolloutRefWorker):
             # --- Add Performance Metrics ---
             # MFU calculation might be less accurate/meaningful here for DPO
             metrics["perf/approx_tokens_processed"] = torch.sum(data.batch.get("attention_mask", torch.tensor(0))).item()  # Approx tokens
-            metrics["perf/max_memory_allocated_gb"] = torch.cuda.max_memory_allocated() / (1024**3)
-            metrics["perf/max_memory_reserved_gb"] = torch.cuda.max_memory_reserved() / (1024**3)
+            metrics["perf/max_memory_allocated_gb"] = get_torch_device().max_memory_allocated() / (1024**3)
+            metrics["perf/max_memory_reserved_gb"] = get_torch_device().max_memory_reserved() / (1024**3)
             metrics["perf/cpu_memory_used_gb"] = psutil.virtual_memory().used / (1024**3)
             global_num_tokens = data.meta_info["global_token_num"]
             estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
@@ -274,7 +275,7 @@ class RewardModelWorker(Worker):
         import torch.distributed
 
         if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend="nccl")
+            torch.distributed.init_process_group(backend=get_nccl_backend())
         self.config = config
 
         # build device mesh for Ulysses Sequence Parallel
@@ -288,7 +289,7 @@ class RewardModelWorker(Worker):
         self.ulysses_sequence_parallel_size = self.config.get("ulysses_sequence_parallel_size", 1)
         dp = world_size // self.ulysses_sequence_parallel_size
         if self.ulysses_sequence_parallel_size > 1:
-            self.ulysses_device_mesh = init_device_mesh("cuda", mesh_shape=(dp, self.ulysses_sequence_parallel_size), mesh_dim_names=["dp", "sp"])
+            self.ulysses_device_mesh = init_device_mesh(get_device_name(), mesh_shape=(dp, self.ulysses_sequence_parallel_size), mesh_dim_names=["dp", "sp"])
 
         self.ulysses_sharding_manager = FSDPUlyssesShardingManager(self.ulysses_device_mesh)
 
@@ -345,7 +346,7 @@ class RewardModelWorker(Worker):
             param_init_fn=init_fn,
             use_orig_params=False,
             auto_wrap_policy=auto_wrap_policy,
-            device_id=torch.cuda.current_device(),
+            device_id=get_device_id(),
             sharding_strategy=sharding_strategy,  # zero3
             sync_module_states=True,
             cpu_offload=CPUOffload(offload_params=True),
@@ -366,7 +367,7 @@ class RewardModelWorker(Worker):
 
         from verl.utils.ulysses import gather_outpus_and_unpad, ulysses_pad_and_slice_inputs
 
-        with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        with torch.no_grad(), torch.autocast(device_type=get_device_name(), dtype=torch.bfloat16):
             input_ids = micro_batch["input_ids"]
             batch_size, seqlen = input_ids.shape
             attention_mask = micro_batch["attention_mask"]
@@ -487,7 +488,7 @@ class RewardModelWorker(Worker):
         from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 
         # Support all hardwares
-        data = data.to(torch.cuda.current_device())
+        data = data.to(get_device_id())
         if self._do_switch_chat_template:
             rm_data = self._switch_chat_template(data)
         else:
@@ -498,7 +499,7 @@ class RewardModelWorker(Worker):
             rm_data = DataProto.from_dict(rm_inputs)
 
         # Support all hardwares
-        rm_data.batch = rm_data.batch.to(torch.cuda.current_device())
+        rm_data.batch = rm_data.batch.to(get_device_id())
 
         # perform forward computation
         with self.ulysses_sharding_manager:

--- a/recipe/spin/main_spin.py
+++ b/recipe/spin/main_spin.py
@@ -128,7 +128,17 @@ class TaskRunner:
         val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=1, compute_score=compute_score, reward_fn_key=config.data.reward_fn_key)
         resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=mapping)
 
-        trainer = RaySPINTrainer(config=config, tokenizer=tokenizer, processor=processor, role_worker_mapping=role_worker_mapping, resource_pool_manager=resource_pool_manager, ray_worker_group_cls=ray_worker_group_cls, reward_fn=reward_fn, val_reward_fn=val_reward_fn)
+        trainer = RaySPINTrainer(
+            config=config,
+            tokenizer=tokenizer,
+            processor=processor,
+            role_worker_mapping=role_worker_mapping,
+            resource_pool_manager=resource_pool_manager,
+            ray_worker_group_cls=ray_worker_group_cls,
+            reward_fn=reward_fn,
+            val_reward_fn=val_reward_fn,
+            device_name=config.trainer.device,
+        )
         trainer.init_workers()
         trainer.fit_dpo()
 

--- a/recipe/spin/spin_trainer.py
+++ b/recipe/spin/spin_trainer.py
@@ -357,8 +357,9 @@ class RaySPINTrainer:
         val_dataset: Optional[Dataset] = None,
         collate_fn=None,
         train_sampler: Optional[Sampler] = None,
+        device_name="cuda",
     ):
-        # assert torch.cuda.is_available(), 'cuda must be available on driver'
+        # assert get_torch_device().is_available(), 'cuda must be available on driver'
 
         self.tokenizer = tokenizer
         self.processor = processor
@@ -379,6 +380,7 @@ class RaySPINTrainer:
         self.ray_worker_group_cls = ray_worker_group_cls
         self.validation_generations_logger = ValidationGenerationsLogger()
         self.async_rollout_mode = False
+        self.device_name = device_name
 
         # define in-reward KL control
         # kl loss control currently not suppoorted
@@ -732,7 +734,7 @@ class RaySPINTrainer:
 
         for resource_pool, class_dict in self.resource_pool_to_cls.items():
             worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
-            wg_dict = self.ray_worker_group_cls(resource_pool=resource_pool, ray_cls_with_init=worker_dict_cls, **wg_kwargs)
+            wg_dict = self.ray_worker_group_cls(resource_pool=resource_pool, ray_cls_with_init=worker_dict_cls, device_name=self.device_name, **wg_kwargs)
             spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())
             all_wg.update(spawn_wg)
             # keep the referece of WorkerDict to support ray >= 2.31. Ref: https://github.com/ray-project/ray/pull/45699

--- a/recipe/sppo/dp_actor.py
+++ b/recipe/sppo/dp_actor.py
@@ -22,9 +22,9 @@ import verl.utils.torch_functional as verl_F
 from verl import DataProto
 from verl.trainer.ppo.core_algos import agg_loss, kl_penalty
 from verl.utils.debug import GPUMemoryLogger
+from verl.utils.device import get_device_id
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import rearrange_micro_batches
-from verl.utils.device import get_device_id
 from verl.workers.actor.dp_actor import DataParallelPPOActor
 
 logger = logging.getLogger(__file__)

--- a/recipe/sppo/dp_actor.py
+++ b/recipe/sppo/dp_actor.py
@@ -24,6 +24,7 @@ from verl.trainer.ppo.core_algos import agg_loss, kl_penalty
 from verl.utils.debug import GPUMemoryLogger
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import rearrange_micro_batches
+from verl.utils.device import get_device_id
 from verl.workers.actor.dp_actor import DataParallelPPOActor
 
 logger = logging.getLogger(__file__)
@@ -104,9 +105,9 @@ class DataParallelSPPOActor(DataParallelPPOActor):
                 for data in micro_batches:
                     # Support all hardwares
                     if isinstance(data, DataProto):
-                        data = {**data.batch.to(torch.cuda.current_device()), **data.non_tensor_batch}
+                        data = {**data.batch.to(get_device_id()), **data.non_tensor_batch}
                     else:
-                        data = data.to(torch.cuda.current_device())  # actor device is cpu when using offload
+                        data = data.to(get_device_id())  # actor device is cpu when using offload
                     responses = data["responses"]
                     response_length = responses.size(1)
                     attention_mask = data["attention_mask"]

--- a/recipe/sppo/main_sppo.py
+++ b/recipe/sppo/main_sppo.py
@@ -23,7 +23,6 @@ import hydra
 import ray
 
 from verl.trainer.ppo.reward import load_reward_manager
-from verl.utils.device import is_cuda_available
 
 from .sppo_ray_trainer import RaySPPOTrainer
 
@@ -141,7 +140,7 @@ class TaskRunner:
             ray_worker_group_cls=ray_worker_group_cls,
             reward_fn=reward_fn,
             val_reward_fn=val_reward_fn,
-            device_name="cuda" if is_cuda_available else "npu",
+            device_name=config.trainer.device,
         )
         trainer.init_workers()
         trainer.fit()

--- a/tests/special_e2e/ppo_trainer/run_function_reward.sh
+++ b/tests/special_e2e/ppo_trainer/run_function_reward.sh
@@ -134,6 +134,7 @@ python3 -m verl.trainer.main_ppo \
     trainer.save_freq="${SAVE_FREQ}" \
     trainer.resume_mode="${RESUME_MODE}" \
     trainer.total_epochs=2 \
+    trainer.device=cuda \
     trainer.total_training_steps="${TOTAL_TRAIN_STEPS}" $@ \
     | tee "${output_file}"
 

--- a/verl/models/llama/megatron/checkpoint_utils/llama_loader.py
+++ b/verl/models/llama/megatron/checkpoint_utils/llama_loader.py
@@ -17,6 +17,8 @@ import time
 import torch
 import torch.distributed as dist
 
+from verl.utils.device import get_torch_device, get_device_id
+
 
 def _megatron_calc_layer_map(config):
     """Calculate the mapping of global layer_idx to local layer_idx
@@ -139,7 +141,7 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
         if gate_name in state_dict and up_name in state_dict:
             gate_weight = state_dict[gate_name]
             up_weight = state_dict[up_name]
-            new_gate_up_weight = torch.empty(config.intermediate_size * 2, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+            new_gate_up_weight = torch.empty(config.intermediate_size * 2, config.hidden_size, dtype=params_dtype, device=get_device_id())
             for i in range(tp_size):
                 intermediate_size_tp = config.intermediate_size // tp_size
                 gate_weight_tp = gate_weight[i * intermediate_size_tp : (i + 1) * intermediate_size_tp]
@@ -169,7 +171,7 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
             q_size_tp = config.hidden_size // tp_size
             kv_size_tp = hidden_size_per_head * config.num_key_value_heads // tp_size
             total_size = q_size_tp + 2 * kv_size_tp
-            new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+            new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=get_device_id())
             for i in range(tp_size):
                 q_part = full_weight_q[i * q_size_tp : (i + 1) * q_size_tp]
                 k_part = full_weight_k[i * kv_size_tp : (i + 1) * kv_size_tp]
@@ -180,7 +182,7 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
             q_size_tp = config.hidden_size // tp_size
             kv_size_tp = hidden_size_per_head
             total_size = q_size_tp + 2 * kv_size_tp
-            new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+            new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=get_device_id())
             for i in range(tp_size):
                 q_part = full_weight_q[i * q_size_tp : (i + 1) * q_size_tp]
                 start_idx = i * config.num_key_value_heads // tp_size * hidden_size_per_head
@@ -292,5 +294,5 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
             _fetch_tp_shard_tensor(lm_head_weight, "lm_head.weight")
 
     dist.barrier()
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     print_rank_0(f"loading megatron ckpt done, time elapsed {time.time() - start_time}s")

--- a/verl/models/llama/megatron/checkpoint_utils/llama_loader.py
+++ b/verl/models/llama/megatron/checkpoint_utils/llama_loader.py
@@ -17,7 +17,7 @@ import time
 import torch
 import torch.distributed as dist
 
-from verl.utils.device import get_torch_device, get_device_id
+from verl.utils.device import get_device_id, get_torch_device
 
 
 def _megatron_calc_layer_map(config):

--- a/verl/models/llama/megatron/checkpoint_utils/llama_loader_depracated.py
+++ b/verl/models/llama/megatron/checkpoint_utils/llama_loader_depracated.py
@@ -17,6 +17,7 @@ import time
 import torch
 import torch.distributed as dist
 
+from verl.utils.device import get_torch_device, get_device_id
 
 def _megatron_calc_layer_map(config):
     """Calculate the mapping of global layer_idx to local layer_idx
@@ -119,7 +120,7 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
             tensor = torch.empty(
                 tensor_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         if torch.distributed.get_rank() == 0:
@@ -158,12 +159,12 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank()} tensor {name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == 0:
@@ -203,12 +204,12 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank()} tensor {name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == 0:
@@ -227,7 +228,7 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
         if torch.distributed.get_rank() == 0:
             gate_weight = state_dict[gate_name]
             up_weight = state_dict[up_name]
-            new_gate_up_weight = torch.empty(config.intermediate_size * 2, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+            new_gate_up_weight = torch.empty(config.intermediate_size * 2, config.hidden_size, dtype=params_dtype, device=get_device_id())
             for i in range(tp_size):
                 intermediate_size_tp = config.intermediate_size // tp_size
                 gate_weight_tp = gate_weight[i * intermediate_size_tp : (i + 1) * intermediate_size_tp]
@@ -251,12 +252,12 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank() == 0:} tensor {gate_name, up_name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == 0:
@@ -284,7 +285,7 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
                 q_size_tp = config.hidden_size // tp_size
                 kv_size_tp = hidden_size_per_head * config.num_key_value_heads // tp_size
                 total_size = q_size_tp + 2 * kv_size_tp
-                new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+                new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=get_device_id())
                 for i in range(tp_size):
                     q_part = full_weight_q[i * q_size_tp : (i + 1) * q_size_tp]
                     k_part = full_weight_k[i * kv_size_tp : (i + 1) * kv_size_tp]
@@ -295,7 +296,7 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
                 q_size_tp = config.hidden_size // tp_size
                 kv_size_tp = hidden_size_per_head
                 total_size = q_size_tp + 2 * kv_size_tp
-                new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+                new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=get_device_id())
                 for i in range(tp_size):
                     q_part = full_weight_q[i * q_size_tp : (i + 1) * q_size_tp]
                     start_idx = i * config.num_key_value_heads // tp_size * hidden_size_per_head
@@ -321,12 +322,12 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank()} tensor {q_name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == 0:
@@ -422,5 +423,5 @@ def load_state_dict_to_megatron_llama(state_dict, wrapped_models, config, params
     for wrapped_model in wrapped_models:
         broadcast_params(wrapped_model)
 
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     print_rank_0(f"loading megatron ckpt done, time elapsed {time.time() - start_time}s")

--- a/verl/models/llama/megatron/checkpoint_utils/llama_loader_depracated.py
+++ b/verl/models/llama/megatron/checkpoint_utils/llama_loader_depracated.py
@@ -17,7 +17,8 @@ import time
 import torch
 import torch.distributed as dist
 
-from verl.utils.device import get_torch_device, get_device_id
+from verl.utils.device import get_device_id, get_torch_device
+
 
 def _megatron_calc_layer_map(config):
     """Calculate the mapping of global layer_idx to local layer_idx

--- a/verl/models/llama/megatron/checkpoint_utils/llama_saver.py
+++ b/verl/models/llama/megatron/checkpoint_utils/llama_saver.py
@@ -21,9 +21,9 @@ from megatron.core.distributed import DistributedDataParallel as LocalDDP
 from megatron.core.transformer.module import Float16Module
 from torch.nn.parallel import DistributedDataParallel as torchDDP
 
+from verl.utils.device import get_device_id, get_torch_device
 from verl.utils.logger import print_rank_0
 from verl.utils.megatron_utils import unwrap_model
-from verl.utils.device import get_torch_device, get_device_id
 
 
 def _megatron_calc_global_rank(tp_rank: int = 0, dp_rank: int = 0, pp_rank: int = 0):

--- a/verl/models/llama/megatron/checkpoint_utils/llama_saver.py
+++ b/verl/models/llama/megatron/checkpoint_utils/llama_saver.py
@@ -23,6 +23,7 @@ from torch.nn.parallel import DistributedDataParallel as torchDDP
 
 from verl.utils.logger import print_rank_0
 from verl.utils.megatron_utils import unwrap_model
+from verl.utils.device import get_torch_device, get_device_id
 
 
 def _megatron_calc_global_rank(tp_rank: int = 0, dp_rank: int = 0, pp_rank: int = 0):
@@ -147,7 +148,7 @@ def merge_megatron_ckpt_llama(wrapped_models, config, dtype, is_value_model=Fals
             weight = torch.empty(
                 tensor_shape,
                 dtype=dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
 
@@ -176,7 +177,7 @@ def merge_megatron_ckpt_llama(wrapped_models, config, dtype, is_value_model=Fals
         buffer_tensor = torch.empty(
             chunk_shape,
             dtype=dtype,
-            device=torch.cuda.current_device(),
+            device=get_device_id(),
             requires_grad=False,
         )
 
@@ -216,7 +217,7 @@ def merge_megatron_ckpt_llama(wrapped_models, config, dtype, is_value_model=Fals
         buffer_tensor = torch.empty(
             chunk_shape,
             dtype=dtype,
-            device=torch.cuda.current_device(),
+            device=get_device_id(),
             requires_grad=False,
         )
 
@@ -265,7 +266,7 @@ def merge_megatron_ckpt_llama(wrapped_models, config, dtype, is_value_model=Fals
         buffer_tensor = torch.empty(
             chunk_shape,
             dtype=dtype,
-            device=torch.cuda.current_device(),
+            device=get_device_id(),
             requires_grad=False,
         )
 
@@ -317,7 +318,7 @@ def merge_megatron_ckpt_llama(wrapped_models, config, dtype, is_value_model=Fals
             state_dict[v_name] = torch.cat(v_weight_list, dim=0)
 
     # empty cache before collecting weights
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     # Embeddings
     # -------------------
     if dp_rank == 0:
@@ -418,7 +419,7 @@ def merge_megatron_ckpt_llama(wrapped_models, config, dtype, is_value_model=Fals
 
     dist.barrier()
 
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     if torch.distributed.get_rank() == 0:
         if dtype not in [torch.float16, torch.bfloat16, torch.float32]:
             print(f'Unknown/unsupported dtype to save: {dtype}"')

--- a/verl/models/mcore/loader.py
+++ b/verl/models/mcore/loader.py
@@ -18,9 +18,9 @@ import time
 import torch
 import torch.distributed as dist
 
-from .saver import _megatron_calc_global_rank
+from verl.utils.device import get_device_id, get_torch_device
 
-from verl.utils.device import get_torch_device, get_device_id
+from .saver import _megatron_calc_global_rank
 
 
 def _megatron_calc_layer_map(config):

--- a/verl/models/mcore/loader.py
+++ b/verl/models/mcore/loader.py
@@ -20,6 +20,8 @@ import torch.distributed as dist
 
 from .saver import _megatron_calc_global_rank
 
+from verl.utils.device import get_torch_device, get_device_id
+
 
 def _megatron_calc_layer_map(config):
     """Calculate the mapping of global layer_idx to local layer_idx
@@ -122,7 +124,7 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
             tensor = torch.empty(
                 tensor_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         if torch.distributed.get_rank() == src_rank:
@@ -161,12 +163,12 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank()} tensor {name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == src_rank:
@@ -206,12 +208,12 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank()} tensor {name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == src_rank:
@@ -230,7 +232,7 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
         if torch.distributed.get_rank() == src_rank:
             gate_weight = state_dict[gate_name]
             up_weight = state_dict[up_name]
-            new_gate_up_weight = torch.empty(config.intermediate_size * 2, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+            new_gate_up_weight = torch.empty(config.intermediate_size * 2, config.hidden_size, dtype=params_dtype, device=get_device_id())
             for i in range(tp_size):
                 intermediate_size_tp = config.intermediate_size // tp_size
                 gate_weight_tp = gate_weight[i * intermediate_size_tp : (i + 1) * intermediate_size_tp]
@@ -254,12 +256,12 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank() == src_rank:} tensor {gate_name, up_name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == src_rank:
@@ -290,7 +292,7 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
                 sizes = [total_size * tp_size]
                 if not bias:
                     sizes.append(config.hidden_size)
-                new_weight_qkv = torch.empty(*sizes, dtype=params_dtype, device=torch.cuda.current_device())
+                new_weight_qkv = torch.empty(*sizes, dtype=params_dtype, device=get_device_id())
                 for i in range(tp_size):
                     q_part = full_weight_q[i * q_size_tp : (i + 1) * q_size_tp]
                     k_part = full_weight_k[i * kv_size_tp : (i + 1) * kv_size_tp]
@@ -311,7 +313,7 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
                 sizes = [total_size * tp_size]
                 if not bias:
                     sizes.append(config.hidden_size)
-                new_weight_qkv = torch.empty(*sizes, dtype=params_dtype, device=torch.cuda.current_device())
+                new_weight_qkv = torch.empty(*sizes, dtype=params_dtype, device=get_device_id())
                 for i in range(tp_size):
                     q_part = full_weight_q[i * q_size_tp : (i + 1) * q_size_tp]
                     start_idx = i * config.num_key_value_heads // tp_size * hidden_size_per_head
@@ -343,12 +345,12 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank()} tensor {q_name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == src_rank:
@@ -465,5 +467,5 @@ def load_state_dict_to_megatron_gptmodel(state_dict, wrapped_models, config, par
     for wrapped_model in wrapped_models:
         broadcast_params(wrapped_model)
     pass
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     print_rank_0(f"loading megatron ckpt done, time elapsed {time.time() - start_time}s")

--- a/verl/models/mcore/saver.py
+++ b/verl/models/mcore/saver.py
@@ -24,6 +24,7 @@ from torch.nn.parallel import DistributedDataParallel as torchDDP
 
 from verl.utils.logger import print_rank_0
 from verl.utils.megatron_utils import unwrap_model
+from verl.utils.device import get_torch_device, get_device_id
 
 
 def _megatron_calc_global_rank(tp_rank: int = 0, dp_rank: int = 0, pp_rank: int = 0, cp_rank: int = 0, ep_rank: int = 0):
@@ -157,7 +158,7 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
             weight = torch.empty(
                 tensor_shape,
                 dtype=dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
 
@@ -187,7 +188,7 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
         buffer_tensor = torch.empty(
             chunk_shape,
             dtype=dtype,
-            device=torch.cuda.current_device(),
+            device=get_device_id(),
             requires_grad=False,
         )
 
@@ -228,7 +229,7 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
         buffer_tensor = torch.empty(
             chunk_shape,
             dtype=dtype,
-            device=torch.cuda.current_device(),
+            device=get_device_id(),
             requires_grad=False,
         )
 
@@ -278,7 +279,7 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
         buffer_tensor = torch.empty(
             chunk_shape,
             dtype=dtype,
-            device=torch.cuda.current_device(),
+            device=get_device_id(),
             requires_grad=False,
         )
 
@@ -338,7 +339,7 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
             state_dict[v_name] = torch.cat(v_weight_list, dim=0)
 
     # empty cache before collecting weights
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     # Embeddings
     # -------------------
     if dp_rank == 0 and cp_rank == 0:  # models are identical across cp ranks
@@ -454,7 +455,7 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
                 )
 
     dist.barrier()
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     if torch.distributed.get_rank() == 0:
         for k, v in state_dict.items():
             if dtype != v.dtype:

--- a/verl/models/mcore/saver.py
+++ b/verl/models/mcore/saver.py
@@ -22,9 +22,9 @@ from megatron.core.distributed import DistributedDataParallel as LocalDDP
 from megatron.core.transformer.module import Float16Module
 from torch.nn.parallel import DistributedDataParallel as torchDDP
 
+from verl.utils.device import get_device_id, get_torch_device
 from verl.utils.logger import print_rank_0
 from verl.utils.megatron_utils import unwrap_model
-from verl.utils.device import get_torch_device, get_device_id
 
 
 def _megatron_calc_global_rank(tp_rank: int = 0, dp_rank: int = 0, pp_rank: int = 0, cp_rank: int = 0, ep_rank: int = 0):

--- a/verl/models/qwen2/megatron/checkpoint_utils/qwen2_loader.py
+++ b/verl/models/qwen2/megatron/checkpoint_utils/qwen2_loader.py
@@ -17,6 +17,8 @@ import time
 import torch
 import torch.distributed as dist
 
+from verl.utils.device import get_torch_device, get_device_id
+
 
 def _megatron_calc_layer_map(config):
     """Calculate the mapping of global layer_idx to local layer_idx
@@ -137,7 +139,7 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
         if gate_name in state_dict and up_name in state_dict:
             gate_weight = state_dict[gate_name]
             up_weight = state_dict[up_name]
-            new_gate_up_weight = torch.empty(config.intermediate_size * 2, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+            new_gate_up_weight = torch.empty(config.intermediate_size * 2, config.hidden_size, dtype=params_dtype, device=get_device_id())
             for i in range(tp_size):
                 intermediate_size_tp = config.intermediate_size // tp_size
                 gate_weight_tp = gate_weight[i * intermediate_size_tp : (i + 1) * intermediate_size_tp]
@@ -168,9 +170,9 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
             kv_size_tp = hidden_size_per_head * config.num_key_value_heads // tp_size
             total_size = q_size_tp + 2 * kv_size_tp
             if not bias:
-                new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+                new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=get_device_id())
             else:
-                new_weight_qkv = torch.empty(total_size * tp_size, dtype=params_dtype, device=torch.cuda.current_device())
+                new_weight_qkv = torch.empty(total_size * tp_size, dtype=params_dtype, device=get_device_id())
             for i in range(tp_size):
                 q_part = full_weight_q[i * q_size_tp : (i + 1) * q_size_tp]
                 k_part = full_weight_k[i * kv_size_tp : (i + 1) * kv_size_tp]
@@ -182,9 +184,9 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
             kv_size_tp = hidden_size_per_head
             total_size = q_size_tp + 2 * kv_size_tp
             if not bias:
-                new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+                new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=get_device_id())
             else:
-                new_weight_qkv = torch.empty(total_size * tp_size, dtype=params_dtype, device=torch.cuda.current_device())
+                new_weight_qkv = torch.empty(total_size * tp_size, dtype=params_dtype, device=get_device_id())
             for i in range(tp_size):
                 q_part = full_weight_q[i * q_size_tp : (i + 1) * q_size_tp]
                 start_idx = i * config.num_key_value_heads // tp_size * hidden_size_per_head
@@ -309,5 +311,5 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
                 _fetch_tp_shard_tensor(lm_head_weight, "lm_head.weight")
 
     dist.barrier()
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     print_rank_0(f"loading megatron ckpt done, time elapsed {time.time() - start_time}s")

--- a/verl/models/qwen2/megatron/checkpoint_utils/qwen2_loader.py
+++ b/verl/models/qwen2/megatron/checkpoint_utils/qwen2_loader.py
@@ -17,7 +17,7 @@ import time
 import torch
 import torch.distributed as dist
 
-from verl.utils.device import get_torch_device, get_device_id
+from verl.utils.device import get_device_id, get_torch_device
 
 
 def _megatron_calc_layer_map(config):

--- a/verl/models/qwen2/megatron/checkpoint_utils/qwen2_loader_depracated.py
+++ b/verl/models/qwen2/megatron/checkpoint_utils/qwen2_loader_depracated.py
@@ -17,6 +17,8 @@ import time
 import torch
 import torch.distributed as dist
 
+from verl.utils.device import get_torch_device, get_device_id
+
 
 def _megatron_calc_layer_map(config):
     """Calculate the mapping of global layer_idx to local layer_idx
@@ -117,7 +119,7 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
             tensor = torch.empty(
                 tensor_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         if torch.distributed.get_rank() == 0:
@@ -156,12 +158,12 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank()} tensor {name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == 0:
@@ -201,12 +203,12 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank()} tensor {name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == 0:
@@ -225,7 +227,7 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
         if torch.distributed.get_rank() == 0:
             gate_weight = state_dict[gate_name]
             up_weight = state_dict[up_name]
-            new_gate_up_weight = torch.empty(config.intermediate_size * 2, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+            new_gate_up_weight = torch.empty(config.intermediate_size * 2, config.hidden_size, dtype=params_dtype, device=get_device_id())
             for i in range(tp_size):
                 intermediate_size_tp = config.intermediate_size // tp_size
                 gate_weight_tp = gate_weight[i * intermediate_size_tp : (i + 1) * intermediate_size_tp]
@@ -249,12 +251,12 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank() == 0:} tensor {gate_name, up_name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == 0:
@@ -283,9 +285,9 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
                 kv_size_tp = hidden_size_per_head * config.num_key_value_heads // tp_size
                 total_size = q_size_tp + 2 * kv_size_tp
                 if not bias:
-                    new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+                    new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=get_device_id())
                 else:
-                    new_weight_qkv = torch.empty(total_size * tp_size, dtype=params_dtype, device=torch.cuda.current_device())
+                    new_weight_qkv = torch.empty(total_size * tp_size, dtype=params_dtype, device=get_device_id())
                 for i in range(tp_size):
                     q_part = full_weight_q[i * q_size_tp : (i + 1) * q_size_tp]
                     k_part = full_weight_k[i * kv_size_tp : (i + 1) * kv_size_tp]
@@ -297,9 +299,9 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
                 kv_size_tp = hidden_size_per_head
                 total_size = q_size_tp + 2 * kv_size_tp
                 if not bias:
-                    new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=torch.cuda.current_device())
+                    new_weight_qkv = torch.empty(total_size * tp_size, config.hidden_size, dtype=params_dtype, device=get_device_id())
                 else:
-                    new_weight_qkv = torch.empty(total_size * tp_size, dtype=params_dtype, device=torch.cuda.current_device())
+                    new_weight_qkv = torch.empty(total_size * tp_size, dtype=params_dtype, device=get_device_id())
                 for i in range(tp_size):
                     q_part = full_weight_q[i * q_size_tp : (i + 1) * q_size_tp]
                     start_idx = i * config.num_key_value_heads // tp_size * hidden_size_per_head
@@ -325,12 +327,12 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
             sync_tensor = torch.empty(
                 chunk_shape,
                 dtype=params_dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
         else:
             assert tensor.shape == chunk_shape, f"rank #{torch.distributed.get_rank()} tensor {q_name} shape {tensor.shape} != {chunk_shape}"
-            sync_tensor = torch.empty_like(tensor, device=torch.cuda.current_device(), requires_grad=False)
+            sync_tensor = torch.empty_like(tensor, device=get_device_id(), requires_grad=False)
 
         for i in range(tp_size):
             if torch.distributed.get_rank() == 0:
@@ -439,5 +441,5 @@ def load_state_dict_to_megatron_qwen2(state_dict, wrapped_models, config, params
     for wrapped_model in wrapped_models:
         broadcast_params(wrapped_model)
 
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     print_rank_0(f"loading megatron ckpt done, time elapsed {time.time() - start_time}s")

--- a/verl/models/qwen2/megatron/checkpoint_utils/qwen2_loader_depracated.py
+++ b/verl/models/qwen2/megatron/checkpoint_utils/qwen2_loader_depracated.py
@@ -17,7 +17,7 @@ import time
 import torch
 import torch.distributed as dist
 
-from verl.utils.device import get_torch_device, get_device_id
+from verl.utils.device import get_device_id, get_torch_device
 
 
 def _megatron_calc_layer_map(config):

--- a/verl/models/qwen2/megatron/checkpoint_utils/qwen2_saver.py
+++ b/verl/models/qwen2/megatron/checkpoint_utils/qwen2_saver.py
@@ -21,9 +21,9 @@ from megatron.core.distributed import DistributedDataParallel as LocalDDP
 from megatron.core.transformer.module import Float16Module
 from torch.nn.parallel import DistributedDataParallel as torchDDP
 
+from verl.utils.device import get_device_id, get_torch_device
 from verl.utils.logger import print_rank_0
 from verl.utils.megatron_utils import unwrap_model
-from verl.utils.device import get_torch_device, get_device_id
 
 
 def _megatron_calc_global_rank(tp_rank: int = 0, dp_rank: int = 0, pp_rank: int = 0):

--- a/verl/models/qwen2/megatron/checkpoint_utils/qwen2_saver.py
+++ b/verl/models/qwen2/megatron/checkpoint_utils/qwen2_saver.py
@@ -23,6 +23,7 @@ from torch.nn.parallel import DistributedDataParallel as torchDDP
 
 from verl.utils.logger import print_rank_0
 from verl.utils.megatron_utils import unwrap_model
+from verl.utils.device import get_torch_device, get_device_id
 
 
 def _megatron_calc_global_rank(tp_rank: int = 0, dp_rank: int = 0, pp_rank: int = 0):
@@ -147,7 +148,7 @@ def merge_megatron_ckpt_qwen2(wrapped_models, config, dtype, is_value_model=Fals
             weight = torch.empty(
                 tensor_shape,
                 dtype=dtype,
-                device=torch.cuda.current_device(),
+                device=get_device_id(),
                 requires_grad=False,
             )
 
@@ -176,7 +177,7 @@ def merge_megatron_ckpt_qwen2(wrapped_models, config, dtype, is_value_model=Fals
         buffer_tensor = torch.empty(
             chunk_shape,
             dtype=dtype,
-            device=torch.cuda.current_device(),
+            device=get_device_id(),
             requires_grad=False,
         )
 
@@ -216,7 +217,7 @@ def merge_megatron_ckpt_qwen2(wrapped_models, config, dtype, is_value_model=Fals
         buffer_tensor = torch.empty(
             chunk_shape,
             dtype=dtype,
-            device=torch.cuda.current_device(),
+            device=get_device_id(),
             requires_grad=False,
         )
 
@@ -265,7 +266,7 @@ def merge_megatron_ckpt_qwen2(wrapped_models, config, dtype, is_value_model=Fals
         buffer_tensor = torch.empty(
             chunk_shape,
             dtype=dtype,
-            device=torch.cuda.current_device(),
+            device=get_device_id(),
             requires_grad=False,
         )
 
@@ -317,7 +318,7 @@ def merge_megatron_ckpt_qwen2(wrapped_models, config, dtype, is_value_model=Fals
             state_dict[v_name] = torch.cat(v_weight_list, dim=0)
 
     # empty cache before collecting weights
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     # Embeddings
     # -------------------
     if dp_rank == 0:
@@ -427,7 +428,7 @@ def merge_megatron_ckpt_qwen2(wrapped_models, config, dtype, is_value_model=Fals
 
     dist.barrier()
 
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
     if torch.distributed.get_rank() == 0:
         for k, v in state_dict.items():
             if dtype != v.dtype:

--- a/verl/models/qwen2/megatron/modeling_qwen2_megatron.py
+++ b/verl/models/qwen2/megatron/modeling_qwen2_megatron.py
@@ -29,10 +29,10 @@ from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
 from transformers.models.qwen2.modeling_qwen2 import CausalLMOutputWithPast
 
+from verl.utils.device import get_device_name
 from verl.utils.megatron import sequence_parallel as sp_utils
 from verl.utils.megatron import tensor_parallel as tp_utils
 from verl.utils.megatron_utils import TransformerConfig, convert_config
-from verl.utils.device import get_device_name
 
 from .layers import ParallelQwen2DecoderLayer, ParallelQwen2DecoderLayerRmPad, ParallelQwen2RMSNorm
 

--- a/verl/models/qwen2/megatron/modeling_qwen2_megatron.py
+++ b/verl/models/qwen2/megatron/modeling_qwen2_megatron.py
@@ -32,6 +32,7 @@ from transformers.models.qwen2.modeling_qwen2 import CausalLMOutputWithPast
 from verl.utils.megatron import sequence_parallel as sp_utils
 from verl.utils.megatron import tensor_parallel as tp_utils
 from verl.utils.megatron_utils import TransformerConfig, convert_config
+from verl.utils.device import get_device_name
 
 from .layers import ParallelQwen2DecoderLayer, ParallelQwen2DecoderLayerRmPad, ParallelQwen2RMSNorm
 
@@ -595,7 +596,7 @@ class ParallelQwen2ForCausalLMRmPadPP(nn.Module):
 
         if torch.distributed.is_initialized() and parallel_state.is_rank_in_embedding_group():
             weight = self.shared_embedding_or_output_weight()
-            weight.data = weight.data.cuda()
+            weight.data = weight.data.to(get_device_name())
             torch.distributed.all_reduce(weight.data, group=parallel_state.get_embedding_group())
 
     def shared_embedding_or_output_weight(self) -> torch.Tensor:

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -34,7 +34,7 @@ from packaging import version
 from tensordict import TensorDict
 from torch.utils.data import DataLoader
 
-from verl.utils.device import get_torch_device
+from verl.utils.device import get_torch_device, get_device_id
 from verl.utils.py_functional import union_two_dict
 from verl.utils.torch_functional import allgather_dict_tensors
 
@@ -890,7 +890,7 @@ def all_gather_data_proto(data: DataProto, process_group):
     group_size = torch.distributed.get_world_size(group=process_group)
     assert isinstance(data, DataProto)
     prev_device = data.batch.device
-    data.batch = data.batch.to(get_torch_device().current_device())
+    data.batch = data.batch.to(get_device_id())
     data.batch = allgather_dict_tensors(data.batch.contiguous(), size=group_size, group=process_group, dim=0)
     data.batch = data.batch.to(prev_device)
     # all gather non_tensor_batch

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -34,7 +34,7 @@ from packaging import version
 from tensordict import TensorDict
 from torch.utils.data import DataLoader
 
-from verl.utils.device import get_torch_device, get_device_id
+from verl.utils.device import get_device_id, get_torch_device
 from verl.utils.py_functional import union_two_dict
 from verl.utils.torch_functional import allgather_dict_tensors
 

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -22,6 +22,7 @@ from typing import Dict
 
 import ray
 
+from verl.utils.device import get_torch_device
 from .decorator import Dispatch, Execute, register
 
 
@@ -229,7 +230,7 @@ class Worker(WorkerHelper):
             # so we need to set local rank when the flag is set.
             local_rank = os.environ.get("RAY_LOCAL_RANK")
             os.environ["LOCAL_RANK"] = local_rank
-            torch.cuda.set_device(int(local_rank))
+            get_torch_device().set_device(int(local_rank))
 
     def _configure_with_store(self, store: Dict):
         """

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -23,6 +23,7 @@ from typing import Dict
 import ray
 
 from verl.utils.device import get_torch_device
+
 from .decorator import Dispatch, Execute, register
 
 
@@ -184,8 +185,6 @@ class Worker(WorkerHelper):
         return self.fused_worker_dict.get(worker_name, None)
 
     def _setup_env_cuda_visible_devices(self):
-        import torch
-
         from verl.utils.ray_utils import ray_noset_visible_devices
 
         is_ray_noset_visible_devices = ray_noset_visible_devices()

--- a/verl/trainer/config/generation.yaml
+++ b/verl/trainer/config/generation.yaml
@@ -1,6 +1,7 @@
 trainer:
   nnodes: 1
   n_gpus_per_node: 8
+  device: cuda
 
 data:
   path: ~/data/rlhf/math/test.parquet

--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -44,7 +44,7 @@ import verl.utils.hdfs_io as hdfs_io
 from verl.utils.dataset import SFTDataset
 from verl.utils.dataset.multiturn_sft_dataset import MultiTurnSFTDataset
 from verl.utils.debug import log_gpu_memory_usage
-from verl.utils.device import get_device_name, get_torch_device, is_cuda_available, is_npu_available
+from verl.utils.device import get_device_name, get_device_id, is_cuda_available, is_npu_available
 from verl.utils.distributed import destroy_global_process_group, initialize_global_process_group
 from verl.utils.fs import copy_to_local
 from verl.utils.fsdp_utils import CPUOffloadPolicy, MixedPrecisionPolicy, apply_fsdp2, fsdp2_clip_grad_norm_, fsdp2_load_full_state_dict, get_fsdp_wrap_policy, get_init_weight_context_manager, init_fn
@@ -242,7 +242,7 @@ class FSDPSFTTrainer:
                 param_init_fn=init_fn,
                 use_orig_params=False,
                 auto_wrap_policy=auto_wrap_policy,
-                device_id=get_torch_device().current_device(),
+                device_id=get_device_id(),
                 sharding_strategy=ShardingStrategy.FULL_SHARD,
                 mixed_precision=mixed_precision,
                 sync_module_states=True,

--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -44,7 +44,7 @@ import verl.utils.hdfs_io as hdfs_io
 from verl.utils.dataset import SFTDataset
 from verl.utils.dataset.multiturn_sft_dataset import MultiTurnSFTDataset
 from verl.utils.debug import log_gpu_memory_usage
-from verl.utils.device import get_device_name, get_device_id, is_cuda_available, is_npu_available
+from verl.utils.device import get_device_id, get_device_name, is_cuda_available, is_npu_available
 from verl.utils.distributed import destroy_global_process_group, initialize_global_process_group
 from verl.utils.fs import copy_to_local
 from verl.utils.fsdp_utils import CPUOffloadPolicy, MixedPrecisionPolicy, apply_fsdp2, fsdp2_clip_grad_norm_, fsdp2_load_full_state_dict, get_fsdp_wrap_policy, get_init_weight_context_manager, init_fn

--- a/verl/trainer/main_generation.py
+++ b/verl/trainer/main_generation.py
@@ -34,7 +34,6 @@ from verl import DataProto
 from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 from verl.utils import hf_tokenizer
-from verl.utils.device import is_cuda_available
 from verl.utils.fs import copy_to_local
 from verl.utils.hdfs_io import makedirs
 from verl.utils.model import compute_position_id_with_mask
@@ -82,7 +81,11 @@ def main_task(config):
 
     ray_cls_with_init = RayClassWithInitArgs(cls=ray.remote(ActorRolloutRefWorker), config=config, role="rollout")
     resource_pool = RayResourcePool(process_on_nodes=[config.trainer.n_gpus_per_node] * config.trainer.nnodes)
-    wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls_with_init, device_name="cuda" if is_cuda_available else "npu")
+    wg = RayWorkerGroup(
+        resource_pool=resource_pool,
+        ray_cls_with_init=ray_cls_with_init,
+        device_name=config.trainer.device,
+    )
     wg.init_model()
 
     total_samples = len(dataset)

--- a/verl/utils/activation_offload.py
+++ b/verl/utils/activation_offload.py
@@ -25,8 +25,8 @@ from typing import Any, Optional
 import torch
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-from verl.utils.fsdp_utils import FSDPModule as FSDP2
 from verl.utils.device import get_torch_device
+from verl.utils.fsdp_utils import FSDPModule as FSDP2
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))

--- a/verl/utils/activation_offload.py
+++ b/verl/utils/activation_offload.py
@@ -26,6 +26,7 @@ import torch
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 from verl.utils.fsdp_utils import FSDPModule as FSDP2
+from verl.utils.device import get_torch_device
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -250,8 +251,8 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
                 self.layer_window_map[i] += constant
 
         # allocate streams and events for synchronization
-        self.d2h_stream = torch.cuda.Stream()
-        self.h2d_stream = torch.cuda.Stream()
+        self.d2h_stream = get_torch_device().Stream()
+        self.h2d_stream = get_torch_device().Stream()
 
     def tensor_push(self, tensor: torch.Tensor, **kwargs) -> Any:
         torch_stray_tensor = isinstance(
@@ -295,7 +296,7 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
         """Bulk offload group."""
         offload_mapping = {}
         offload_size = 0
-        with torch.cuda.stream(self.d2h_stream):
+        with get_torch_device().stream(self.d2h_stream):
             for tensor_tag, state in self.tensor_tag_to_state.items():
                 group_id, _ = tensor_tag
                 if group_id == group_to_offload:
@@ -318,15 +319,15 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
         # For the first group, kickstart the offload after we have
         # the first compute completion
         if current_group == 0:
-            self.d2h_stream.wait_stream(torch.cuda.current_stream())
+            self.d2h_stream.wait_stream(get_torch_device().current_stream())
             self.bulk_offload_group(current_group)
 
         # Window map data structure helps us synchronize based on number
         # of layers offloaded
         if self.layer_window_map[self.offloaded_group_count] == current_group:
             # Stream synchronization both ways
-            self.d2h_stream.wait_stream(torch.cuda.current_stream())
-            torch.cuda.current_stream().wait_stream(self.d2h_stream)
+            self.d2h_stream.wait_stream(get_torch_device().current_stream())
+            get_torch_device().current_stream().wait_stream(self.d2h_stream)
 
             # Time to free the activation memory after usage
             for tensor_tag, _ in self.tensor_tag_to_buf.items():
@@ -352,7 +353,7 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
         """Bulk reload group."""
         assert group_to_reload < self.num_offload_group
 
-        with torch.cuda.stream(self.h2d_stream):
+        with get_torch_device().stream(self.h2d_stream):
             # move back tensors
             offload_mapping = self.group_offload_mapping.pop(group_to_reload)
             assert offload_mapping is not None
@@ -376,8 +377,8 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
         # Layer window data structure helps us to reload at right times
         if self.layer_window_map[self.offloaded_group_count - 1] == self.current_group:
             # Stream synchronization both ways
-            self.h2d_stream.wait_stream(torch.cuda.current_stream())
-            torch.cuda.current_stream().wait_stream(self.h2d_stream)
+            self.h2d_stream.wait_stream(get_torch_device().current_stream())
+            get_torch_device().current_stream().wait_stream(self.h2d_stream)
 
             # Time to reload the next group
             self.bulk_reload_group(self.offloaded_group_count - 1)
@@ -387,7 +388,7 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
 
         # Last group computation needs to wait till all the reloads complete
         if self.current_group == 0:
-            torch.cuda.current_stream().wait_stream(self.h2d_stream)
+            get_torch_device().current_stream().wait_stream(self.h2d_stream)
             self.offloaded_group_count = 0
 
 

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -25,6 +25,7 @@ from omegaconf import DictConfig
 from transformers import GenerationConfig
 
 from verl.models.weight_loader_registry import get_weight_saver
+from verl.utils.device import is_cuda_available, is_npu_available
 from verl.utils.fs import is_non_local
 from verl.utils.logger import log_with_rank
 from verl.utils.megatron_utils import (
@@ -35,7 +36,6 @@ from verl.utils.megatron_utils import (
     get_optimizer_scheduler_checkpoint_path,
     get_rng_states_checkpoint_path,
 )
-from verl.utils.device import is_cuda_available, is_npu_available
 
 from .checkpoint_manager import BaseCheckpointManager
 

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -35,6 +35,7 @@ from verl.utils.megatron_utils import (
     get_optimizer_scheduler_checkpoint_path,
     get_rng_states_checkpoint_path,
 )
+from verl.utils.device import is_cuda_available, is_npu_available
 
 from .checkpoint_manager import BaseCheckpointManager
 
@@ -107,9 +108,13 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             "random_rng_state": random.getstate(),
             "np_rng_state": np.random.get_state(),
             "torch_rng_state": torch.get_rng_state(),
-            "cuda_rng_state": torch.cuda.get_rng_state(),
             "rng_tracker_states": tensor_parallel.get_cuda_rng_tracker().get_states(),
         }
+
+        if is_cuda_available:
+            rng_state["cuda_rng_state"] = torch.cuda.get_rng_state()
+        elif is_npu_available:
+            rng_state["npu_rng_state"] = torch.npu.get_rng_state()
 
         rng_state_list = None
         if torch.distributed.is_initialized() and mpu.get_data_parallel_world_size() > 1 and data_parallel_random_init:
@@ -197,7 +202,12 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         random.setstate(rng_state["random_rng_state"])
         np.random.set_state(rng_state["np_rng_state"])
         torch.set_rng_state(rng_state["torch_rng_state"])
-        torch.cuda.set_rng_state(rng_state["cuda_rng_state"])
+
+        if is_cuda_available:
+            torch.cuda.set_rng_state(rng_state["cuda_rng_state"])
+        elif is_npu_available:
+            torch.npu.set_rng_state(rng_state["npu_rng_state"])
+
         # Check for empty states array
         if not rng_state["rng_tracker_states"]:
             raise KeyError

--- a/verl/utils/debug/performance.py
+++ b/verl/utils/debug/performance.py
@@ -22,7 +22,7 @@ import torch
 import torch.distributed as dist
 from codetiming import Timer
 
-from verl.utils.device import get_torch_device
+from verl.utils.device import get_torch_device, get_device_id
 from verl.utils.logger import DecoratorLoggerBase
 
 
@@ -144,7 +144,7 @@ def reduce_timing(timing_raw: Dict[str, float]) -> Dict[str, float]:
     for key in sorted(timing_raw.keys()):
         key_list.append(key)
         timing_list.append(timing_raw[key])
-    timing_list = torch.tensor(timing_list, dtype=torch.float32, device=get_torch_device().current_device())
+    timing_list = torch.tensor(timing_list, dtype=torch.float32, device=get_device_id())
     torch.distributed.all_reduce(timing_list, op=torch.distributed.ReduceOp.AVG)
     timing_list = [tensor.item() for tensor in timing_list.to("cpu")]
     timing_generate = {key_list[i]: timing_list[i] for i in range(len(key_list))}

--- a/verl/utils/debug/performance.py
+++ b/verl/utils/debug/performance.py
@@ -22,7 +22,7 @@ import torch
 import torch.distributed as dist
 from codetiming import Timer
 
-from verl.utils.device import get_torch_device, get_device_id
+from verl.utils.device import get_device_id, get_torch_device
 from verl.utils.logger import DecoratorLoggerBase
 
 

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -76,4 +76,3 @@ def get_nccl_backend() -> str:
         return "hccl"
     else:
         raise RuntimeError(f"No available nccl backend found on device type {get_device_name()}.")
-

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -55,3 +55,25 @@ def get_torch_device() -> any:
     except AttributeError:
         logger.warning(f"Device namespace '{device_name}' not found in torch, try to load torch.cuda.")
         return torch.cuda
+
+
+def get_device_id() -> int:
+    """Return current device id based on the device type.
+    Returns:
+        device index
+    """
+    return get_torch_device().current_device()
+
+
+def get_nccl_backend() -> str:
+    """Return nccl backend type based on the device type.
+    Returns:
+        nccl backend type string.
+    """
+    if is_cuda_available:
+        return "nccl"
+    elif is_npu_available:
+        return "hccl"
+    else:
+        raise RuntimeError(f"No available nccl backend found on device type {get_device_name()}.")
+

--- a/verl/utils/distributed.py
+++ b/verl/utils/distributed.py
@@ -17,13 +17,13 @@ import os
 
 import torch.distributed
 
-from verl.utils.device import get_torch_device, is_cuda_available
+from verl.utils.device import get_torch_device, get_nccl_backend
 
 
 def initialize_global_process_group(timeout_second=36000):
     from datetime import timedelta
 
-    torch.distributed.init_process_group("nccl" if is_cuda_available else "hccl", timeout=timedelta(seconds=timeout_second))
+    torch.distributed.init_process_group(get_nccl_backend(), timeout=timedelta(seconds=timeout_second))
     local_rank = int(os.environ["LOCAL_RANK"])
     rank = int(os.environ["RANK"])
     world_size = int(os.environ["WORLD_SIZE"])

--- a/verl/utils/distributed.py
+++ b/verl/utils/distributed.py
@@ -17,7 +17,7 @@ import os
 
 import torch.distributed
 
-from verl.utils.device import get_torch_device, get_nccl_backend
+from verl.utils.device import get_nccl_backend, get_torch_device
 
 
 def initialize_global_process_group(timeout_second=36000):

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -31,7 +31,7 @@ from torch.distributed.fsdp._runtime_utils import _lazy_init
 from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
 from transformers.trainer_pt_utils import get_module_class_from_name
 
-from verl.utils.device import get_device_name, get_torch_device, get_device_id
+from verl.utils.device import get_device_id, get_device_name, get_torch_device
 
 if version.parse(torch.__version__) >= version.parse("2.6"):
     from torch.distributed.fsdp import CPUOffloadPolicy, FSDPModule, MixedPrecisionPolicy, fully_shard

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -31,7 +31,7 @@ from torch.distributed.fsdp._runtime_utils import _lazy_init
 from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
 from transformers.trainer_pt_utils import get_module_class_from_name
 
-from verl.utils.device import get_device_name, get_torch_device
+from verl.utils.device import get_device_name, get_torch_device, get_device_id
 
 if version.parse(torch.__version__) >= version.parse("2.6"):
     from torch.distributed.fsdp import CPUOffloadPolicy, FSDPModule, MixedPrecisionPolicy, fully_shard
@@ -43,7 +43,7 @@ else:
 
 def init_fn(x: torch.nn.Module):
     if torch.distributed.get_rank() != 0:
-        x = x.to_empty(device=get_torch_device().current_device(), recurse=False)
+        x = x.to_empty(device=get_device_id(), recurse=False)
         get_torch_device().empty_cache()
     return x
 
@@ -168,7 +168,7 @@ def load_fsdp_model_to_gpu(model: FSDP):
     # lazy init FSDP model
     _lazy_init(model, model)
     assert model._is_root, "Only support root model loading to GPU"
-    device_id = get_torch_device().current_device()
+    device_id = get_device_id()
     for handle in model._all_handles:
         if handle._offload_params:
             continue
@@ -180,7 +180,7 @@ def load_fsdp_model_to_gpu(model: FSDP):
 
 @torch.no_grad()
 def load_fsdp2_model_to_gpu(model):
-    device = torch.cuda.current_device()
+    device = get_device_id()
     for param in model.parameters():
         param.data = param.data.to(device, non_blocking=True)
 
@@ -282,7 +282,7 @@ def parallel_load_safetensors(filepath):
     ckpt_chunks = [ckpt_chunks[rank * size : rank * size + size] for rank in range(world_size)]
 
     shard_states = {}
-    device = get_torch_device().current_device()
+    device = get_device_id()
     for rank, files in enumerate(ckpt_chunks):
         if rank == dist.get_rank():
             for file in files:
@@ -320,7 +320,7 @@ def parallel_init_module_fn(module: torch.nn.Module, shard_states: Dict[str, tor
     @torch.no_grad()
     def create_and_sync_state(param_name, state, is_param):
         assert param_name in shard_states, f"{param_name} not loaded"
-        device = get_torch_device().current_device()
+        device = get_device_id()
         if is_param:
             param = torch.nn.Parameter(torch.empty_like(state.data, device=device), requires_grad=state.requires_grad)
         else:  # buffer
@@ -405,9 +405,9 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_state: dict, device_
 
     # To broadcast, it needs to be instantiated in the GPU.
     if dist.get_rank() == 0:
-        model = model.to(device=torch.cuda.current_device(), non_blocking=True)
+        model = model.to(device=get_device_id(), non_blocking=True)
     else:
-        model = model.to_empty(device=torch.cuda.current_device())
+        model = model.to_empty(device=get_device_id())
 
     cpu_offload = cpu_offload is not None
     options = StateDictOptions(full_state_dict=True, cpu_offload=cpu_offload, broadcast_from_rank0=True)
@@ -420,7 +420,7 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_state: dict, device_
     if cpu_offload:
         model.to("cpu", non_blocking=True)
         for buf in model.buffers():
-            buf.data = buf.data.to(torch.cuda.current_device())
+            buf.data = buf.data.to(get_device_id())
 
 
 def apply_fsdp2(model, fsdp_kwargs, config):
@@ -456,7 +456,7 @@ def fsdp2_clip_grad_norm_(parameters, max_norm, norm_type=2.0, error_if_nonfinit
         parameters = list(parameters)
     grads = [p.grad for p in parameters if p.grad is not None]
     total_norm = _get_total_norm(grads, norm_type, error_if_nonfinite, foreach)
-    total_norm = total_norm.to(torch.cuda.current_device(), non_blocking=True)
+    total_norm = total_norm.to(get_device_id(), non_blocking=True)
     _clip_grads_with_norm_(parameters, max_norm, total_norm, foreach)
     return total_norm
 
@@ -492,5 +492,5 @@ def layered_summon_lora_params(fsdp_module) -> OrderedDict:
                     sub_lora_params = {f"{prefix}.{name}": param.full_tensor().detach().cpu() if hasattr(param, "full_tensor") else param.detach().cpu() for name, param in sub_lora_params.items()}
                     lora_params.update(sub_lora_params)
                     submodule._is_root = False
-                torch.cuda.empty_cache()
+                get_torch_device().empty_cache()
     return lora_params

--- a/verl/utils/megatron/memory.py
+++ b/verl/utils/megatron/memory.py
@@ -14,13 +14,15 @@
 
 import torch
 
+from verl.utils.device import get_device_id
+
 
 class MemoryBuffer:
     def __init__(self, numel, numel_padded, dtype):
         self.numel = numel
         self.numel_padded = numel_padded
         self.dtype = dtype
-        self.data = torch.zeros(self.numel_padded, dtype=self.dtype, device=torch.cuda.current_device(), requires_grad=False)
+        self.data = torch.zeros(self.numel_padded, dtype=self.dtype, device=get_device_id(), requires_grad=False)
 
     def zero(self):
         """Reset the buffer to zero."""

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -36,6 +36,7 @@ from transformers import PretrainedConfig
 import verl.utils.megatron.tensor_parallel as tp_utils
 from verl.utils.model import normalize_model_name
 from verl.utils.torch_dtypes import PrecisionType
+from verl.utils.device import get_device_name, get_torch_device, get_device_id
 
 
 def get_model_config(model):
@@ -107,7 +108,7 @@ def get_model(
     # GPU allocation.
     if transformer_config is None or (not transformer_config.use_cpu_initialization):
         for model_module in model:
-            model_module.cuda(torch.cuda.current_device())
+            model_module.to(f"{get_device_name()}:{get_device_id()}")
 
     # Fp16 conversion.
     config: TransformerConfig = get_model_config(model[0])
@@ -270,7 +271,7 @@ def offload_megatron_model_to_cpu(models):
                 if param.grad is not None:
                     param.grad = param.grad.to("cpu", non_blocking=True)
     gc.collect()
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
 
 
 @torch.no_grad()
@@ -291,13 +292,13 @@ def load_megatron_model_to_gpu(models, load_grad=True):
                         buffer.param_data.copy_(buffer.param_data.cpu_data, non_blocking=True)
         else:
             # we need this for ref module
-            device_id = torch.cuda.current_device()
+            device_id = get_device_id()
             for _, param in model_chunk.named_parameters():
                 param.data = param.data.to(device_id, non_blocking=True)
                 if param.grad is not None:
                     param.grad = param.grad.to(device_id, non_blocking=True)
     gc.collect()
-    torch.cuda.empty_cache()
+    get_torch_device().empty_cache()
 
 
 @torch.no_grad()
@@ -358,7 +359,7 @@ def load_megatron_copy_params(optimizers):
     def load_tensor_to_gpu(tensor):
         if tensor is None:
             return
-        device_id = torch.cuda.current_device()
+        device_id = get_device_id()
         tensor.data = tensor.data.to(device_id, non_blocking=True)
 
     def load_group_to_gpu(group):
@@ -398,7 +399,7 @@ def offload_megatron_optimizer(optimizers):
             if "exp_avg_sq" in v:
                 v["exp_avg_sq"] = v["exp_avg_sq"].to("cpu", non_blocking=True)
         gc.collect()
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
 
 
 @torch.no_grad()
@@ -413,11 +414,11 @@ def load_megatron_optimizer(optimizers):
         opt_state_dict_values = _opt.optimizer.state.values()
         for v in opt_state_dict_values:
             if "exp_avg" in v:
-                v["exp_avg"] = v["exp_avg"].to(torch.cuda.current_device(), non_blocking=True)
+                v["exp_avg"] = v["exp_avg"].to(get_device_id(), non_blocking=True)
             if "exp_avg_sq" in v:
-                v["exp_avg_sq"] = v["exp_avg_sq"].to(torch.cuda.current_device(), non_blocking=True)
+                v["exp_avg_sq"] = v["exp_avg_sq"].to(get_device_id(), non_blocking=True)
         gc.collect()
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
 
 
 def get_model_checkpoint_path(checkpoint_path):
@@ -635,7 +636,7 @@ def broadcast_from_megatron_pp(tensor: torch.Tensor):
             src_rank = rank
     assert target_tensor_spec is not None
     if tensor is None:
-        tensor = torch.empty(size=target_tensor_spec[0], dtype=target_tensor_spec[1], device=torch.cuda.current_device())
+        tensor = torch.empty(size=target_tensor_spec[0], dtype=target_tensor_spec[1], device=get_device_id())
         if target_tensor_spec[2] is not None:
             tensor.tensor_model_parallel = target_tensor_spec[2]
         if target_tensor_spec[3] is not None:
@@ -763,7 +764,7 @@ def per_tensor_generator(actor_module, model_config, weight_converter, transform
             # for now we patch it by adding those keys to extra_keys.
             extra_keys = [x for x in model.state_dict().keys() if "_extra_state" not in x and x not in existing_keys]
             for name in extra_keys:
-                yield name, model.state_dict()[name].to(torch.cuda.current_device())
+                yield name, model.state_dict()[name].to(get_device_id())
 
     # we need first make all rank get full model information
     meta_info = []

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -34,9 +34,9 @@ from megatron.core.utils import get_attr_wrapped_model
 from transformers import PretrainedConfig
 
 import verl.utils.megatron.tensor_parallel as tp_utils
+from verl.utils.device import get_device_id, get_device_name, get_torch_device
 from verl.utils.model import normalize_model_name
 from verl.utils.torch_dtypes import PrecisionType
-from verl.utils.device import get_device_name, get_torch_device, get_device_id
 
 
 def get_model_config(model):

--- a/verl/utils/memory_buffer.py
+++ b/verl/utils/memory_buffer.py
@@ -20,6 +20,8 @@ from typing import Dict, List, Optional
 import torch
 from torch import nn
 
+from verl.utils.device import get_device_name
+
 
 class MemoryBuffer:
     """
@@ -34,7 +36,7 @@ class MemoryBuffer:
         if source is not None:
             self.data = source
         else:
-            self.data = torch.zeros(self.numel_padded, dtype=self.dtype, device="cuda", requires_grad=False)
+            self.data = torch.zeros(self.numel_padded, dtype=self.dtype, device=get_device_name(), requires_grad=False)
 
     def zero(self):
         """Reset the buffer to zero."""

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -698,7 +698,7 @@ def distributed_mean_max_min_std(local_tensor, compute_max=True, compute_min=Tru
     """
     # Sum the local tensor across all processes
     local_sum = torch.sum(local_tensor)
-    local_num = torch.tensor(torch.numel(local_tensor), device="cuda")
+    local_num = torch.tensor(torch.numel(local_tensor), device=get_device_name())
 
     torch.distributed.all_reduce(local_sum, op=torch.distributed.ReduceOp.SUM)
     torch.distributed.all_reduce(local_num, op=torch.distributed.ReduceOp.SUM)

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -30,7 +30,7 @@ import verl.utils.torch_functional as verl_F
 from verl import DataProto
 from verl.trainer.ppo.core_algos import agg_loss, compute_policy_loss, kl_penalty
 from verl.utils.debug import GPUMemoryLogger
-from verl.utils.device import is_cuda_available, is_npu_available, get_device_name, get_device_id
+from verl.utils.device import get_device_id, get_device_name, is_cuda_available, is_npu_available
 from verl.utils.fsdp_utils import FSDPModule, fsdp2_clip_grad_norm_
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -30,7 +30,7 @@ import verl.utils.torch_functional as verl_F
 from verl import DataProto
 from verl.trainer.ppo.core_algos import agg_loss, compute_policy_loss, kl_penalty
 from verl.utils.debug import GPUMemoryLogger
-from verl.utils.device import get_device_name, get_torch_device, is_cuda_available, is_npu_available
+from verl.utils.device import is_cuda_available, is_npu_available, get_device_name, get_device_id
 from verl.utils.fsdp_utils import FSDPModule, fsdp2_clip_grad_norm_
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
@@ -372,9 +372,9 @@ class DataParallelPPOActor(BasePPOActor):
                 for data in micro_batches:
                     # Support all hardwares
                     if isinstance(data, DataProto):
-                        data = {**data.batch.to(get_torch_device().current_device()), **data.non_tensor_batch}
+                        data = {**data.batch.to(get_device_id()), **data.non_tensor_batch}
                     else:
-                        data = data.to(get_torch_device().current_device())  # actor device is cpu when using offload
+                        data = data.to(get_device_id())  # actor device is cpu when using offload
                     responses = data["responses"]
                     response_length = responses.size(1)
                     attention_mask = data["attention_mask"]

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -41,13 +41,13 @@ from verl import DataProto
 from verl.trainer.ppo.core_algos import agg_loss, compute_policy_loss, kl_penalty
 from verl.utils.debug import GPUMemoryLogger
 from verl.utils.debug.profile import Profiler
+from verl.utils.device import get_device_id, get_torch_device
 from verl.utils.megatron.pipeline_parallel import make_batch_generator
 from verl.utils.megatron.tensor_parallel import vocab_parallel_entropy, vocab_parallel_log_probs_from_logits
 from verl.utils.megatron_utils import get_model_config
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.torch_functional import broadcast_dict_tensor
-from verl.utils.device import get_torch_device, get_device_id
 from verl.workers.actor import BasePPOActor
 
 __all__ = ["MegatronPPOActor"]

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -21,14 +21,13 @@ import os
 
 import torch
 import torch.distributed
-from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
 from torch import nn, optim
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 from verl import DataProto
 from verl.trainer.ppo import core_algos
 from verl.utils.debug import GPUMemoryLogger
-from verl.utils.device import get_device_name, get_torch_device, is_cuda_available, is_npu_available
+from verl.utils.device import get_device_name, get_device_id, is_cuda_available, is_npu_available
 from verl.utils.fsdp_utils import FSDPModule, fsdp2_clip_grad_norm_
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
@@ -224,9 +223,9 @@ class DataParallelPPOCritic(BasePPOCritic):
                 for data in micro_batches:
                     # Support all devices
                     if isinstance(data, DataProto):
-                        data = {**data.batch.to(get_torch_device().current_device()), **data.non_tensor_batch}
+                        data = {**data.batch.to(get_device_id()), **data.non_tensor_batch}
                     else:
-                        data = data.to(get_torch_device().current_device())  # critic device is cpu when using offload
+                        data = data.to(get_device_id())  # critic device is cpu when using offload
                     responses = data["responses"]
                     attention_mask = data["attention_mask"]
                     values = data["values"]

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -27,7 +27,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from verl import DataProto
 from verl.trainer.ppo import core_algos
 from verl.utils.debug import GPUMemoryLogger
-from verl.utils.device import get_device_name, get_device_id, is_cuda_available, is_npu_available
+from verl.utils.device import get_device_id, get_device_name, is_cuda_available, is_npu_available
 from verl.utils.fsdp_utils import FSDPModule, fsdp2_clip_grad_norm_
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches

--- a/verl/workers/critic/megatron_critic.py
+++ b/verl/workers/critic/megatron_critic.py
@@ -36,6 +36,7 @@ from verl.utils.megatron.pipeline_parallel import make_batch_generator
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.torch_functional import broadcast_dict_tensor, masked_mean
+from verl.utils.device import get_torch_device, get_device_id
 from verl.workers.critic import BasePPOCritic
 
 logger = logging.getLogger(__file__)
@@ -90,7 +91,7 @@ class MegatronPPOCritic(BasePPOCritic):
 
     @GPUMemoryLogger("megatron critic", logger=logger)
     def compute_values(self, data: DataProto) -> DataProto:
-        data.to(torch.cuda.current_device())
+        data.to(get_device_id())
         responses = data.batch["responses"]
         attention_mask = data.batch["attention_mask"]
         use_dynamic_bsz = data.meta_info.get("use_dynamic_bsz", False)
@@ -130,7 +131,7 @@ class MegatronPPOCritic(BasePPOCritic):
             )
 
         # add empty cache after each compute
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
 
         return values
 
@@ -147,7 +148,7 @@ class MegatronPPOCritic(BasePPOCritic):
     def forward_backward_batch(self, data: DataProto, forward_only=False, use_dynamic_bsz=False, micro_batch_size=None, max_token_len=None, mini_batch_size=None):
         # broadcast from last pp rank to all other pp ranks
         mini_batch = data
-        mini_batch.to(torch.cuda.current_device())
+        mini_batch.to(get_device_id())
         mini_batch.batch = mini_batch.batch.contiguous()
         broadcast_dict_tensor(mini_batch.batch, src=mpu.get_pipeline_model_parallel_last_rank(), group=mpu.get_pipeline_model_parallel_group())
         # split into micro-batches
@@ -292,5 +293,5 @@ class MegatronPPOCritic(BasePPOCritic):
                 append_to_dict(metrics, metric)  # append the metric from this micro-batch to global metrics.
 
         # add empty cache after each compute
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
         return metrics

--- a/verl/workers/critic/megatron_critic.py
+++ b/verl/workers/critic/megatron_critic.py
@@ -32,11 +32,11 @@ from torch import nn
 from verl import DataProto
 from verl.trainer.ppo import core_algos
 from verl.utils.debug import GPUMemoryLogger
+from verl.utils.device import get_device_id, get_torch_device
 from verl.utils.megatron.pipeline_parallel import make_batch_generator
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.torch_functional import broadcast_dict_tensor, masked_mean
-from verl.utils.device import get_torch_device, get_device_id
 from verl.workers.critic import BasePPOCritic
 
 logger = logging.getLogger(__file__)

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -43,6 +43,7 @@ from verl.utils.activation_offload import enable_activation_offloading
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.utils.debug import log_gpu_memory_usage
 from verl.utils.debug.performance import _timer, reduce_timing
+from verl.utils.device import get_device_id, get_device_name, get_nccl_backend, get_torch_device, is_cuda_available, is_npu_available
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.fs import copy_to_local
 from verl.utils.fsdp_utils import (
@@ -59,9 +60,6 @@ from verl.utils.fsdp_utils import (
     load_fsdp_optimizer,
     offload_fsdp_model_to_cpu,
     offload_fsdp_optimizer,
-)
-from verl.utils.device import (
-    is_cuda_available, is_npu_available, get_device_name, get_torch_device, get_device_id, get_nccl_backend
 )
 from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -43,7 +43,6 @@ from verl.utils.activation_offload import enable_activation_offloading
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.utils.debug import log_gpu_memory_usage
 from verl.utils.debug.performance import _timer, reduce_timing
-from verl.utils.device import get_device_name, get_torch_device, is_cuda_available, is_npu_available
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.fs import copy_to_local
 from verl.utils.fsdp_utils import (
@@ -60,6 +59,9 @@ from verl.utils.fsdp_utils import (
     load_fsdp_optimizer,
     offload_fsdp_model_to_cpu,
     offload_fsdp_optimizer,
+)
+from verl.utils.device import (
+    is_cuda_available, is_npu_available, get_device_name, get_torch_device, get_device_id, get_nccl_backend
 )
 from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
@@ -106,7 +108,7 @@ class ActorRolloutRefWorker(Worker):
         if not torch.distributed.is_initialized():
             rank = int(os.environ.get("RANK", 0))
             world_size = int(os.environ.get("WORLD_SIZE", 1))
-            torch.distributed.init_process_group(backend="cpu:gloo,cuda:nccl" if is_cuda_available else "cpu:gloo,npu:hccl", rank=rank, world_size=world_size)
+            torch.distributed.init_process_group(backend=f"cpu:gloo,{get_device_name()}:{get_nccl_backend()}", rank=rank, world_size=world_size)
 
         # build device mesh for FSDP
         world_size = torch.distributed.get_world_size()
@@ -308,7 +310,7 @@ class ActorRolloutRefWorker(Worker):
                 param_init_fn=init_fn,
                 use_orig_params=False,
                 auto_wrap_policy=auto_wrap_policy,
-                device_id=get_torch_device().current_device(),
+                device_id=get_device_id(),
                 sharding_strategy=sharding_strategy,  # zero3
                 mixed_precision=mixed_precision,
                 sync_module_states=True,
@@ -592,7 +594,7 @@ class ActorRolloutRefWorker(Worker):
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.actor_module_fsdp)
         if self._is_offload_optimizer:
-            load_fsdp_optimizer(optimizer=self.actor_optimizer, device_id=get_torch_device().current_device())
+            load_fsdp_optimizer(optimizer=self.actor_optimizer, device_id=get_device_id())
 
         with self.ulysses_sharding_manager:
             data = self.ulysses_sharding_manager.preprocess_data(data=data)
@@ -629,7 +631,7 @@ class ActorRolloutRefWorker(Worker):
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def generate_sequences(self, prompts: DataProto):
         # Support all hardwares
-        prompts = prompts.to(get_torch_device().current_device())
+        prompts = prompts.to(get_device_id())
 
         assert self._is_rollout
 
@@ -674,7 +676,7 @@ class ActorRolloutRefWorker(Worker):
 
         is_lora = data.meta_info.pop("is_lora", False)
         adapter_ctx = self.actor.actor_module.disable_adapter() if is_lora else nullcontext()
-        data = data.to(get_torch_device().current_device())
+        data = data.to(get_device_id())
         # we should always recompute old_log_probs when it is HybridEngine
         data.meta_info["micro_batch_size"] = self.config.rollout.log_prob_micro_batch_size_per_gpu
         data.meta_info["max_token_len"] = self.config.rollout.log_prob_max_token_len_per_gpu
@@ -717,7 +719,7 @@ class ActorRolloutRefWorker(Worker):
         # else:
         # otherwise, the class have a standalone ref model
         # Support all hardwares
-        data = data.to(get_torch_device().current_device())
+        data = data.to(get_device_id())
 
         micro_batch_size = self.config.ref.log_prob_micro_batch_size_per_gpu
         data.meta_info["micro_batch_size"] = micro_batch_size
@@ -764,7 +766,7 @@ class ActorRolloutRefWorker(Worker):
                 peft_config["target_modules"] = list(peft_config["target_modules"])
             try:
                 if fsdp_version(self.actor_module_fsdp) > 0:
-                    self.actor_module_fsdp = self.actor_module_fsdp.cuda()
+                    self.actor_module_fsdp = self.actor_module_fsdp.to(get_device_name())
                     lora_params = layered_summon_lora_params(self.actor_module_fsdp)
                     if dist.get_rank() == 0:
                         save_file(lora_params, os.path.join(lora_save_path, "adapter_model.safetensors"))
@@ -801,7 +803,7 @@ class CriticWorker(Worker):
         import torch.distributed
 
         if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend="nccl" if is_cuda_available else "hccl")
+            torch.distributed.init_process_group(backend=get_nccl_backend())
         self.config = config
 
         # build device mesh for Ulysses Sequence Parallel
@@ -951,7 +953,7 @@ class CriticWorker(Worker):
                 param_init_fn=init_fn,
                 use_orig_params=False,
                 auto_wrap_policy=auto_wrap_policy,
-                device_id=get_torch_device().current_device(),
+                device_id=get_device_id(),
                 sharding_strategy=sharding_strategy,
                 mixed_precision=mixed_precision,
                 sync_module_states=True,
@@ -1044,7 +1046,7 @@ class CriticWorker(Worker):
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_values(self, data: DataProto):
         # Support all hardwares
-        data = data.to(get_torch_device().current_device())
+        data = data.to(get_device_id())
 
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.critic_module)
@@ -1067,11 +1069,11 @@ class CriticWorker(Worker):
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def update_critic(self, data: DataProto):
         # Support all hardwares
-        data = data.to(get_torch_device().current_device())
+        data = data.to(get_device_id())
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.critic_module)
         if self._is_offload_optimizer:
-            load_fsdp_optimizer(optimizer=self.critic_optimizer, device_id=get_torch_device().current_device())
+            load_fsdp_optimizer(optimizer=self.critic_optimizer, device_id=get_device_id())
 
         # perform forward computation
         with self.ulysses_sharding_manager:
@@ -1141,7 +1143,7 @@ class RewardModelWorker(Worker):
         import torch.distributed
 
         if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend="nccl" if is_cuda_available else "hccl")
+            torch.distributed.init_process_group(backend=get_nccl_backend())
         self.config = config
 
         # build device mesh for Ulysses Sequence Parallel
@@ -1220,7 +1222,7 @@ class RewardModelWorker(Worker):
                 param_init_fn=init_fn,
                 use_orig_params=False,
                 auto_wrap_policy=auto_wrap_policy,
-                device_id=get_torch_device().current_device(),
+                device_id=get_device_id(),
                 sharding_strategy=sharding_strategy,  # zero3
                 sync_module_states=True,
                 cpu_offload=CPUOffload(offload_params=True),
@@ -1377,7 +1379,7 @@ class RewardModelWorker(Worker):
         from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 
         # Support all hardwares
-        data = data.to(get_torch_device().current_device())
+        data = data.to(get_device_id())
         if self._do_switch_chat_template:
             rm_data = self._switch_chat_template(data)
         else:
@@ -1392,7 +1394,7 @@ class RewardModelWorker(Worker):
             rm_data = DataProto.from_dict(rm_inputs)
 
         # Support all hardwares
-        rm_data.batch = rm_data.batch.to(get_torch_device().current_device())
+        rm_data.batch = rm_data.batch.to(get_device_id())
 
         # perform forward computation
         with self.ulysses_sharding_manager:

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -35,6 +35,7 @@ from verl.utils import hf_tokenizer
 from verl.utils.checkpoint.megatron_checkpoint_manager import MegatronCheckpointManager
 from verl.utils.debug import GPUMemoryLogger, log_gpu_memory_usage
 from verl.utils.debug.performance import _timer, reduce_timing
+from verl.utils.device import get_device_id, get_device_name, get_nccl_backend, get_torch_device
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.fs import copy_to_local
 from verl.utils.megatron_utils import (
@@ -43,7 +44,6 @@ from verl.utils.megatron_utils import (
     offload_megatron_model_to_cpu,
     offload_megatron_optimizer,
 )
-from verl.utils.device import get_torch_device, get_device_name, get_nccl_backend, get_device_id
 from verl.utils.model import load_mcore_dist_weights, load_megatron_gptmodel_weights
 from verl.workers.actor.megatron_actor import MegatronPPOActor
 from verl.workers.critic.megatron_critic import MegatronPPOCritic

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -43,6 +43,7 @@ from verl.utils.megatron_utils import (
     offload_megatron_model_to_cpu,
     offload_megatron_optimizer,
 )
+from verl.utils.device import get_torch_device, get_device_name, get_nccl_backend, get_device_id
 from verl.utils.model import load_mcore_dist_weights, load_megatron_gptmodel_weights
 from verl.workers.actor.megatron_actor import MegatronPPOActor
 from verl.workers.critic.megatron_critic import MegatronPPOCritic
@@ -61,7 +62,7 @@ def set_random_seed(seed):
     torch.manual_seed(seed)
     np.random.seed(seed)
     random.seed(seed)
-    if torch.cuda.device_count() > 0:
+    if get_torch_device().device_count() > 0:
         from megatron.core import tensor_parallel
 
         tensor_parallel.model_parallel_cuda_manual_seed(seed)
@@ -89,8 +90,8 @@ class ActorRolloutRefWorker(MegatronWorker):
         # 3. and apply the following patch in ray==2.10, https://github.com/ray-project/ray/pull/44385
         if not torch.distributed.is_initialized():
             rank = int(os.environ["LOCAL_RANK"])
-            torch.distributed.init_process_group(backend="nccl", timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600)))
-            torch.cuda.set_device(rank)
+            torch.distributed.init_process_group(backend=get_nccl_backend(), timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600)))
+            get_torch_device().set_device(rank)
 
             if self.config.actor.megatron.sequence_parallel:
                 os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
@@ -156,7 +157,7 @@ class ActorRolloutRefWorker(MegatronWorker):
             from verl.models.mcore import init_mcore_model
 
             parallel_model = init_mcore_model(self.tf_config, self.hf_config, pre_process, post_process, share_embeddings_and_output_weights=self.share_embeddings_and_output_weights, value=False, freeze_moe_router=override_model_config.get("moe_config", {}).get("freeze_moe_router", False))
-            parallel_model.cuda()
+            parallel_model.to(get_device_name())
             return parallel_model
 
         # Step 3: initialize the megatron model
@@ -229,7 +230,7 @@ class ActorRolloutRefWorker(MegatronWorker):
             infer_tp = self.config.rollout.tensor_model_parallel_size
             dp = self.world_size // infer_tp
             assert self.world_size % infer_tp == 0, f"rollout world_size: {self.world_size} is not divisible by infer_tp: {infer_tp}"
-            rollout_device_mesh = init_device_mesh("cuda", mesh_shape=(dp, infer_tp), mesh_dim_names=["dp", "infer_tp"])
+            rollout_device_mesh = init_device_mesh(get_device_name(), mesh_shape=(dp, infer_tp), mesh_dim_names=["dp", "infer_tp"])
             log_gpu_memory_usage("Before building vllm rollout", logger=None)
 
             local_path = copy_to_local(self.config.model.path, use_shm=self.config.model.get("use_shm", False))
@@ -409,7 +410,7 @@ class ActorRolloutRefWorker(MegatronWorker):
                 use_checkpoint_opt_param_scheduler=self.config.actor.optim.use_checkpoint_opt_param_scheduler,
                 checkpoint_contents=self.config.actor.checkpoint,
             )
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
         log_gpu_memory_usage("After init_model finish", logger=logger)
 
     @register(dispatch_mode=Dispatch.MEGATRON_COMPUTE_PROTO)
@@ -422,7 +423,7 @@ class ActorRolloutRefWorker(MegatronWorker):
         if self._is_offload_optimizer:
             load_megatron_optimizer(self.actor_optimizer)
             log_gpu_memory_usage("After load actor optimizer during update_actor", logger=logger)
-        data.batch = data.batch.cuda()
+        data.batch = data.batch.to(get_device_name())
 
         micro_batch_size = self.config.actor.ppo_micro_batch_size_per_gpu
         data.meta_info["micro_batch_size"] = micro_batch_size
@@ -449,7 +450,7 @@ class ActorRolloutRefWorker(MegatronWorker):
             offload_megatron_optimizer(self.actor_optimizer)
             log_gpu_memory_usage("After offload actor optimizer during update_actor", logger=logger)
 
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
         return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
@@ -459,7 +460,7 @@ class ActorRolloutRefWorker(MegatronWorker):
         if self._is_offload_param:
             load_megatron_model_to_gpu(self.actor_module)
             log_gpu_memory_usage("After load actor params during generate_sequences", logger=logger)
-        prompts.batch = prompts.batch.cuda()
+        prompts.batch = prompts.batch.to(get_device_name())
         meta_info = {
             "eos_token_id": self.generation_config.eos_token_id if self.generation_config is not None else self.tokenizer.eos_token_id,
             "pad_token_id": self.generation_config.pad_token_id if self.generation_config is not None else self.tokenizer.pad_token_id,
@@ -496,7 +497,7 @@ class ActorRolloutRefWorker(MegatronWorker):
         output.meta_info["timing"] = timing_generate
         output = output.to("cpu")
         # clear kv cache
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
         return output
 
     @register(dispatch_mode=Dispatch.MEGATRON_COMPUTE_PROTO)
@@ -511,14 +512,14 @@ class ActorRolloutRefWorker(MegatronWorker):
         data.meta_info["max_token_len"] = self.config.ref.log_prob_max_token_len_per_gpu
         data.meta_info["use_dynamic_bsz"] = self.config.ref.log_prob_use_dynamic_bsz
         data.meta_info["temperature"] = self.config.rollout.temperature
-        data = data.to(torch.cuda.current_device())
+        data = data.to(get_device_id())
         output, _ = self.ref_policy.compute_log_prob(data=data, calculate_entropy=False)
         output = DataProto.from_dict(tensors={"ref_log_prob": output})
         output = output.to("cpu")
         if self._ref_is_offload_param:
             offload_megatron_model_to_cpu(self.ref_module)
             log_gpu_memory_usage("After offload ref params and grad during compute_ref_log_prob", logger=logger)
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
         return output
 
     @register(dispatch_mode=Dispatch.MEGATRON_COMPUTE_PROTO)
@@ -533,7 +534,7 @@ class ActorRolloutRefWorker(MegatronWorker):
         data.meta_info["max_token_len"] = self.config.rollout.log_prob_max_token_len_per_gpu
         data.meta_info["use_dynamic_bsz"] = self.config.rollout.log_prob_use_dynamic_bsz
         data.meta_info["temperature"] = self.config.rollout.temperature
-        data = data.to(torch.cuda.current_device())
+        data = data.to(get_device_id())
         output, entropys = self.actor.compute_log_prob(data=data, calculate_entropy=True)
         output = DataProto.from_dict(tensors={"old_log_probs": output, "entropys": entropys}, meta_info={"temperature": self.config.rollout.temperature})
         output = output.to("cpu")
@@ -541,7 +542,7 @@ class ActorRolloutRefWorker(MegatronWorker):
         if self._is_offload_param:
             offload_megatron_model_to_cpu(self.actor_module)
             log_gpu_memory_usage("After offload actor params and grad during compute_log_prob", logger=logger)
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
         return output
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
@@ -622,8 +623,8 @@ class CriticWorker(MegatronWorker):
         # 3. and apply the following patch in ray==2.10, https://github.com/ray-project/ray/pull/44385
         if not torch.distributed.is_initialized():
             rank = int(os.environ["LOCAL_RANK"])
-            torch.distributed.init_process_group(backend="nccl", timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600)))
-            torch.cuda.set_device(rank)
+            torch.distributed.init_process_group(backend=get_nccl_backend(), timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600)))
+            get_torch_device().set_device(rank)
 
             if self.config.megatron.sequence_parallel:
                 os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
@@ -667,7 +668,7 @@ class CriticWorker(MegatronWorker):
             from verl.models.mcore import init_mcore_model
 
             parallel_model = init_mcore_model(self.tf_config, self.hf_config, pre_process, post_process, share_embeddings_and_output_weights=False, value=True, freeze_moe_router=override_model_config.get("moe_config", {}).get("freeze_moe_router", False))
-            parallel_model.cuda()
+            parallel_model.to(get_device_name())
             return parallel_model
 
         # Step 3: initialize the megatron model
@@ -697,7 +698,7 @@ class CriticWorker(MegatronWorker):
         optim_config_megatron = init_megatron_optim_config(optim_config)
         critic_optimizer = get_megatron_optimizer(model=critic_module, config=optim_config_megatron)
         critic_optimizer_scheduler = get_megatron_optimizer_param_scheduler(optimizer=critic_optimizer, config=optim_config)
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
         return critic_module, critic_optimizer, critic_optimizer_scheduler, self.hf_config, optim_config
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
@@ -760,7 +761,7 @@ class CriticWorker(MegatronWorker):
         data.meta_info["micro_batch_size"] = micro_batch_size
         data.meta_info["max_token_len"] = self.config.forward_max_token_len_per_gpu
         data.meta_info["use_dynamic_bsz"] = self.config.use_dynamic_bsz
-        data = data.to(torch.cuda.current_device())
+        data = data.to(get_device_id())
         if self._is_offload_param:
             load_megatron_model_to_gpu(self.critic_module)
         values = self.critic.compute_values(data=data)
@@ -772,7 +773,7 @@ class CriticWorker(MegatronWorker):
 
     @register(dispatch_mode=Dispatch.MEGATRON_COMPUTE_PROTO)
     def update_critic(self, data: DataProto):
-        data = data.to(torch.cuda.current_device())
+        data = data.to(get_device_id())
 
         if self._is_offload_param:
             load_megatron_model_to_gpu(self.critic_module)
@@ -836,8 +837,8 @@ class RewardModelWorker(MegatronWorker):
         # 3. and apply the following patch in ray==2.10, https://github.com/ray-project/ray/pull/44385
         if not torch.distributed.is_initialized():
             rank = int(os.environ["LOCAL_RANK"])
-            torch.distributed.init_process_group(backend="nccl", timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600)))
-            torch.cuda.set_device(rank)
+            torch.distributed.init_process_group(backend=get_nccl_backend(), timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600)))
+            get_torch_device().set_device(rank)
 
             if self.config.megatron.sequence_parallel:
                 os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
@@ -878,7 +879,7 @@ class RewardModelWorker(MegatronWorker):
                 share_embeddings_and_output_weights=False,
                 value=True,
             )
-            parallel_model.cuda()
+            parallel_model.to(get_device_name())
             return parallel_model
 
         # Step 3: initialize the megatron model
@@ -899,7 +900,7 @@ class RewardModelWorker(MegatronWorker):
                 load_megatron_gptmodel_weights(self.config, self.hf_config, reward_model, params_dtype=self.dtype, is_value_model=True)
 
         # TODO: add more optimizer args into config
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
         return reward_model, self.hf_config
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
@@ -954,7 +955,7 @@ class RewardModelWorker(MegatronWorker):
         data.meta_info["micro_batch_size"] = self.config.micro_batch_size_per_gpu
         data.meta_info["max_token_len"] = self.config.forward_max_token_len_per_gpu
         data.meta_info["use_dynamic_bsz"] = self.config.use_dynamic_bsz
-        data = data.to(torch.cuda.current_device())
+        data = data.to(get_device_id())
         output = self.rm.compute_reward(data)
         output = output.to("cpu")
         return output

--- a/verl/workers/reward_model/megatron/reward_model.py
+++ b/verl/workers/reward_model/megatron/reward_model.py
@@ -27,6 +27,7 @@ from verl import DataProto
 from verl.utils.megatron.pipeline_parallel import make_batch_generator
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.torch_functional import broadcast_dict_tensor, pad_sequence_to_length
+from verl.utils.device import get_torch_device, get_device_name, get_device_id
 from verl.workers.reward_model.base import BasePPORewardModel
 
 
@@ -85,8 +86,8 @@ class MegatronRewardModel(BasePPORewardModel):
             if print_decode and torch.distributed.get_rank() == 0:
                 # only print first decode result
                 print(
-                    f"device {torch.cuda.current_device()}: sft decode result:\n{decode_result}\n \
-                        \ndevice {torch.cuda.current_device()}: sft decode result with \
+                    f"device {get_device_id()}: sft decode result:\n{decode_result}\n \
+                        \ndevice {get_device_id()}: sft decode result with \
                         rm chat template:\n{decode_with_rm_chat}\n\n"
                 )
                 print_decode = False
@@ -194,7 +195,7 @@ class MegatronRewardModel(BasePPORewardModel):
             self.offload_params_to_cpu()
         else:
             # add empty cache after each compute
-            torch.cuda.empty_cache()
+            get_torch_device().empty_cache()
 
         batch = TensorDict({"rm_scores": token_level_rewards}, batch_size=input_ids.shape[0])
 
@@ -306,16 +307,16 @@ class MegatronRewardModel(BasePPORewardModel):
         return losses_reduced
 
     def offload_params_to_cpu(self):
-        if self.device == "cuda":
+        if self.device in ["cuda", "npu"]:
             for reward_model_module in self.reward_model_module:
                 for name, param in reward_model_module.named_parameters():
                     param.data = param.data.to("cpu", non_blocking=True)
             self.device = "cpu"
-            torch.cuda.empty_cache()
+            get_torch_device().empty_cache()
 
     def load_params_to_cuda(self):
         if self.device == "cpu":
             for reward_model_module in self.reward_model_module:
                 for name, param in reward_model_module.named_parameters():
-                    param.data = param.data.to(torch.cuda.current_device(), non_blocking=True)
-            self.device = "cuda"
+                    param.data = param.data.to(get_device_id(), non_blocking=True)
+            self.device = get_device_name()

--- a/verl/workers/reward_model/megatron/reward_model.py
+++ b/verl/workers/reward_model/megatron/reward_model.py
@@ -24,10 +24,10 @@ from megatron.core.pipeline_parallel import get_forward_backward_func
 from tensordict import TensorDict
 
 from verl import DataProto
+from verl.utils.device import get_device_id, get_device_name, get_torch_device
 from verl.utils.megatron.pipeline_parallel import make_batch_generator
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.torch_functional import broadcast_dict_tensor, pad_sequence_to_length
-from verl.utils.device import get_torch_device, get_device_name, get_device_id
 from verl.workers.reward_model.base import BasePPORewardModel
 
 

--- a/verl/workers/rollout/hf_rollout.py
+++ b/verl/workers/rollout/hf_rollout.py
@@ -28,7 +28,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from transformers import GenerationConfig
 
 from verl import DataProto
-from verl.utils.device import get_torch_device, get_device_name
+from verl.utils.device import get_device_name, get_torch_device
 from verl.utils.torch_functional import get_response_mask
 
 from .base import BaseRollout

--- a/verl/workers/rollout/hf_rollout.py
+++ b/verl/workers/rollout/hf_rollout.py
@@ -28,7 +28,7 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from transformers import GenerationConfig
 
 from verl import DataProto
-from verl.utils.device import get_torch_device
+from verl.utils.device import get_torch_device, get_device_name
 from verl.utils.torch_functional import get_response_mask
 
 from .base import BaseRollout
@@ -106,7 +106,7 @@ class HFRollout(BaseRollout):
         if isinstance(self.module, FSDP):
             # recurse need to set to False according to https://github.com/pytorch/pytorch/issues/100069
             param_ctx = FSDP.summon_full_params(self.module, writeback=False, recurse=False)
-        with param_ctx, torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        with param_ctx, torch.autocast(device_type=get_device_name(), dtype=torch.bfloat16):
             output = self.module.generate(
                 input_ids=idx,
                 attention_mask=attention_mask,

--- a/verl/workers/rollout/sglang_rollout/utils.py
+++ b/verl/workers/rollout/sglang_rollout/utils.py
@@ -20,6 +20,8 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
+from verl.utils.device import get_device_name
+
 
 def broadcast_pyobj(
     data: List[Any],
@@ -34,7 +36,7 @@ def broadcast_pyobj(
     The `rank` here refer to the source rank on global process group (regardless
     of dist_group argument).
     """
-    device = torch.device("cuda" if torch.cuda.is_available() and not force_cpu_device else "cpu")
+    device = torch.device(get_device_name() if not force_cpu_device else "cpu")
 
     if rank == src:
         if len(data) == 0:

--- a/verl/workers/sharding_manager/fsdp_sglang.py
+++ b/verl/workers/sharding_manager/fsdp_sglang.py
@@ -35,6 +35,7 @@ from verl.utils.debug.performance import _timer
 from verl.utils.fsdp_utils import fsdp_version, load_fsdp_model_to_gpu, offload_fsdp_model_to_cpu
 from verl.utils.model import convert_weight_keys
 from verl.utils.torch_functional import check_device_is_available
+from verl.utils.device import get_torch_device, get_device_id
 
 from .base import BaseShardingManager
 
@@ -81,13 +82,13 @@ class FSDPSGLangShardingManager(BaseShardingManager):
         self.tp_rank = self.device_mesh["infer_tp"].get_local_rank()
 
         # Note that torch_random_states may be different on each dp rank
-        self.torch_random_states = torch.cuda.get_rng_state()
+        self.torch_random_states = get_torch_device().get_rng_state()
         # get a random rng states
         if self.device_mesh is not None:
             gen_dp_rank = self.device_mesh["dp"].get_local_rank()
-            torch.cuda.manual_seed(gen_dp_rank + 1000)  # make sure all tp ranks have the same random states
-            self.gen_random_states = torch.cuda.get_rng_state()
-            torch.cuda.set_rng_state(self.torch_random_states)
+            get_torch_device().manual_seed(gen_dp_rank + 1000)  # make sure all tp ranks have the same random states
+            self.gen_random_states = get_torch_device().get_rng_state()
+            get_torch_device().set_rng_state(self.torch_random_states)
         else:
             self.gen_random_states = None
 
@@ -95,13 +96,13 @@ class FSDPSGLangShardingManager(BaseShardingManager):
     def __enter__(self):
         self.timing = {}
         with _timer("reshard", self.timing):
-            torch.cuda.empty_cache()
+            get_torch_device().empty_cache()
             log_gpu_memory_usage("Before state_dict() in sharding manager memory", logger=logger)
             if self.offload_param:
                 load_fsdp_model_to_gpu(self.module)
             params = self.module.state_dict()
             log_gpu_memory_usage("After state_dict() in sharding manager memory", logger=logger)
-            device = torch.cuda.current_device()  # used when fsdp2 set cpu_offload_policy
+            device = get_device_id()  # used when fsdp2 set cpu_offload_policy
             params = {k: v.to(device, non_blocking=True) if fsdp_version(self.module) == 2 else v for k, v in params.items()}
             params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
             # Copy, not share memory
@@ -112,13 +113,13 @@ class FSDPSGLangShardingManager(BaseShardingManager):
             del params
             if self.offload_param:
                 offload_fsdp_model_to_cpu(self.module)
-            torch.cuda.empty_cache()
+            get_torch_device().empty_cache()
             log_gpu_memory_usage("After del state_dict and empty_cache in sharding manager", logger=logger)
 
             # important: need to manually set the random states of each tp to be identical.
             if self.device_mesh is not None:
-                self.torch_random_states = torch.cuda.get_rng_state()
-                torch.cuda.set_rng_state(self.gen_random_states)
+                self.torch_random_states = get_torch_device().get_rng_state()
+                get_torch_device().set_rng_state(self.gen_random_states)
 
     @GPUMemoryLogger(role="FSDPSGLangShardingManager exit", logger=logger)
     def __exit__(self, exc_type, exc_value, traceback):
@@ -130,12 +131,12 @@ class FSDPSGLangShardingManager(BaseShardingManager):
         self.module.train()
 
         # add empty cache after each compute
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
 
         # restore random states
         if self.device_mesh is not None:
-            self.gen_random_states = torch.cuda.get_rng_state()
-            torch.cuda.set_rng_state(self.torch_random_states)
+            self.gen_random_states = get_torch_device().get_rng_state()
+            get_torch_device().set_rng_state(self.torch_random_states)
 
     async def update_weights(self, params):
         if self.device_mesh["infer_tp"].get_local_rank() == 0:
@@ -176,13 +177,13 @@ class FSDPSGLangShardingManager(BaseShardingManager):
 
     @GPUMemoryLogger(role="FSDPSGLangShardingManager enter", logger=logger)
     async def wake_up(self):
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
         log_gpu_memory_usage("Before state_dict() in sharding manager memory", logger=logger)
         if self.offload_param:
             load_fsdp_model_to_gpu(self.module)
         params = self.module.state_dict()
         log_gpu_memory_usage("After state_dict() in sharding manager memory", logger=logger)
-        device = torch.cuda.current_device()  # used when fsdp2 set cpu_offload_policy
+        device = get_device_id()  # used when fsdp2 set cpu_offload_policy
         params = {k: v.to(device, non_blocking=True) if fsdp_version(self.module) == 2 else v for k, v in params.items()}
         # Copy, not share memory
         await self.update_weights(params)
@@ -191,13 +192,13 @@ class FSDPSGLangShardingManager(BaseShardingManager):
         del params
         if self.offload_param:
             offload_fsdp_model_to_cpu(self.module)
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
         log_gpu_memory_usage("After del state_dict and empty_cache in sharding manager", logger=logger)
 
         # important: need to manually set the random states of each tp to be identical.
         if self.device_mesh is not None:
-            self.torch_random_states = torch.cuda.get_rng_state()
-            torch.cuda.set_rng_state(self.gen_random_states)
+            self.torch_random_states = get_torch_device().get_rng_state()
+            get_torch_device().set_rng_state(self.gen_random_states)
 
     @GPUMemoryLogger(role="FSDPSGLangShardingManager exit", logger=logger)
     async def sleep(self):
@@ -208,12 +209,12 @@ class FSDPSGLangShardingManager(BaseShardingManager):
         self.module.train()
 
         # add empty cache after each compute
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
 
         # restore random states
         if self.device_mesh is not None:
-            self.gen_random_states = torch.cuda.get_rng_state()
-            torch.cuda.set_rng_state(self.torch_random_states)
+            self.gen_random_states = get_torch_device().get_rng_state()
+            get_torch_device().set_rng_state(self.torch_random_states)
 
     def preprocess_data(self, data: DataProto) -> DataProto:
         """All gather across tp group to make each rank has identical input."""

--- a/verl/workers/sharding_manager/fsdp_sglang.py
+++ b/verl/workers/sharding_manager/fsdp_sglang.py
@@ -32,10 +32,10 @@ from verl import DataProto
 from verl.protocol import all_gather_data_proto
 from verl.utils.debug import GPUMemoryLogger, log_gpu_memory_usage
 from verl.utils.debug.performance import _timer
+from verl.utils.device import get_device_id, get_torch_device
 from verl.utils.fsdp_utils import fsdp_version, load_fsdp_model_to_gpu, offload_fsdp_model_to_cpu
 from verl.utils.model import convert_weight_keys
 from verl.utils.torch_functional import check_device_is_available
-from verl.utils.device import get_torch_device, get_device_id
 
 from .base import BaseShardingManager
 

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -18,7 +18,6 @@ import os
 import time
 from collections import OrderedDict
 
-import torch
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp.api import FullStateDictConfig, ShardedStateDictConfig, StateDictType
 from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
@@ -37,7 +36,7 @@ from verl.third_party.vllm import LLM, vllm_version
 from verl.third_party.vllm import parallel_state as vllm_ps
 from verl.utils.debug import GPUMemoryLogger, log_gpu_memory_usage
 from verl.utils.debug.performance import _timer
-from verl.utils.device import get_torch_device, get_device_name, get_device_id
+from verl.utils.device import get_device_id, get_device_name, get_torch_device
 from verl.utils.fsdp_utils import fsdp_version, layered_summon_lora_params, load_fsdp_model_to_gpu, offload_fsdp_model_to_cpu
 from verl.utils.model import convert_weight_keys
 from verl.utils.torch_functional import check_device_is_available

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -37,7 +37,7 @@ from verl.third_party.vllm import LLM, vllm_version
 from verl.third_party.vllm import parallel_state as vllm_ps
 from verl.utils.debug import GPUMemoryLogger, log_gpu_memory_usage
 from verl.utils.debug.performance import _timer
-from verl.utils.device import get_torch_device
+from verl.utils.device import get_torch_device, get_device_name, get_device_id
 from verl.utils.fsdp_utils import fsdp_version, layered_summon_lora_params, load_fsdp_model_to_gpu, offload_fsdp_model_to_cpu
 from verl.utils.model import convert_weight_keys
 from verl.utils.torch_functional import check_device_is_available
@@ -122,7 +122,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
                             lora_params = {name: param.full_tensor().detach().cpu() if hasattr(param, "full_tensor") else param.detach().cpu() for name, param in lora_params.items()}
                         else:
                             model = peft_model.base_model.model
-                            orig_dev = "cpu" if "cpu" in str(next(model.parameters()).device) else "cuda"
+                            orig_dev = "cpu" if "cpu" in str(next(model.parameters()).device) else get_device_name()
                             model = model.to("cpu")
                             for name, param in model.state_dict().items():
                                 if any(x in name for x in ["_flat_param", "lora_"]):
@@ -130,13 +130,13 @@ class FSDPVLLMShardingManager(BaseShardingManager):
                                 name = name.replace("_fsdp_wrapped_module.", "").replace(".base_layer", "")
                                 lora_params[name] = param.full_tensor().detach().cpu() if hasattr(param, "full_tensor") else param.detach().cpu()
                             model = model.to(orig_dev)
-                    torch.cuda.empty_cache()
+                    get_torch_device().empty_cache()
             else:
                 if self.base_sync_done:
                     lora_params = get_peft_model_state_dict(peft_model)
                 else:
                     model = peft_model.base_model.model
-                    orig_dev = "cpu" if "cpu" in str(next(model.parameters()).device) else "cuda"
+                    orig_dev = "cpu" if "cpu" in str(next(model.parameters()).device) else get_device_name()
                     model = model.to("cpu")
                     for name, param in model.state_dict().items():
                         if any(x in name for x in ["_flat_param", "lora_"]):
@@ -280,7 +280,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
                 updated_params = {replace_lora_wrapper(k): v for k, v in updated_params.items()}
 
         patch_vllm_moe_model_weight_loader(model)
-        device = get_torch_device().current_device()  # used when fsdp2 set cpu_offload_policy
+        device = get_device_id()  # used when fsdp2 set cpu_offload_policy
         loaded_params = model.load_weights(((name, param.to(device, non_blocking=True).full_tensor() if isinstance(param, DTensor) else param) for name, param in updated_params.items()))
 
         self.base_sync_done = True

--- a/verl/workers/sharding_manager/megatron_sglang.py
+++ b/verl/workers/sharding_manager/megatron_sglang.py
@@ -30,6 +30,7 @@ from verl.protocol import DataProto, all_gather_data_proto
 from verl.utils.debug import GPUMemoryLogger, log_gpu_memory_usage
 from verl.utils.debug.performance import _timer
 from verl.utils.megatron_utils import per_tensor_generator
+from verl.utils.device import get_torch_device
 
 from .base import BaseShardingManager
 
@@ -72,13 +73,13 @@ class MegatronSGLangShardingManager(BaseShardingManager):
             self.infer_tp_size = self.inference_engine._tp_size
 
         # Note that torch_random_states may be different on each dp rank
-        self.torch_random_states = torch.cuda.get_rng_state()
+        self.torch_random_states = get_torch_device().get_rng_state()
         # get a random rng states
         if self.device_mesh is not None:
             gen_dp_rank = self.device_mesh["dp"].get_local_rank()
-            torch.cuda.manual_seed(gen_dp_rank + 1000)  # make sure all tp ranks have the same random states
-            self.gen_random_states = torch.cuda.get_rng_state()
-            torch.cuda.set_rng_state(self.torch_random_states)
+            get_torch_device().manual_seed(gen_dp_rank + 1000)  # make sure all tp ranks have the same random states
+            self.gen_random_states = get_torch_device().get_rng_state()
+            get_torch_device().set_rng_state(self.torch_random_states)
         else:
             self.gen_random_states = None
 
@@ -97,8 +98,8 @@ class MegatronSGLangShardingManager(BaseShardingManager):
             loop.run_until_complete(self.update_weights(per_tensor_param))
             # important: need to manually set the random states of each tp to be identical.
             if self.device_mesh is not None:
-                self.torch_random_states = torch.cuda.get_rng_state()
-                torch.cuda.set_rng_state(self.gen_random_states)
+                self.torch_random_states = get_torch_device().get_rng_state()
+                get_torch_device().set_rng_state(self.gen_random_states)
 
     @GPUMemoryLogger(role="MegatronSGLangShardingManager exit", logger=logger)
     def __exit__(self, exc_type, exc_value, traceback):
@@ -110,12 +111,12 @@ class MegatronSGLangShardingManager(BaseShardingManager):
         for model in self.actor_module:
             model.train()
         # add empty cache after each compute
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
 
         # restore random states
         if self.device_mesh is not None:
-            self.gen_random_states = torch.cuda.get_rng_state()
-            torch.cuda.set_rng_state(self.torch_random_states)
+            self.gen_random_states = get_torch_device().get_rng_state()
+            get_torch_device().set_rng_state(self.torch_random_states)
 
     async def update_weights(self, params):
         if self.device_mesh["tp"].get_local_rank() == 0:
@@ -157,8 +158,8 @@ class MegatronSGLangShardingManager(BaseShardingManager):
         await self.update_weights(per_tensor_param)
         # important: need to manually set the random states of each tp to be identical.
         if self.device_mesh is not None:
-            self.torch_random_states = torch.cuda.get_rng_state()
-            torch.cuda.set_rng_state(self.gen_random_states)
+            self.torch_random_states = get_torch_device().get_rng_state()
+            get_torch_device().set_rng_state(self.gen_random_states)
 
     @GPUMemoryLogger(role="FSDPSGLangShardingManager exit", logger=logger)
     async def sleep(self):
@@ -169,12 +170,12 @@ class MegatronSGLangShardingManager(BaseShardingManager):
         for model in self.actor_module:
             model.train()
         # add empty cache after each compute
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
 
         # restore random states
         if self.device_mesh is not None:
-            self.gen_random_states = torch.cuda.get_rng_state()
-            torch.cuda.set_rng_state(self.torch_random_states)
+            self.gen_random_states = get_torch_device().get_rng_state()
+            get_torch_device().set_rng_state(self.torch_random_states)
 
     @GPUMemoryLogger(role="megatron sglang sharding_manager", logger=logger)
     def preprocess_data(self, data: DataProto) -> DataProto:

--- a/verl/workers/sharding_manager/megatron_sglang.py
+++ b/verl/workers/sharding_manager/megatron_sglang.py
@@ -21,7 +21,6 @@ import asyncio
 import logging
 import os
 
-import torch
 from sglang.srt.entrypoints.engine import Engine
 from torch import nn
 from torch.distributed.device_mesh import DeviceMesh
@@ -29,8 +28,8 @@ from torch.distributed.device_mesh import DeviceMesh
 from verl.protocol import DataProto, all_gather_data_proto
 from verl.utils.debug import GPUMemoryLogger, log_gpu_memory_usage
 from verl.utils.debug.performance import _timer
-from verl.utils.megatron_utils import per_tensor_generator
 from verl.utils.device import get_torch_device
+from verl.utils.megatron_utils import per_tensor_generator
 
 from .base import BaseShardingManager
 

--- a/verl/workers/sharding_manager/megatron_vllm.py
+++ b/verl/workers/sharding_manager/megatron_vllm.py
@@ -31,12 +31,12 @@ from verl.third_party.vllm import LLM, vllm_version
 from verl.third_party.vllm import parallel_state as vllm_ps
 from verl.utils.debug import GPUMemoryLogger
 from verl.utils.debug.performance import _timer
+from verl.utils.device import get_torch_device
 from verl.utils.megatron_utils import (
     per_tensor_generator,
 )
 from verl.utils.torch_functional import check_device_is_available
 from verl.utils.vllm_utils import patch_vllm_moe_model_weight_loader
-from verl.utils.device import get_torch_device
 
 from .base import BaseShardingManager
 

--- a/verl/workers/sharding_manager/megatron_vllm.py
+++ b/verl/workers/sharding_manager/megatron_vllm.py
@@ -36,6 +36,7 @@ from verl.utils.megatron_utils import (
 )
 from verl.utils.torch_functional import check_device_is_available
 from verl.utils.vllm_utils import patch_vllm_moe_model_weight_loader
+from verl.utils.device import get_torch_device
 
 from .base import BaseShardingManager
 
@@ -136,7 +137,7 @@ class MegatronVLLMShardingManager(BaseShardingManager):
         for model in self.actor_module:
             model.train()
 
-        torch.cuda.empty_cache()
+        get_torch_device().empty_cache()
 
     @GPUMemoryLogger(role="megatron vllm sharding_manager", logger=logger)
     def preprocess_data(self, data: DataProto) -> DataProto:


### PR DESCRIPTION
### Checklist Before Starting

- [x] Searched for similar PR(s).
- [x] Checked PR Title format
  - [x] In format of: [modules] type: Title
  - [x] modules are in `fsdp, megatron, sglang, vllm, rollout, trainer, tests, training_utils, recipe, hardware, deployment, ray, worker, single_controller, misc, perf, model, algo, env, tool, ckpt, doc`
  - [x] type is in `feat, fix, refactor, chore`
  - [x] can involve multiple modules, seperated by `,` or space, like `[megatron, fsdp, doc] feat: xxx`

### What does this PR do?

Refactor device management such as `torch.cuda` and `nccl` in most part of code in  `verl/recipe` and `verl/verl`, which is more convinent for supporting other devices or platforms.

### Test

Not related.

### High-Level Design

Not related.

### Specific Changes

1. use `get_torch_device()` to get corresponding `torch.device()` object based on specific device.
2. use `get_device_id()` to get corresponding device rank index based on specific device.
3. use `get_nccl_backend()` to get corresponding nccl backend based on specific device.

### API

Not related.

### Usage Example

Monifications in this PR should not be perceived.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title `description` if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] New CI unit test(s) are added to cover the code path.
- [x] Rely on existing unit tests on CI that covers the code path.
