### PR TITLE
WIP: [Refactor] Training Engine Interface and Development Plan

### DIFF
--- a/examples/ppo_trainer/run_deepseek7b_llm.sh
+++ b/examples/ppo_trainer/run_deepseek7b_llm.sh
@@ -36,9 +36,8 @@ python3 -m verl.trainer.main_ppo \
     trainer.experiment_name='deepseek_llm_7b_function_rm' \
     trainer.n_gpus_per_node=8 \
     trainer.nnodes=1 \
-    trainer.total_training_steps=2 \
+    trainer.total_training_steps=5 \
+    trainer.save_freq=2 \
+    trainer.test_freq=4 \
     trainer.use_legacy_worker_impl=False \
     trainer.total_epochs=15 $@
-
-    # trainer.save_freq=20 \
-    # trainer.test_freq=1 \

--- a/examples/ppo_trainer/run_deepseek7b_llm.sh
+++ b/examples/ppo_trainer/run_deepseek7b_llm.sh
@@ -23,7 +23,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
     critic.optim.lr=1e-5 \
-    critic.model.use_remove_padding=False \
+    critic.model.use_remove_padding=True \
     critic.model.path=deepseek-ai/deepseek-llm-7b-chat \
     critic.model.enable_gradient_checkpointing=True \
     critic.ppo_micro_batch_size_per_gpu=32 \

--- a/examples/ppo_trainer/run_deepseek7b_llm.sh
+++ b/examples/ppo_trainer/run_deepseek7b_llm.sh
@@ -23,7 +23,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
     critic.optim.lr=1e-5 \
-    critic.model.use_remove_padding=True \
+    critic.model.use_remove_padding=False \
     critic.model.path=deepseek-ai/deepseek-llm-7b-chat \
     critic.model.enable_gradient_checkpointing=True \
     critic.ppo_micro_batch_size_per_gpu=32 \

--- a/examples/ppo_trainer/run_deepseek7b_llm.sh
+++ b/examples/ppo_trainer/run_deepseek7b_llm.sh
@@ -36,8 +36,8 @@ python3 -m verl.trainer.main_ppo \
     trainer.experiment_name='deepseek_llm_7b_function_rm' \
     trainer.n_gpus_per_node=8 \
     trainer.nnodes=1 \
-    trainer.total_training_steps=5 \
-    trainer.save_freq=2 \
-    trainer.test_freq=4 \
+    trainer.total_training_steps=2 \
+    trainer.save_freq=20 \
+    trainer.test_freq=5 \
     trainer.use_legacy_worker_impl=False \
     trainer.total_epochs=15 $@

--- a/examples/ppo_trainer/run_deepseek7b_llm.sh
+++ b/examples/ppo_trainer/run_deepseek7b_llm.sh
@@ -31,11 +31,14 @@ python3 -m verl.trainer.main_ppo \
     critic.model.fsdp_config.optimizer_offload=False \
     algorithm.use_kl_in_reward=False \
     trainer.critic_warmup=0 \
-    trainer.logger=['console','wandb'] \
+    trainer.logger=['console'] \
     trainer.project_name='verl_example_gsm8k' \
     trainer.experiment_name='deepseek_llm_7b_function_rm' \
     trainer.n_gpus_per_node=8 \
     trainer.nnodes=1 \
-    trainer.save_freq=20 \
-    trainer.test_freq=1 \
+    trainer.total_training_steps=2 \
+    trainer.use_legacy_worker_impl=False \
     trainer.total_epochs=15 $@
+
+    # trainer.save_freq=20 \
+    # trainer.test_freq=1 \

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -819,6 +819,9 @@ trainer:
   # Device to run training on (e.g., "cuda", "cpu")
   device: cuda
 
+  # whether to use legacy role implementation
+  use_legacy_worker_impl: False
+
 # configs related to ray initialization
 ray_init:
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -89,7 +89,17 @@ class TaskRunner:
         if config.actor_rollout_ref.actor.strategy in ["fsdp", "fsdp2"]:
             assert config.critic.strategy in ["fsdp", "fsdp2"]
             from verl.single_controller.ray import RayWorkerGroup
-            from verl.workers.fsdp_workers import ActorRolloutRefWorker, AsyncActorRolloutRefWorker, CriticWorker
+            from verl.workers.fsdp_workers import ActorRolloutRefWorker, AsyncActorRolloutRefWorker
+
+            print("use_legacy_worker_impl", config.trainer.use_legacy_worker_impl)
+            assert config.trainer.use_legacy_worker_impl == False
+            if config.trainer.use_legacy_worker_impl:
+                import warnings
+                warnings.warn(f"Legacy worker impl is going to be deprecated, will be removed in the future. \
+                              Please use the new worker impl supported for PPO trainer.")
+                from verl.workers.fsdp_workers import CriticWorker
+            else:
+                from verl.workers.roles import CriticWorker
 
             actor_rollout_cls = AsyncActorRolloutRefWorker if config.actor_rollout_ref.rollout.mode == "async" else ActorRolloutRefWorker
             ray_worker_group_cls = RayWorkerGroup

--- a/verl/workers/engine/__init__.py
+++ b/verl/workers/engine/__init__.py
@@ -1,0 +1,3 @@
+from .base import BaseEngine
+
+__all__ = ["BaseEngine"]

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -1,10 +1,3 @@
-from contextlib import nullcontext
-
-"""
-TODO:
-- checkpointing
-"""
-
 class BaseEngine(object):
     def __init__(self, config):
         """
@@ -19,7 +12,7 @@ class BaseEngine(object):
         """
         raise NotImplementedError
 
-    def init_model_and_optimizer(self):
+    def init_model(self):
         """
         Initialize the model and its corresponding optimizer.
         """
@@ -39,12 +32,15 @@ class BaseEngine(object):
         """
         raise NotImplementedError
 
-    def forward_backward_step(self, batch, forward_only=False, ctx=None):
+    def forward_backward_step(self, 
+                              batch, 
+                              ctx=None, 
+                              forward_only=False, 
+                              preprocess_fn=None, 
+                              postprocess_fn=None):
         """
-        return
-        - preds
-        - loss
-        - out_ctx
+        inputs, ctx = preprocess_fn(batch, ctx)
+        preds, ctx = postprocess_fn(outputs, ctx)
         """
         raise NotImplementedError
 
@@ -81,24 +77,11 @@ class BaseEngine(object):
 
     def unshard_data(self, data):
         raise NotImplementedError
-
-    def set_preprocess_fn(self, preprocess_fn):
-        """
-        preprocess_fn(data, ctx) -> inputs, ctx
-        """
-        raise NotImplementedError
-
-
-    def set_postprocess_fn(self, postprocess_fn):
-        """
-        postprocess_fn(outputs, ctx) -> preds, ctx
-        """
-        raise NotImplementedError
         
 
     def set_loss_fn(self, loss_fn):
         """
-        loss_fn(data, preds, ctx) -> loss, out_ctx
+        loss_fn(data, preds, ctx) -> loss, ctx
         """
         raise NotImplementedError
 

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -1,34 +1,61 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The abstract base class defining the interface for model training engines.
+"""
+
+
 class BaseEngine(object):
+    """
+    Abstract base class defining the interface for model training engines.
+
+    Engine implementations must subclass BaseEngine and provide concrete behavior for all methods.
+    """
     def __init__(self, config):
         """
-        Initialize the BaseEngine instance.
-
-        This method serves as the constructor for the BaseEngine class. BaseEngine 
-        is likely an abstract base class.
+        Initialize the BaseEngine.
 
         Args:
-            config: A configuration object containing parameters and settings
-                    required for initializing the engine.
+            config: Configuration object containing parameters for engine setup.
         """
         raise NotImplementedError
 
     def init_model(self):
         """
-        Initialize the model and its corresponding optimizer.
+        Instantiate or load the model, optimizer, and learning rate scheduler.
+
+        Should prepare all components necessary for training or evaluation.
         """
         raise NotImplementedError
 
     def train_mode(self):
         """
-        Set the engine to training mode. This method is designed to switch the engine 
-        and its associated model(s) into training mode. 
+        Context manager entry for switching the engine and model into training mode.
+
+        Usage:
+            with engine.train_mode():
+                # runs in training mode
         """
         raise NotImplementedError
 
-    def eval_mode(self):
+    def eval_mode(self):        
         """
-        Set the engine to eval mode. This method is designed to switch the engine 
-        and its associated model(s) into eval mode. 
+        Context manager entry for switching the engine and model into evaluation mode.
+
+        Usage:
+            with engine.eval_mode():
+                # runs in evaluation mode
         """
         raise NotImplementedError
 
@@ -39,59 +66,113 @@ class BaseEngine(object):
                               preprocess_fn=None, 
                               postprocess_fn=None):
         """
-        inputs, ctx = preprocess_fn(batch, ctx)
-        preds, ctx = postprocess_fn(outputs, ctx)
+        Execute a forward pass (and optional backward pass) over a batch of data.
+
+        Args:
+            batch: Raw batch data (e.g., tensors or mappings) to process.
+            ctx: Optional context dict passed to preprocess/postprocess functions.
+            forward_only: If True, skip gradient computation and backward pass.
+            preprocess_fn: Function(batch, ctx) -> (inputs, ctx), applied before model call.
+            postprocess_fn: Function(outputs, ctx) -> (predictions, ctx), applied after model call.
+
+        Returns:
+            If forward_only:
+                (predictions, ctx)
+            Else:
+                (predictions, loss, ctx)
         """
         raise NotImplementedError
 
     def optimizer_zero_grad(self):
         """
-        Zero out the gradients of all the parameters optimized by the optimizer.
-        Before starting a new round of gradient computation for a fresh batch of data,
-        it's necessary to zero out the gradients to prevent the gradients from being
-        added to the previous ones.
+        Zero out gradients of all parameters before starting a new backward pass.
         """
         raise NotImplementedError
 
     def optimizer_step(self):
         """
-        Perform a single optimization step.
-        This method is designed to update the model's parameters based on the computed gradients.
+        Perform an optimization step to update model parameters based on accumulated gradients.
+
+        Returns:
+            grad_norm (float): The norm of the gradients before clipping or update.
         """
         raise NotImplementedError
 
     def lr_scheduler_step(self):
         """
-        Perform a single step of the learning rate scheduler.
+        Advance the learning rate scheduler by one step.
 
-        In the process of model training, the learning rate scheduler is used to adjust 
-        the learning rate dynamically over time, which can help the model converge better.
-        This method is designed to trigger the learning rate adjustment mechanism of the scheduler.
-        For example, it can be used to decay the learning rate after a certain number of epochs 
-        or when the validation loss plateaus.
+        Returns:
+            current_lr (float or list[float]): Updated learning rate(s).
         """
         raise NotImplementedError
 
     def shard_data(self, data):
+        """
+        Shard or partition data for distributed training or parallel execution.
+
+        Args:
+            data: Data structure to be sharded across devices/workers.
+
+        Returns:
+            Sharded data in the same format as input.
+        """
         raise NotImplementedError
 
     def unshard_data(self, data):
+        """
+        Reconstruct or gather sharded data back to a unified format.
+
+        Args:
+            data: Sharded data structure to reconstruct.
+
+        Returns:
+            Unsharded, combined data.
+        """
         raise NotImplementedError
         
 
     def set_loss_fn(self, loss_fn):
         """
-        loss_fn(data, preds, ctx) -> loss, ctx
+        Set the loss function to be used during training.
+
+        Args:
+            loss_fn: Callable(data, predictions, ctx) -> (loss_tensor, new_ctx)
         """
         raise NotImplementedError
 
     def to(self, device: str, model: bool = True, optimizer: bool = True):
+        """
+        Move model parameters, optimizer states, or both to the specified device.
+
+        Args:
+            device: Target device identifier (e.g., "cuda" or "cpu").
+            model: If True, move the model.
+            optimizer: If True, move the optimizer states.
+        """
         raise NotImplementedError
 
 
     def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
+        """
+        Save model, optimizer, and scheduler states to a checkpoint.
+
+        Args:
+            local_path: Local filesystem path to save checkpoint.
+            hdfs_path: Optional HDFS path to copy checkpoint.
+            global_step: Integer training step number for naming.
+            max_ckpt_to_keep: Maximum number of recent checkpoints to retain.
+        """
         raise NotImplementedError
 
 
     def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=True):
+        """
+        Load model, optimizer, and scheduler states from a checkpoint.
+
+        Args:
+            local_path: Local filesystem path of the checkpoint.
+            hdfs_path: Optional HDFS path where checkpoint is stored.
+            del_local_after_load: Whether to delete local copy after loading.
+        """
         raise NotImplementedError

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -102,5 +102,13 @@ class BaseEngine(object):
         """
         raise NotImplementedError
 
-    def to():
+    def to(self, device: str, model: bool = True, optimizer: bool = True):
+        raise NotImplementedError
+
+
+    def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
+        raise NotImplementedError
+
+
+    def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=True):
         raise NotImplementedError

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -35,9 +35,12 @@ class BaseEngine(object):
 
     def lr_scheduler_step(self):
         raise NotImplementedError
-    
-    def sharding_manager(self):
-        pass
+
+    def shard_data(self, data):
+        raise NotImplementedError
+
+    def unshard_data(self, data):
+        raise NotImplementedError
 
     def set_preprocess_fn(self, preprocess_fn):
         """

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -1,0 +1,63 @@
+from contextlib import nullcontext
+
+"""
+TODO:
+- checkpointing
+"""
+
+class BaseEngine(object):
+    def __init__(self, config):
+        raise NotImplementedError
+
+    def init_model_and_optimizer(self):
+        raise NotImplementedError
+
+    def train_mode(self):
+        raise NotImplementedError
+
+    def eval_mode(self):
+        raise NotImplementedError
+
+    def forward_backward_step(self, batch, forward_only=False, ctx=None):
+        """
+        return
+        - preds
+        - loss
+        - out_ctx
+        """
+        raise NotImplementedError
+
+    def optimizer_zero_grad(self):
+        raise NotImplementedError
+
+    def optimizer_step(self):
+        raise NotImplementedError
+
+    def lr_scheduler_step(self):
+        raise NotImplementedError
+    
+    def sharding_manager(self):
+        pass
+
+    def set_preprocess_fn(self, preprocess_fn):
+        """
+        preprocess_fn(data, ctx) -> inputs, ctx
+        """
+        raise NotImplementedError
+
+
+    def set_postprocess_fn(self, postprocess_fn):
+        """
+        postprocess_fn(outputs, ctx) -> preds, ctx
+        """
+        raise NotImplementedError
+        
+
+    def set_loss_fn(self, loss_fn):
+        """
+        loss_fn(data, preds, ctx) -> loss, out_ctx
+        """
+        raise NotImplementedError
+
+    def to():
+        raise NotImplementedError

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -7,15 +7,36 @@ TODO:
 
 class BaseEngine(object):
     def __init__(self, config):
+        """
+        Initialize the BaseEngine instance.
+
+        This method serves as the constructor for the BaseEngine class. BaseEngine 
+        is likely an abstract base class.
+
+        Args:
+            config: A configuration object containing parameters and settings
+                    required for initializing the engine.
+        """
         raise NotImplementedError
 
     def init_model_and_optimizer(self):
+        """
+        Initialize the model and its corresponding optimizer.
+        """
         raise NotImplementedError
 
     def train_mode(self):
+        """
+        Set the engine to training mode. This method is designed to switch the engine 
+        and its associated model(s) into training mode. 
+        """
         raise NotImplementedError
 
     def eval_mode(self):
+        """
+        Set the engine to eval mode. This method is designed to switch the engine 
+        and its associated model(s) into eval mode. 
+        """
         raise NotImplementedError
 
     def forward_backward_step(self, batch, forward_only=False, ctx=None):
@@ -28,12 +49,31 @@ class BaseEngine(object):
         raise NotImplementedError
 
     def optimizer_zero_grad(self):
+        """
+        Zero out the gradients of all the parameters optimized by the optimizer.
+        Before starting a new round of gradient computation for a fresh batch of data,
+        it's necessary to zero out the gradients to prevent the gradients from being
+        added to the previous ones.
+        """
         raise NotImplementedError
 
     def optimizer_step(self):
+        """
+        Perform a single optimization step.
+        This method is designed to update the model's parameters based on the computed gradients.
+        """
         raise NotImplementedError
 
     def lr_scheduler_step(self):
+        """
+        Perform a single step of the learning rate scheduler.
+
+        In the process of model training, the learning rate scheduler is used to adjust 
+        the learning rate dynamically over time, which can help the model converge better.
+        This method is designed to trigger the learning rate adjustment mechanism of the scheduler.
+        For example, it can be used to decay the learning rate after a certain number of epochs 
+        or when the validation loss plateaus.
+        """
         raise NotImplementedError
 
     def shard_data(self, data):

--- a/verl/workers/engine/fsdp/__init__.py
+++ b/verl/workers/engine/fsdp/__init__.py
@@ -1,0 +1,3 @@
+from .engine_impl import FSDPEngine
+
+__all__ = ["FSDPEngine"]

--- a/verl/workers/engine/fsdp/engine_impl.py
+++ b/verl/workers/engine/fsdp/engine_impl.py
@@ -91,7 +91,7 @@ class EngineEvalModeCtx:
 
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.engine.ulysses_sharding_manager.__exit__()
+        self.engine.ulysses_sharding_manager.__exit__(exc_type, exc_value, traceback)
         if self.engine._is_offload_param:
             offload_fsdp_model_to_cpu(self.engine.critic_module)
         self.engine.mode = None
@@ -356,19 +356,24 @@ class FSDPEngine(object):
 
     def eval_mode(self):
         return EngineEvalModeCtx(self)
+    
+    def shard_data(self, data):
+        return self.ulysses_sharding_manager.preprocess_data(data)
 
+    def unshard_data(self, data):
+        return self.ulysses_sharding_manager.postprocess_data(data)
 
-    def sharding_manager(self):
-        return self.ulysses_sharding_manager
-
-    def forward_backward_step(self, batch, forward_only=False, ctx={}):
+    def forward_backward_step(self, batch, ctx=None, forward_only=False):
         """
         return
         - preds
         - loss
         - out_ctx
         """
-        raise NotImplementedError
+        inputs, ctx = self.preprocess_fn(batch, ctx)
+        outputs = self.critic_module(**inputs)
+        preds, ctx = self.postprocess_fn(outputs, ctx)
+        return preds
 
     def optimizer_zero_grad(self):
         raise NotImplementedError
@@ -379,18 +384,19 @@ class FSDPEngine(object):
     def lr_scheduler_step(self):
         raise NotImplementedError
 
+
     def set_preprocess_fn(self, preprocess_fn):
         """
         preprocess_fn(data, ctx) -> inputs, ctx
         """
-        raise NotImplementedError
+        self.preprocess_fn = preprocess_fn
 
 
     def set_postprocess_fn(self, postprocess_fn):
         """
         postprocess_fn(outputs, ctx) -> preds, ctx
         """
-        raise NotImplementedError
+        self.postprocess_fn = postprocess_fn
         
 
     def set_loss_fn(self, loss_fn):

--- a/verl/workers/engine/fsdp/engine_impl.py
+++ b/verl/workers/engine/fsdp/engine_impl.py
@@ -4,9 +4,8 @@ import logging
 import os
 import warnings
 from dataclasses import asdict
-from typing import Union
+import gc
 
-import psutil
 import torch
 import torch.distributed
 import torch.distributed as dist
@@ -134,8 +133,6 @@ class FSDPEngine(object):
         # This is used to import external_lib into the huggingface systems
         import_external_libs(self.config.model.get("external_lib", None))
 
-        # from verl.workers.critic import DataParallelPPOCritic
-
         self.critic_module, self.critic_optimizer, self.critic_lr_scheduler = self._build_critic_model_optimizer(self.config)
 
         if self._is_offload_param:
@@ -144,8 +141,6 @@ class FSDPEngine(object):
         if self._is_offload_optimizer:
             offload_fsdp_optimizer(optimizer=self.critic_optimizer)
             log_gpu_memory_usage("After offload critic optimizer during init", logger=logger)
-
-        # self.critic = DataParallelPPOCritic(config=self.config, critic_module=self.critic_module, critic_optimizer=self.critic_optimizer)
 
         self.flops_counter = FlopsCounter(self.critic_model_config)
         self.checkpoint_manager = FSDPCheckpointManager(
@@ -423,5 +418,52 @@ class FSDPEngine(object):
         """
         self.loss_fn = loss_fn
 
-    def to():
-        pass
+
+    def to(self, device: str, model: bool = True, optimizer: bool = True):
+        """
+        move model to device.
+        """
+        assert device in ("cuda", "cpu")
+        if device == "cuda":
+            if not self.config.model.fsdp_config.param_offload:
+                if model:
+                    load_fsdp_model_to_gpu(self.model_module)
+                if optimizer and self.optimizer is not None:
+                    load_fsdp_optimizer(self.optimizer, device)
+            gc.collect()
+        elif device == "cpu":
+            if not self.config.model.fsdp_config.param_offload:
+                if model:
+                    offload_fsdp_model_to_cpu(self.model_module)
+                if optimizer and self.optimizer is not None:
+                    offload_fsdp_optimizer(self.optimizer)
+        else:
+            raise ValueError(f"Invalid device type: {device}")
+
+
+
+    def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
+        if self._is_offload_param:
+            load_fsdp_model_to_gpu(self.critic_module)
+
+        self.checkpoint_manager.save_checkpoint(local_path=local_path, hdfs_path=hdfs_path, global_step=global_step, max_ckpt_to_keep=max_ckpt_to_keep)
+
+        torch.distributed.barrier()
+        if self._is_offload_param:
+            offload_fsdp_model_to_cpu(self.critic_module)
+
+
+    def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=True):
+        import torch
+
+        if self._is_offload_param:
+            load_fsdp_model_to_gpu(self.critic_module)
+
+        self.checkpoint_manager.load_checkpoint(local_path=local_path, hdfs_path=hdfs_path, del_local_after_load=del_local_after_load)
+
+        torch.distributed.barrier()
+        if self._is_offload_param:
+            offload_fsdp_model_to_cpu(self.critic_module)
+
+        if self._is_offload_optimizer:
+            offload_fsdp_optimizer(self.critic_optimizer)

--- a/verl/workers/engine/fsdp/engine_impl.py
+++ b/verl/workers/engine/fsdp/engine_impl.py
@@ -1,0 +1,403 @@
+
+import json
+import logging
+import os
+import warnings
+from dataclasses import asdict
+from typing import Union
+
+import psutil
+import torch
+import torch.distributed
+import torch.distributed as dist
+from codetiming import Timer
+from omegaconf import DictConfig, open_dict
+from peft import LoraConfig, TaskType, get_peft_model
+from safetensors.torch import save_file
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+import verl.utils.torch_functional as verl_F
+from verl import DataProto
+from verl.models.transformers.monkey_patch import apply_monkey_patch
+from verl.single_controller.base import Worker
+from verl.single_controller.base.decorator import Dispatch, register
+from verl.utils import hf_processor, hf_tokenizer
+from verl.utils.activation_offload import enable_activation_offloading
+from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
+from verl.utils.debug import log_gpu_memory_usage
+from verl.utils.debug.performance import _timer, reduce_timing
+from verl.utils.device import get_device_name, get_torch_device, is_cuda_available, is_npu_available
+from verl.utils.flops_counter import FlopsCounter
+from verl.utils.fs import copy_to_local
+from verl.utils.fsdp_utils import (
+    CPUOffloadPolicy,
+    MixedPrecisionPolicy,
+    apply_fsdp2,
+    fsdp2_load_full_state_dict,
+    fsdp_version,
+    get_fsdp_wrap_policy,
+    get_init_weight_context_manager,
+    init_fn,
+    layered_summon_lora_params,
+    load_fsdp_model_to_gpu,
+    load_fsdp_optimizer,
+    offload_fsdp_model_to_cpu,
+    offload_fsdp_optimizer,
+)
+from verl.utils.import_utils import import_external_libs
+from verl.utils.model import compute_position_id_with_mask
+from verl.utils.py_functional import convert_to_regular_types
+from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+device_name = get_device_name()
+
+
+def create_device_mesh(world_size, fsdp_size):
+    if fsdp_size < 0 or fsdp_size >= world_size:
+        device_mesh = init_device_mesh(device_name, mesh_shape=(world_size,), mesh_dim_names=["fsdp"])
+    else:
+        device_mesh = init_device_mesh(device_name, mesh_shape=(world_size // fsdp_size, fsdp_size), mesh_dim_names=["ddp", "fsdp"])
+    return device_mesh
+
+
+def get_sharding_strategy(device_mesh):
+    from torch.distributed.fsdp import ShardingStrategy
+
+    if device_mesh.ndim == 1:
+        sharding_strategy = ShardingStrategy.FULL_SHARD
+    elif device_mesh.ndim == 2:
+        sharding_strategy = ShardingStrategy.HYBRID_SHARD
+    else:
+        raise NotImplementedError(f"Get device mesh ndim={device_mesh.ndim}, but only support 1 or 2")
+    return sharding_strategy
+
+
+
+class EngineEvalModeCtx:
+    def __init__(self, engine):
+        self.engine = engine
+    
+    def __enter__(self):
+        self.engine.mode = "eval"
+        if self.engine._is_offload_param:
+            load_fsdp_model_to_gpu(self.engine.critic_module)
+
+        self.engine.ulysses_sharding_manager.__enter__()
+        self.engine.critic_module.eval()
+
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.engine.ulysses_sharding_manager.__exit__()
+        if self.engine._is_offload_param:
+            offload_fsdp_model_to_cpu(self.engine.critic_module)
+        self.engine.mode = None
+        
+
+class EngineTrainModeCtx:
+    def __init__(self, engine):
+        self.engine = engine
+    
+    
+    def __enter__(self):
+        self.engine.mode = "train"
+        if self.engine._is_offload_param:
+            load_fsdp_model_to_gpu(self.engine.critic_module)
+        if self.engine._is_offload_optimizer:
+            load_fsdp_optimizer(optimizer=self.engine.critic_optimizer, device_id=torch.cuda.current_device())
+
+        self.engine.ulysses_sharding_manager.__enter__()
+        self.engine.critic_module.train()
+
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.engine.ulysses_sharding_manager.__exit__(exc_type, exc_value, traceback)
+
+        if self.engine._is_offload_param:
+            offload_fsdp_model_to_cpu(self.engine.critic_module)
+        if self.engine._is_offload_optimizer:
+            load_fsdp_optimizer(optimizer=self.engine.critic_optimizer, device_id=torch.cuda.current_device())
+        self.engine.mode = None
+
+
+
+class FSDPEngine(object):
+    def __init__(self, config):
+        self.config = config
+        self.rank = torch.distributed.get_rank()
+        # build device mesh for Ulysses Sequence Parallel
+        world_size = torch.distributed.get_world_size()
+        from torch.distributed.device_mesh import init_device_mesh
+
+        fsdp_size = self.config.model.fsdp_config.fsdp_size
+        self.device_mesh = create_device_mesh(world_size=world_size, fsdp_size=fsdp_size)
+
+        self.ulysses_device_mesh = None
+        self.ulysses_sequence_parallel_size = self.config.get("ulysses_sequence_parallel_size", 1)
+        dp = world_size // self.ulysses_sequence_parallel_size
+        if self.ulysses_sequence_parallel_size > 1:
+            self.ulysses_device_mesh = init_device_mesh(device_name, mesh_shape=(dp, self.ulysses_sequence_parallel_size), mesh_dim_names=["dp", "sp"])
+
+        self.ulysses_sharding_manager = FSDPUlyssesShardingManager(self.ulysses_device_mesh)        
+        self._is_lora = self.config.model.get("lora_rank", 0) > 0
+        # set FSDP offload params
+        self._is_offload_param = self.config.model.fsdp_config.param_offload
+        self._is_offload_optimizer = self.config.model.fsdp_config.optimizer_offload
+
+
+    def init_model_and_optimizer(self):
+        # This is used to import external_lib into the huggingface systems
+        import_external_libs(self.config.model.get("external_lib", None))
+
+        # from verl.workers.critic import DataParallelPPOCritic
+
+        self.critic_module, self.critic_optimizer, self.critic_lr_scheduler = self._build_critic_model_optimizer(self.config)
+
+        if self._is_offload_param:
+            offload_fsdp_model_to_cpu(self.critic_module)
+            log_gpu_memory_usage("After offload critic model during init", logger=logger)
+        if self._is_offload_optimizer:
+            offload_fsdp_optimizer(optimizer=self.critic_optimizer)
+            log_gpu_memory_usage("After offload critic optimizer during init", logger=logger)
+
+        # self.critic = DataParallelPPOCritic(config=self.config, critic_module=self.critic_module, critic_optimizer=self.critic_optimizer)
+
+        self.flops_counter = FlopsCounter(self.critic_model_config)
+        self.checkpoint_manager = FSDPCheckpointManager(
+            model=self.critic_module,
+            optimizer=self.critic_optimizer,
+            lr_scheduler=self.critic_lr_scheduler,
+            processing_class=self.processor if self.processor is not None else self.tokenizer,
+            checkpoint_contents=self.config.checkpoint.contents,
+        )
+    
+    def _build_critic_model_optimizer(self, config):
+        # the following line is necessary
+        from torch import optim
+        from torch.distributed.fsdp import MixedPrecision
+
+        from verl.utils.model import load_valuehead_model, print_model_size
+        from verl.utils.torch_dtypes import PrecisionType
+
+        use_shm = config.model.get("use_shm", False)
+        local_path = copy_to_local(config.model.path, use_shm=use_shm)
+        # note that the tokenizer between actor and critic may be different. So override tokenizer info with actor info
+        # using random initialized model from any architecture. May not be the same as Actor.
+
+        tokenizer_path = copy_to_local(config.model.tokenizer_path, use_shm=use_shm)
+        self.tokenizer = hf_tokenizer(tokenizer_path, trust_remote_code=config.model.get("trust_remote_code", False))
+        self.processor = hf_processor(tokenizer_path, trust_remote_code=config.model.get("trust_remote_code", False))
+
+        from omegaconf import OmegaConf
+
+        override_config = OmegaConf.to_container(self.config.model.get("override_config", OmegaConf.create()))
+        override_config_kwargs = {
+            "bos_token_id": self.tokenizer.bos_token_id,
+            "eos_token_id": self.tokenizer.eos_token_id,
+            "pad_token_id": self.tokenizer.pad_token_id,
+        }
+        override_config_kwargs.update(override_config)
+        if self.rank == 0:
+            print(f"Critic overriding config {override_config_kwargs}")
+
+        torch_dtype = self.config.model.fsdp_config.get("model_dtype", "fp32")
+        torch_dtype = PrecisionType.to_dtype(torch_dtype)
+
+        from transformers import AutoConfig, AutoModelForTokenClassification
+
+        critic_model_config = AutoConfig.from_pretrained(local_path, attn_implementation="flash_attention_2", trust_remote_code=config.model.get("trust_remote_code", False))
+        critic_model_config.num_labels = 1
+        # patch for kimi-vl
+        if getattr(critic_model_config, "model_type", None) == "kimi_vl":
+            critic_model_config.text_config.topk_method = "greedy"
+
+        init_context = get_init_weight_context_manager(use_meta_tensor=not critic_model_config.tie_word_embeddings, mesh=self.device_mesh)
+
+        with init_context(), warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            critic_model_config.classifier_dropout = 0.0
+            critic_model_config.hidden_dropout = "0"
+            critic_model_config.summary_dropout_prob = 0.0
+
+            critic_module = load_valuehead_model(
+                local_path,
+                torch_dtype,
+                critic_model_config,
+                config.model.get("trust_remote_code", False),
+            )
+
+            use_remove_padding = config.model.get("use_remove_padding", False)
+
+            apply_monkey_patch(
+                model=critic_module,
+                use_remove_padding=use_remove_padding,
+                ulysses_sp_size=self.ulysses_sequence_parallel_size,
+            )
+
+            # some parameters may not in torch_dtype
+            critic_module.to(torch_dtype)
+
+            if config.model.get("enable_gradient_checkpointing", False):
+                critic_module.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+
+        if self._is_lora:
+            print("Applying LoRA to critic module")
+            critic_module.enable_input_require_grads()
+            # Convert config to regular Python types before creating PEFT model
+            lora_config = {
+                "task_type": TaskType.CAUSAL_LM,
+                "r": self.config.model.lora_rank,
+                "lora_alpha": self.config.model.lora_alpha,
+                "target_modules": convert_to_regular_types(self.config.model.target_modules),
+                "bias": "none",
+            }
+            critic_module = get_peft_model(critic_module, LoraConfig(**lora_config))
+
+        if self.rank == 0:
+            print_model_size(critic_module)
+
+        self.critic_model_config = critic_model_config
+
+        fsdp_config = self.config.model.fsdp_config
+        mixed_precision_config = fsdp_config.get("mixed_precision", None)
+        if mixed_precision_config is not None:
+            param_dtype = PrecisionType.to_dtype(mixed_precision_config.get("param_dtype", "bf16"))
+            reduce_dtype = PrecisionType.to_dtype(mixed_precision_config.get("reduce_dtype", "fp32"))
+            buffer_dtype = PrecisionType.to_dtype(mixed_precision_config.get("buffer_dtype", "fp32"))
+        else:
+            param_dtype = torch.bfloat16
+            reduce_dtype = torch.float32
+            buffer_dtype = torch.float32
+
+        mixed_precision = MixedPrecision(param_dtype=param_dtype, reduce_dtype=reduce_dtype, buffer_dtype=buffer_dtype)
+
+        auto_wrap_policy = get_fsdp_wrap_policy(module=critic_module, config=self.config.model.fsdp_config.wrap_policy, is_lora=self.config.model.get("lora_rank", 0) > 0)
+
+        log_gpu_memory_usage("Before critic FSDP", logger=None)
+
+        fsdp_mesh = self.device_mesh
+        sharding_strategy = get_sharding_strategy(fsdp_mesh)
+
+        # Note: We force turn off CPUOffload for critic because it causes incorrect results when using grad accumulation
+        if config.strategy == "fsdp":
+            critic_module = FSDP(
+                critic_module,
+                param_init_fn=init_fn,
+                use_orig_params=False,
+                auto_wrap_policy=auto_wrap_policy,
+                device_id=get_torch_device().current_device(),
+                sharding_strategy=sharding_strategy,
+                mixed_precision=mixed_precision,
+                sync_module_states=True,
+                forward_prefetch=False,
+                device_mesh=self.device_mesh,
+                cpu_offload=None,
+            )
+        elif config.strategy == "fsdp2":
+            assert CPUOffloadPolicy is not None, "PyTorch version >= 2.4 is required for using fully_shard API (FSDP2)"
+            mp_policy = MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype, cast_forward_inputs=True)
+            offload_policy = None
+            if fsdp_config.offload_policy:
+                self._is_offload_param = False
+                self._is_offload_optimizer = False
+                offload_policy = CPUOffloadPolicy(pin_memory=True)
+
+            fsdp_kwargs = {
+                "mesh": fsdp_mesh,
+                "mp_policy": mp_policy,
+                "offload_policy": offload_policy,
+                "reshard_after_forward": fsdp_config.reshard_after_forward,
+            }
+            full_state = critic_module.state_dict()
+            apply_fsdp2(critic_module, fsdp_kwargs, fsdp_config)
+            fsdp2_load_full_state_dict(critic_module, full_state, fsdp_mesh, offload_policy)
+        else:
+            raise NotImplementedError(f"Unknown strategy {config.strategy}")
+
+        if config.model.get("enable_activation_offload", False):
+            enable_gradient_checkpointing = config.model.get("enable_gradient_checkpointing", False)
+            enable_activation_offloading(critic_module, config.strategy, enable_gradient_checkpointing)
+
+        log_gpu_memory_usage("After critic FSDP", logger=None)
+
+        critic_optimizer = optim.AdamW(
+            critic_module.parameters(),
+            lr=config.optim.lr,
+            betas=config.optim.get("betas", (0.9, 0.999)),
+            weight_decay=config.optim.get("weight_decay", 1e-2),
+        )
+
+        total_steps = config.optim.get("total_training_steps", 0)
+        num_warmup_steps = int(config.optim.get("lr_warmup_steps", -1))
+        warmup_style = config.optim.get("warmup_style", "constant")
+        if num_warmup_steps < 0:
+            num_warmup_steps_ratio = config.optim.get("lr_warmup_steps_ratio", 0.0)
+            num_warmup_steps = int(num_warmup_steps_ratio * total_steps)
+
+        if self.rank == 0:
+            print(f"Total steps: {total_steps}, num_warmup_steps: {num_warmup_steps}")
+
+        from verl.utils.torch_functional import get_constant_schedule_with_warmup, get_cosine_schedule_with_warmup
+
+        if warmup_style == "constant":
+            critic_lr_scheduler = get_constant_schedule_with_warmup(optimizer=critic_optimizer, num_warmup_steps=num_warmup_steps)
+        elif warmup_style == "cosine":
+            critic_lr_scheduler = get_cosine_schedule_with_warmup(optimizer=critic_optimizer, num_warmup_steps=num_warmup_steps, num_training_steps=total_steps)
+        else:
+            raise NotImplementedError(f"Warmup style {warmup_style} is not supported")
+
+        return critic_module, critic_optimizer, critic_lr_scheduler
+
+    def train_mode(self):
+        return EngineTrainModeCtx(self)
+
+    def eval_mode(self):
+        return EngineEvalModeCtx(self)
+
+
+    def sharding_manager(self):
+        return self.ulysses_sharding_manager
+
+    def forward_backward_step(self, batch, forward_only=False, ctx={}):
+        """
+        return
+        - preds
+        - loss
+        - out_ctx
+        """
+        raise NotImplementedError
+
+    def optimizer_zero_grad(self):
+        raise NotImplementedError
+
+    def optimizer_step(self):
+        raise NotImplementedError
+
+    def lr_scheduler_step(self):
+        raise NotImplementedError
+
+    def set_preprocess_fn(self, preprocess_fn):
+        """
+        preprocess_fn(data, ctx) -> inputs, ctx
+        """
+        raise NotImplementedError
+
+
+    def set_postprocess_fn(self, postprocess_fn):
+        """
+        postprocess_fn(outputs, ctx) -> preds, ctx
+        """
+        raise NotImplementedError
+        
+
+    def set_loss_fn(self, loss_fn):
+        """
+        loss_fn(data, preds, ctx) -> loss, out_ctx
+        """
+        raise NotImplementedError
+
+    def to():
+        pass

--- a/verl/workers/engine/fsdp/engine_impl.py
+++ b/verl/workers/engine/fsdp/engine_impl.py
@@ -14,7 +14,6 @@ from codetiming import Timer
 from omegaconf import DictConfig, open_dict
 from peft import LoraConfig, TaskType, get_peft_model
 from safetensors.torch import save_file
-from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 import verl.utils.torch_functional as verl_F
@@ -49,31 +48,14 @@ from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.py_functional import convert_to_regular_types
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
+from verl.utils.fsdp_utils import FSDPModule, fsdp2_clip_grad_norm_
+from .utils import create_device_mesh, get_sharding_strategy
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 device_name = get_device_name()
 
-
-def create_device_mesh(world_size, fsdp_size):
-    if fsdp_size < 0 or fsdp_size >= world_size:
-        device_mesh = init_device_mesh(device_name, mesh_shape=(world_size,), mesh_dim_names=["fsdp"])
-    else:
-        device_mesh = init_device_mesh(device_name, mesh_shape=(world_size // fsdp_size, fsdp_size), mesh_dim_names=["ddp", "fsdp"])
-    return device_mesh
-
-
-def get_sharding_strategy(device_mesh):
-    from torch.distributed.fsdp import ShardingStrategy
-
-    if device_mesh.ndim == 1:
-        sharding_strategy = ShardingStrategy.FULL_SHARD
-    elif device_mesh.ndim == 2:
-        sharding_strategy = ShardingStrategy.HYBRID_SHARD
-    else:
-        raise NotImplementedError(f"Get device mesh ndim={device_mesh.ndim}, but only support 1 or 2")
-    return sharding_strategy
 
 
 
@@ -107,7 +89,7 @@ class EngineTrainModeCtx:
         if self.engine._is_offload_param:
             load_fsdp_model_to_gpu(self.engine.critic_module)
         if self.engine._is_offload_optimizer:
-            load_fsdp_optimizer(optimizer=self.engine.critic_optimizer, device_id=torch.cuda.current_device())
+            load_fsdp_optimizer(optimizer=self.engine.critic_optimizer, device_id=get_torch_device().current_device())
 
         self.engine.ulysses_sharding_manager.__enter__()
         self.engine.critic_module.train()
@@ -119,7 +101,7 @@ class EngineTrainModeCtx:
         if self.engine._is_offload_param:
             offload_fsdp_model_to_cpu(self.engine.critic_module)
         if self.engine._is_offload_optimizer:
-            load_fsdp_optimizer(optimizer=self.engine.critic_optimizer, device_id=torch.cuda.current_device())
+            offload_fsdp_optimizer(optimizer=self.critic_optimizer)
         self.engine.mode = None
 
 
@@ -351,38 +333,73 @@ class FSDPEngine(object):
 
         return critic_module, critic_optimizer, critic_lr_scheduler
 
+
     def train_mode(self):
         return EngineTrainModeCtx(self)
+
 
     def eval_mode(self):
         return EngineEvalModeCtx(self)
     
+
     def shard_data(self, data):
         return self.ulysses_sharding_manager.preprocess_data(data)
+
 
     def unshard_data(self, data):
         return self.ulysses_sharding_manager.postprocess_data(data)
 
-    def forward_backward_step(self, batch, ctx=None, forward_only=False):
-        """
-        return
-        - preds
-        - loss
-        - out_ctx
-        """
+
+    def forward_backward_step(self, 
+                              batch, 
+                              ctx=None, 
+                              forward_only=False, 
+                              preprocess_fn=None, 
+                              postprocess_fn=None):
+        assert self.mode is not None
+        if self.mode == "train":
+            assert forward_only == False
+        elif self.mode == "eval":
+            assert forward_only ==True
+
         inputs, ctx = self.preprocess_fn(batch, ctx)
         outputs = self.critic_module(**inputs)
         preds, ctx = self.postprocess_fn(outputs, ctx)
-        return preds
+        if forward_only:
+            return preds, ctx
+
+        loss, ctx = self.loss_fn(batch, preds, ctx)
+        loss.backward()
+        return preds, loss, ctx
+
 
     def optimizer_zero_grad(self):
-        raise NotImplementedError
+        self.critic_optimizer.zero_grad()
+
 
     def optimizer_step(self):
-        raise NotImplementedError
+        assert self.config.grad_clip is not None
+
+        if isinstance(self.critic_module, FSDP):
+            grad_norm = self.critic_module.clip_grad_norm_(self.config.grad_clip)
+        elif isinstance(self.critic_module, FSDPModule):
+            grad_norm = fsdp2_clip_grad_norm_(self.critic_module.parameters(), max_norm=self.config.grad_clip)
+        else:
+            grad_norm = torch.nn.utils.clip_grad_norm_(self.critic_module.parameters(), max_norm=self.config.grad_clip)
+
+        # if grad_norm is not finite, skip the update
+        if not torch.isfinite(grad_norm):
+            print(f"WARN: grad_norm is not finite: {grad_norm}")
+            self.critic_optimizer.zero_grad()
+        else:
+            self.critic_optimizer.step()
+        return grad_norm
+
 
     def lr_scheduler_step(self):
-        raise NotImplementedError
+        self.critic_lr_scheduler.step()
+        lr = self.critic_lr_scheduler.get_last_lr()
+        return lr
 
 
     def set_preprocess_fn(self, preprocess_fn):
@@ -403,7 +420,7 @@ class FSDPEngine(object):
         """
         loss_fn(data, preds, ctx) -> loss, out_ctx
         """
-        raise NotImplementedError
+        self.loss_fn = loss_fn
 
     def to():
         pass

--- a/verl/workers/engine/fsdp/engine_impl.py
+++ b/verl/workers/engine/fsdp/engine_impl.py
@@ -1,31 +1,36 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The concrete Engine implementation using PyTorch FullyShardedDataParallel (FSDP)
+"""
 
-import json
 import logging
 import os
 import warnings
-from dataclasses import asdict
 import gc
 
 import torch
 import torch.distributed
-import torch.distributed as dist
-from codetiming import Timer
-from omegaconf import DictConfig, open_dict
 from peft import LoraConfig, TaskType, get_peft_model
-from safetensors.torch import save_file
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-import verl.utils.torch_functional as verl_F
-from verl import DataProto
 from verl.models.transformers.monkey_patch import apply_monkey_patch
-from verl.single_controller.base import Worker
-from verl.single_controller.base.decorator import Dispatch, register
 from verl.utils import hf_processor, hf_tokenizer
 from verl.utils.activation_offload import enable_activation_offloading
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.utils.debug import log_gpu_memory_usage
-from verl.utils.debug.performance import _timer, reduce_timing
-from verl.utils.device import get_device_name, get_torch_device, is_cuda_available, is_npu_available
+from verl.utils.device import get_device_name, get_torch_device
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.fs import copy_to_local
 from verl.utils.fsdp_utils import (
@@ -33,18 +38,15 @@ from verl.utils.fsdp_utils import (
     MixedPrecisionPolicy,
     apply_fsdp2,
     fsdp2_load_full_state_dict,
-    fsdp_version,
     get_fsdp_wrap_policy,
     get_init_weight_context_manager,
     init_fn,
-    layered_summon_lora_params,
     load_fsdp_model_to_gpu,
     load_fsdp_optimizer,
     offload_fsdp_model_to_cpu,
     offload_fsdp_optimizer,
 )
 from verl.utils.import_utils import import_external_libs
-from verl.utils.model import compute_position_id_with_mask
 from verl.utils.py_functional import convert_to_regular_types
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
 from verl.utils.fsdp_utils import FSDPModule, fsdp2_clip_grad_norm_
@@ -53,60 +55,23 @@ from .utils import create_device_mesh, get_sharding_strategy
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
-device_name = get_device_name()
-
-
-
-
-class EngineEvalModeCtx:
-    def __init__(self, engine):
-        self.engine = engine
-    
-    def __enter__(self):
-        self.engine.mode = "eval"
-        if self.engine._is_offload_param:
-            load_fsdp_model_to_gpu(self.engine.module)
-
-        self.engine.ulysses_sharding_manager.__enter__()
-        self.engine.module.eval()
-
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.engine.ulysses_sharding_manager.__exit__(exc_type, exc_value, traceback)
-        if self.engine._is_offload_param:
-            offload_fsdp_model_to_cpu(self.engine.module)
-        self.engine.mode = None
-        
-
-class EngineTrainModeCtx:
-    def __init__(self, engine):
-        self.engine = engine
-    
-    
-    def __enter__(self):
-        self.engine.mode = "train"
-        if self.engine._is_offload_param:
-            load_fsdp_model_to_gpu(self.engine.module)
-        if self.engine._is_offload_optimizer:
-            load_fsdp_optimizer(optimizer=self.engine.optimizer, device_id=get_torch_device().current_device())
-
-        self.engine.ulysses_sharding_manager.__enter__()
-        self.engine.module.train()
-
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.engine.ulysses_sharding_manager.__exit__(exc_type, exc_value, traceback)
-
-        if self.engine._is_offload_param:
-            offload_fsdp_model_to_cpu(self.engine.module)
-        if self.engine._is_offload_optimizer:
-            offload_fsdp_optimizer(optimizer=self.optimizer)
-        self.engine.mode = None
-
 
 
 class FSDPEngine(object):
+    """
+    Concrete Engine implementation using PyTorch FullyShardedDataParallel (FSDP).
+
+    Supports model sharding, activation/optimizer offloading, LoRA, and sequence parallelism.
+    """
     def __init__(self, config):
+        """
+        Initialize the FSDPEngine.
+
+        Sets up distributed device meshes, LoRA, and offload policies based on config.
+
+        Args:
+            config: Configuration object with FSDP and model settings.
+        """
         self.config = config
         self.rank = torch.distributed.get_rank()
         # build device mesh for Ulysses Sequence Parallel
@@ -120,6 +85,7 @@ class FSDPEngine(object):
         self.ulysses_sequence_parallel_size = self.config.get("ulysses_sequence_parallel_size", 1)
         dp = world_size // self.ulysses_sequence_parallel_size
         if self.ulysses_sequence_parallel_size > 1:
+            device_name = get_device_name()
             self.ulysses_device_mesh = init_device_mesh(device_name, mesh_shape=(dp, self.ulysses_sequence_parallel_size), mesh_dim_names=["dp", "sp"])
 
         self.ulysses_sharding_manager = FSDPUlyssesShardingManager(self.ulysses_device_mesh)        
@@ -130,6 +96,12 @@ class FSDPEngine(object):
 
 
     def init_model(self):
+        """
+        Build the model, optimizer, and learning rate scheduler under FSDP.
+
+        Applies device, dtype, and precision configurations, including mixed precision.
+        Sets up checkpoint manager and FLOPs counter.
+        """
         # This is used to import external_lib into the huggingface systems
         import_external_libs(self.config.model.get("external_lib", None))
 
@@ -330,18 +302,34 @@ class FSDPEngine(object):
 
 
     def train_mode(self):
+        """
+        Return a context manager that switches to training mode with FSDP-specific handling.
+
+        Includes parameter and optimizer offload entry/exit.
+        """
         return EngineTrainModeCtx(self)
 
 
     def eval_mode(self):
+        """
+        Return a context manager that switches to evaluation mode with FSDP-specific handling.
+
+        Includes activation offload entry/exit.
+        """
         return EngineEvalModeCtx(self)
     
 
     def shard_data(self, data):
+        """
+        Preprocess data into sharded format via UlyssesShardingManager.
+        """
         return self.ulysses_sharding_manager.preprocess_data(data)
 
 
     def unshard_data(self, data):
+        """
+        Postprocess data from sharded format back to full format.
+        """
         return self.ulysses_sharding_manager.postprocess_data(data)
 
 
@@ -351,6 +339,22 @@ class FSDPEngine(object):
                               forward_only=False, 
                               preprocess_fn=None, 
                               postprocess_fn=None):
+        """
+        Perform forward (and backward if training) pass using the FSDP-wrapped module.
+
+        Args:
+            batch: Raw batch data (e.g., tensors or mappings) to process.
+            ctx: Optional context dict passed to preprocess/postprocess functions.
+            forward_only: If True, skip gradient computation and backward pass.
+            preprocess_fn: Function(batch, ctx) -> (inputs, ctx), applied before model call.
+            postprocess_fn: Function(outputs, ctx) -> (predictions, ctx), applied after model call.
+
+        Returns:
+            If forward_only:
+                (predictions, ctx)
+            Else:
+                (predictions, loss, ctx)
+        """
         # mode guard to check this method is called in a proper context manager
         assert self.mode is not None
         if self.mode == "train":
@@ -385,10 +389,19 @@ class FSDPEngine(object):
 
 
     def optimizer_zero_grad(self):
+        """
+        Zero gradients and enforce FSDP grad-clipping logic.
+        """
         self.optimizer.zero_grad()
 
 
-    def optimizer_step(self):
+    def optimizer_step(self):        
+        """
+        Clip gradients, skip update if non-finite, and step optimizer.
+
+        Returns:
+            grad_norm (float): Norm of gradients before clipping.
+        """
         assert self.config.grad_clip is not None
 
         if isinstance(self.module, FSDP):
@@ -408,6 +421,9 @@ class FSDPEngine(object):
 
 
     def lr_scheduler_step(self):
+        """
+        Advance FSDP scheduler and return updated learning rate.
+        """
         self.lr_scheduler.step()
         lr = self.lr_scheduler.get_last_lr()
         return lr
@@ -415,14 +431,17 @@ class FSDPEngine(object):
 
     def set_loss_fn(self, loss_fn):
         """
-        loss_fn(data, preds, ctx) -> loss, out_ctx
+        Register custom loss function for training.
+
+        Args:
+            loss_fn: Callable(data, preds, ctx) -> (loss_tensor, updated_ctx)
         """
         self.loss_fn = loss_fn
 
 
     def to(self, device: str, model: bool = True, optimizer: bool = True):
         """
-        move model to device.
+        Move FSDP model and/or optimizer to CPU or GPU with offload support.
         """
         assert device in ("cuda", "cpu")
         if device == "cuda":
@@ -444,6 +463,9 @@ class FSDPEngine(object):
 
 
     def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
+        """
+        Save FSDP checkpoint, handling parameter offload as needed.
+        """
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.module)
 
@@ -455,6 +477,9 @@ class FSDPEngine(object):
 
 
     def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=True):
+        """
+        Load FSDP checkpoint, restoring parameters and optimizer state.
+        """
         import torch
 
         if self._is_offload_param:
@@ -468,3 +493,49 @@ class FSDPEngine(object):
 
         if self._is_offload_optimizer:
             offload_fsdp_optimizer(self.optimizer)
+
+
+class EngineEvalModeCtx:
+    def __init__(self, engine):
+        self.engine = engine
+    
+    def __enter__(self):
+        self.engine.mode = "eval"
+        if self.engine._is_offload_param:
+            load_fsdp_model_to_gpu(self.engine.module)
+
+        self.engine.ulysses_sharding_manager.__enter__()
+        self.engine.module.eval()
+
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.engine.ulysses_sharding_manager.__exit__(exc_type, exc_value, traceback)
+        if self.engine._is_offload_param:
+            offload_fsdp_model_to_cpu(self.engine.module)
+        self.engine.mode = None
+        
+
+class EngineTrainModeCtx:
+    def __init__(self, engine):
+        self.engine = engine
+    
+    
+    def __enter__(self):
+        self.engine.mode = "train"
+        if self.engine._is_offload_param:
+            load_fsdp_model_to_gpu(self.engine.module)
+        if self.engine._is_offload_optimizer:
+            load_fsdp_optimizer(optimizer=self.engine.optimizer, device_id=get_torch_device().current_device())
+
+        self.engine.ulysses_sharding_manager.__enter__()
+        self.engine.module.train()
+
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.engine.ulysses_sharding_manager.__exit__(exc_type, exc_value, traceback)
+
+        if self.engine._is_offload_param:
+            offload_fsdp_model_to_cpu(self.engine.module)
+        if self.engine._is_offload_optimizer:
+            offload_fsdp_optimizer(optimizer=self.optimizer)
+        self.engine.mode = None

--- a/verl/workers/engine/fsdp/engine_impl.py
+++ b/verl/workers/engine/fsdp/engine_impl.py
@@ -363,6 +363,7 @@ class FSDPEngine(object):
             assert forward_only ==True
 
         inputs, ctx = self.preprocess_fn(batch, ctx)
+        inputs["use_cache"] = False
         outputs = self.critic_module(**inputs)
         preds, ctx = self.postprocess_fn(outputs, ctx)
         if forward_only:

--- a/verl/workers/engine/fsdp/engine_impl.py
+++ b/verl/workers/engine/fsdp/engine_impl.py
@@ -65,16 +65,16 @@ class EngineEvalModeCtx:
     def __enter__(self):
         self.engine.mode = "eval"
         if self.engine._is_offload_param:
-            load_fsdp_model_to_gpu(self.engine.critic_module)
+            load_fsdp_model_to_gpu(self.engine.module)
 
         self.engine.ulysses_sharding_manager.__enter__()
-        self.engine.critic_module.eval()
+        self.engine.module.eval()
 
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.engine.ulysses_sharding_manager.__exit__(exc_type, exc_value, traceback)
         if self.engine._is_offload_param:
-            offload_fsdp_model_to_cpu(self.engine.critic_module)
+            offload_fsdp_model_to_cpu(self.engine.module)
         self.engine.mode = None
         
 
@@ -86,21 +86,21 @@ class EngineTrainModeCtx:
     def __enter__(self):
         self.engine.mode = "train"
         if self.engine._is_offload_param:
-            load_fsdp_model_to_gpu(self.engine.critic_module)
+            load_fsdp_model_to_gpu(self.engine.module)
         if self.engine._is_offload_optimizer:
-            load_fsdp_optimizer(optimizer=self.engine.critic_optimizer, device_id=get_torch_device().current_device())
+            load_fsdp_optimizer(optimizer=self.engine.optimizer, device_id=get_torch_device().current_device())
 
         self.engine.ulysses_sharding_manager.__enter__()
-        self.engine.critic_module.train()
+        self.engine.module.train()
 
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.engine.ulysses_sharding_manager.__exit__(exc_type, exc_value, traceback)
 
         if self.engine._is_offload_param:
-            offload_fsdp_model_to_cpu(self.engine.critic_module)
+            offload_fsdp_model_to_cpu(self.engine.module)
         if self.engine._is_offload_optimizer:
-            offload_fsdp_optimizer(optimizer=self.critic_optimizer)
+            offload_fsdp_optimizer(optimizer=self.optimizer)
         self.engine.mode = None
 
 
@@ -133,25 +133,25 @@ class FSDPEngine(object):
         # This is used to import external_lib into the huggingface systems
         import_external_libs(self.config.model.get("external_lib", None))
 
-        self.critic_module, self.critic_optimizer, self.critic_lr_scheduler = self._build_critic_model_optimizer(self.config)
+        self.module, self.optimizer, self.lr_scheduler = self._build_model_optimizer(self.config)
 
         if self._is_offload_param:
-            offload_fsdp_model_to_cpu(self.critic_module)
-            log_gpu_memory_usage("After offload critic model during init", logger=logger)
+            offload_fsdp_model_to_cpu(self.module)
+            log_gpu_memory_usage("After offload model during init", logger=logger)
         if self._is_offload_optimizer:
-            offload_fsdp_optimizer(optimizer=self.critic_optimizer)
-            log_gpu_memory_usage("After offload critic optimizer during init", logger=logger)
+            offload_fsdp_optimizer(optimizer=self.optimizer)
+            log_gpu_memory_usage("After offload optimizer during init", logger=logger)
 
-        self.flops_counter = FlopsCounter(self.critic_model_config)
+        self.flops_counter = FlopsCounter(self.model_config)
         self.checkpoint_manager = FSDPCheckpointManager(
-            model=self.critic_module,
-            optimizer=self.critic_optimizer,
-            lr_scheduler=self.critic_lr_scheduler,
+            model=self.module,
+            optimizer=self.optimizer,
+            lr_scheduler=self.lr_scheduler,
             processing_class=self.processor if self.processor is not None else self.tokenizer,
             checkpoint_contents=self.config.checkpoint.contents,
         )
     
-    def _build_critic_model_optimizer(self, config):
+    def _build_model_optimizer(self, config):
         # the following line is necessary
         from torch import optim
         from torch.distributed.fsdp import MixedPrecision
@@ -178,51 +178,51 @@ class FSDPEngine(object):
         }
         override_config_kwargs.update(override_config)
         if self.rank == 0:
-            print(f"Critic overriding config {override_config_kwargs}")
+            print(f"Overriding config {override_config_kwargs}")
 
         torch_dtype = self.config.model.fsdp_config.get("model_dtype", "fp32")
         torch_dtype = PrecisionType.to_dtype(torch_dtype)
 
         from transformers import AutoConfig, AutoModelForTokenClassification
 
-        critic_model_config = AutoConfig.from_pretrained(local_path, attn_implementation="flash_attention_2", trust_remote_code=config.model.get("trust_remote_code", False))
-        critic_model_config.num_labels = 1
+        model_config = AutoConfig.from_pretrained(local_path, attn_implementation="flash_attention_2", trust_remote_code=config.model.get("trust_remote_code", False))
+        model_config.num_labels = 1
         # patch for kimi-vl
-        if getattr(critic_model_config, "model_type", None) == "kimi_vl":
-            critic_model_config.text_config.topk_method = "greedy"
+        if getattr(model_config, "model_type", None) == "kimi_vl":
+            model_config.text_config.topk_method = "greedy"
 
-        init_context = get_init_weight_context_manager(use_meta_tensor=not critic_model_config.tie_word_embeddings, mesh=self.device_mesh)
+        init_context = get_init_weight_context_manager(use_meta_tensor=not model_config.tie_word_embeddings, mesh=self.device_mesh)
 
         with init_context(), warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            critic_model_config.classifier_dropout = 0.0
-            critic_model_config.hidden_dropout = "0"
-            critic_model_config.summary_dropout_prob = 0.0
+            model_config.classifier_dropout = 0.0
+            model_config.hidden_dropout = "0"
+            model_config.summary_dropout_prob = 0.0
 
-            critic_module = load_valuehead_model(
+            module = load_valuehead_model(
                 local_path,
                 torch_dtype,
-                critic_model_config,
+                model_config,
                 config.model.get("trust_remote_code", False),
             )
 
             use_remove_padding = config.model.get("use_remove_padding", False)
 
             apply_monkey_patch(
-                model=critic_module,
+                model=module,
                 use_remove_padding=use_remove_padding,
                 ulysses_sp_size=self.ulysses_sequence_parallel_size,
             )
 
             # some parameters may not in torch_dtype
-            critic_module.to(torch_dtype)
+            module.to(torch_dtype)
 
             if config.model.get("enable_gradient_checkpointing", False):
-                critic_module.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+                module.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
 
         if self._is_lora:
-            print("Applying LoRA to critic module")
-            critic_module.enable_input_require_grads()
+            print("Applying LoRA to module")
+            module.enable_input_require_grads()
             # Convert config to regular Python types before creating PEFT model
             lora_config = {
                 "task_type": TaskType.CAUSAL_LM,
@@ -231,12 +231,12 @@ class FSDPEngine(object):
                 "target_modules": convert_to_regular_types(self.config.model.target_modules),
                 "bias": "none",
             }
-            critic_module = get_peft_model(critic_module, LoraConfig(**lora_config))
+            module = get_peft_model(module, LoraConfig(**lora_config))
 
         if self.rank == 0:
-            print_model_size(critic_module)
+            print_model_size(module)
 
-        self.critic_model_config = critic_model_config
+        self.model_config = model_config
 
         fsdp_config = self.config.model.fsdp_config
         mixed_precision_config = fsdp_config.get("mixed_precision", None)
@@ -251,17 +251,17 @@ class FSDPEngine(object):
 
         mixed_precision = MixedPrecision(param_dtype=param_dtype, reduce_dtype=reduce_dtype, buffer_dtype=buffer_dtype)
 
-        auto_wrap_policy = get_fsdp_wrap_policy(module=critic_module, config=self.config.model.fsdp_config.wrap_policy, is_lora=self.config.model.get("lora_rank", 0) > 0)
+        auto_wrap_policy = get_fsdp_wrap_policy(module=module, config=self.config.model.fsdp_config.wrap_policy, is_lora=self.config.model.get("lora_rank", 0) > 0)
 
-        log_gpu_memory_usage("Before critic FSDP", logger=None)
+        log_gpu_memory_usage("Before FSDP", logger=None)
 
         fsdp_mesh = self.device_mesh
         sharding_strategy = get_sharding_strategy(fsdp_mesh)
 
-        # Note: We force turn off CPUOffload for critic because it causes incorrect results when using grad accumulation
+        # Note: We force turn off CPUOffload because it causes incorrect results when using grad accumulation
         if config.strategy == "fsdp":
-            critic_module = FSDP(
-                critic_module,
+            module = FSDP(
+                module,
                 param_init_fn=init_fn,
                 use_orig_params=False,
                 auto_wrap_policy=auto_wrap_policy,
@@ -288,20 +288,20 @@ class FSDPEngine(object):
                 "offload_policy": offload_policy,
                 "reshard_after_forward": fsdp_config.reshard_after_forward,
             }
-            full_state = critic_module.state_dict()
-            apply_fsdp2(critic_module, fsdp_kwargs, fsdp_config)
-            fsdp2_load_full_state_dict(critic_module, full_state, fsdp_mesh, offload_policy)
+            full_state = module.state_dict()
+            apply_fsdp2(module, fsdp_kwargs, fsdp_config)
+            fsdp2_load_full_state_dict(module, full_state, fsdp_mesh, offload_policy)
         else:
             raise NotImplementedError(f"Unknown strategy {config.strategy}")
 
         if config.model.get("enable_activation_offload", False):
             enable_gradient_checkpointing = config.model.get("enable_gradient_checkpointing", False)
-            enable_activation_offloading(critic_module, config.strategy, enable_gradient_checkpointing)
+            enable_activation_offloading(module, config.strategy, enable_gradient_checkpointing)
 
-        log_gpu_memory_usage("After critic FSDP", logger=None)
+        log_gpu_memory_usage("After FSDP", logger=None)
 
-        critic_optimizer = optim.AdamW(
-            critic_module.parameters(),
+        optimizer = optim.AdamW(
+            module.parameters(),
             lr=config.optim.lr,
             betas=config.optim.get("betas", (0.9, 0.999)),
             weight_decay=config.optim.get("weight_decay", 1e-2),
@@ -320,13 +320,13 @@ class FSDPEngine(object):
         from verl.utils.torch_functional import get_constant_schedule_with_warmup, get_cosine_schedule_with_warmup
 
         if warmup_style == "constant":
-            critic_lr_scheduler = get_constant_schedule_with_warmup(optimizer=critic_optimizer, num_warmup_steps=num_warmup_steps)
+            lr_scheduler = get_constant_schedule_with_warmup(optimizer=optimizer, num_warmup_steps=num_warmup_steps)
         elif warmup_style == "cosine":
-            critic_lr_scheduler = get_cosine_schedule_with_warmup(optimizer=critic_optimizer, num_warmup_steps=num_warmup_steps, num_training_steps=total_steps)
+            lr_scheduler = get_cosine_schedule_with_warmup(optimizer=optimizer, num_warmup_steps=num_warmup_steps, num_training_steps=total_steps)
         else:
             raise NotImplementedError(f"Warmup style {warmup_style} is not supported")
 
-        return critic_module, critic_optimizer, critic_lr_scheduler
+        return module, optimizer, lr_scheduler
 
 
     def train_mode(self):
@@ -359,7 +359,7 @@ class FSDPEngine(object):
 
         inputs, ctx = self.preprocess_fn(batch, ctx)
         inputs["use_cache"] = False
-        outputs = self.critic_module(**inputs)
+        outputs = self.module(**inputs)
         preds, ctx = self.postprocess_fn(outputs, ctx)
         if forward_only:
             return preds, ctx
@@ -370,31 +370,31 @@ class FSDPEngine(object):
 
 
     def optimizer_zero_grad(self):
-        self.critic_optimizer.zero_grad()
+        self.optimizer.zero_grad()
 
 
     def optimizer_step(self):
         assert self.config.grad_clip is not None
 
-        if isinstance(self.critic_module, FSDP):
-            grad_norm = self.critic_module.clip_grad_norm_(self.config.grad_clip)
-        elif isinstance(self.critic_module, FSDPModule):
-            grad_norm = fsdp2_clip_grad_norm_(self.critic_module.parameters(), max_norm=self.config.grad_clip)
+        if isinstance(self.module, FSDP):
+            grad_norm = self.module.clip_grad_norm_(self.config.grad_clip)
+        elif isinstance(self.module, FSDPModule):
+            grad_norm = fsdp2_clip_grad_norm_(self.module.parameters(), max_norm=self.config.grad_clip)
         else:
-            grad_norm = torch.nn.utils.clip_grad_norm_(self.critic_module.parameters(), max_norm=self.config.grad_clip)
+            grad_norm = torch.nn.utils.clip_grad_norm_(self.module.parameters(), max_norm=self.config.grad_clip)
 
         # if grad_norm is not finite, skip the update
         if not torch.isfinite(grad_norm):
             print(f"WARN: grad_norm is not finite: {grad_norm}")
-            self.critic_optimizer.zero_grad()
+            self.optimizer.zero_grad()
         else:
-            self.critic_optimizer.step()
+            self.optimizer.step()
         return grad_norm
 
 
     def lr_scheduler_step(self):
-        self.critic_lr_scheduler.step()
-        lr = self.critic_lr_scheduler.get_last_lr()
+        self.lr_scheduler.step()
+        lr = self.lr_scheduler.get_last_lr()
         return lr
 
 
@@ -444,26 +444,26 @@ class FSDPEngine(object):
 
     def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
         if self._is_offload_param:
-            load_fsdp_model_to_gpu(self.critic_module)
+            load_fsdp_model_to_gpu(self.module)
 
         self.checkpoint_manager.save_checkpoint(local_path=local_path, hdfs_path=hdfs_path, global_step=global_step, max_ckpt_to_keep=max_ckpt_to_keep)
 
         torch.distributed.barrier()
         if self._is_offload_param:
-            offload_fsdp_model_to_cpu(self.critic_module)
+            offload_fsdp_model_to_cpu(self.module)
 
 
     def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=True):
         import torch
 
         if self._is_offload_param:
-            load_fsdp_model_to_gpu(self.critic_module)
+            load_fsdp_model_to_gpu(self.module)
 
         self.checkpoint_manager.load_checkpoint(local_path=local_path, hdfs_path=hdfs_path, del_local_after_load=del_local_after_load)
 
         torch.distributed.barrier()
         if self._is_offload_param:
-            offload_fsdp_model_to_cpu(self.critic_module)
+            offload_fsdp_model_to_cpu(self.module)
 
         if self._is_offload_optimizer:
-            offload_fsdp_optimizer(self.critic_optimizer)
+            offload_fsdp_optimizer(self.optimizer)

--- a/verl/workers/engine/fsdp/engine_impl.py
+++ b/verl/workers/engine/fsdp/engine_impl.py
@@ -129,7 +129,7 @@ class FSDPEngine(object):
         self._is_offload_optimizer = self.config.model.fsdp_config.optimizer_offload
 
 
-    def init_model_and_optimizer(self):
+    def init_model(self):
         # This is used to import external_lib into the huggingface systems
         import_external_libs(self.config.model.get("external_lib", None))
 
@@ -351,20 +351,35 @@ class FSDPEngine(object):
                               forward_only=False, 
                               preprocess_fn=None, 
                               postprocess_fn=None):
+        # mode guard to check this method is called in a proper context manager
         assert self.mode is not None
         if self.mode == "train":
             assert forward_only == False
         elif self.mode == "eval":
             assert forward_only ==True
 
-        inputs, ctx = self.preprocess_fn(batch, ctx)
+        # optional microbatch preprocess
+        if preprocess_fn is not None:
+            inputs, ctx = preprocess_fn(batch, ctx)
+        else:
+            inputs = batch
+
+        # forward execution
         inputs["use_cache"] = False
         outputs = self.module(**inputs)
-        preds, ctx = self.postprocess_fn(outputs, ctx)
+
+        # optional microbatch postprocess
+        if postprocess_fn is not None:
+            preds, ctx = postprocess_fn(outputs, ctx)
+        else:
+            preds = outputs
+
         if forward_only:
             return preds, ctx
 
+        # loss function
         loss, ctx = self.loss_fn(batch, preds, ctx)
+        # backward
         loss.backward()
         return preds, loss, ctx
 
@@ -397,20 +412,6 @@ class FSDPEngine(object):
         lr = self.lr_scheduler.get_last_lr()
         return lr
 
-
-    def set_preprocess_fn(self, preprocess_fn):
-        """
-        preprocess_fn(data, ctx) -> inputs, ctx
-        """
-        self.preprocess_fn = preprocess_fn
-
-
-    def set_postprocess_fn(self, postprocess_fn):
-        """
-        postprocess_fn(outputs, ctx) -> preds, ctx
-        """
-        self.postprocess_fn = postprocess_fn
-        
 
     def set_loss_fn(self, loss_fn):
         """

--- a/verl/workers/engine/fsdp/utils.py
+++ b/verl/workers/engine/fsdp/utils.py
@@ -1,0 +1,22 @@
+from torch.distributed.device_mesh import init_device_mesh
+from verl.utils.device import get_device_name, get_torch_device, is_cuda_available, is_npu_available
+
+def create_device_mesh(world_size, fsdp_size):
+    device_name = get_device_name()
+    if fsdp_size < 0 or fsdp_size >= world_size:
+        device_mesh = init_device_mesh(device_name, mesh_shape=(world_size,), mesh_dim_names=["fsdp"])
+    else:
+        device_mesh = init_device_mesh(device_name, mesh_shape=(world_size // fsdp_size, fsdp_size), mesh_dim_names=["ddp", "fsdp"])
+    return device_mesh
+
+
+def get_sharding_strategy(device_mesh):
+    from torch.distributed.fsdp import ShardingStrategy
+
+    if device_mesh.ndim == 1:
+        sharding_strategy = ShardingStrategy.FULL_SHARD
+    elif device_mesh.ndim == 2:
+        sharding_strategy = ShardingStrategy.HYBRID_SHARD
+    else:
+        raise NotImplementedError(f"Get device mesh ndim={device_mesh.ndim}, but only support 1 or 2")
+    return sharding_strategy

--- a/verl/workers/roles/__init__.py
+++ b/verl/workers/roles/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .critic import CriticWorker
+
+__all__ = ["CriticWorker"]

--- a/verl/workers/roles/critic.py
+++ b/verl/workers/roles/critic.py
@@ -236,8 +236,6 @@ class CriticWorker(Worker):
             ctx["indices"] = indices
             ctx["seqlen"] = seqlen
             ctx["bs"] = bs
-            torch.cuda.synchronize()
-            torch.distributed.barrier()
             return inputs, ctx
 
         def postprocess_fn_with_rmpad(outputs, ctx):
@@ -257,10 +255,7 @@ class CriticWorker(Worker):
             # pad it back
             values = pad_input(values_rmpad, indices=ctx["indices"], batch=ctx["bs"], seqlen=ctx["seqlen"]).squeeze(-1)
             values = values[:, -response_length - 1 : -1]
-            torch.cuda.synchronize()
-            torch.distributed.barrier()
-            raise ValueError
-            return values
+            return values, ctx
 
 
         self.use_remove_padding = self.config.model.get("use_remove_padding", False)
@@ -408,37 +403,16 @@ class CriticWorker(Worker):
             output = self.engine.unshard_data(data=output)
 
         output = output.to("cpu")
-        raise ValueError
         return output
 
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
-        import torch
-
-        if self._is_offload_param:
-            load_fsdp_model_to_gpu(self.critic_module)
-
-        self.checkpoint_manager.save_checkpoint(local_path=local_path, hdfs_path=hdfs_path, global_step=global_step, max_ckpt_to_keep=max_ckpt_to_keep)
-
-        torch.distributed.barrier()
-        if self._is_offload_param:
-            offload_fsdp_model_to_cpu(self.critic_module)
+        self.engine.save_checkpoint(local_path, hdfs_path, global_step, max_ckpt_to_keep)
 
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=True):
-        import torch
-
-        if self._is_offload_param:
-            load_fsdp_model_to_gpu(self.critic_module)
-
-        self.checkpoint_manager.load_checkpoint(local_path=local_path, hdfs_path=hdfs_path, del_local_after_load=del_local_after_load)
-
-        torch.distributed.barrier()
-        if self._is_offload_param:
-            offload_fsdp_model_to_cpu(self.critic_module)
-
-        if self._is_offload_optimizer:
-            offload_fsdp_optimizer(self.critic_optimizer)
+        self.engine.load_checkpoint(local_path, hdfs_path, del_local_after_load)
+        raise ValueError
 

--- a/verl/workers/roles/critic.py
+++ b/verl/workers/roles/critic.py
@@ -119,7 +119,7 @@ class CriticWorker(Worker):
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
-        self.engine.init_model_and_optimizer()
+        self.engine.init_model()
 
 
     def get_microbatch_process_fn(self):
@@ -218,10 +218,6 @@ class CriticWorker(Worker):
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_values(self, data: DataProto):
-        preprocess_fn, postprocess_fn = self.get_microbatch_process_fn()
-        self.engine.set_preprocess_fn(preprocess_fn)
-        self.engine.set_postprocess_fn(postprocess_fn)
-        
         # Support all hardwares
         data = data.to(get_torch_device().current_device())
         micro_batch_size = self.config.forward_micro_batch_size_per_gpu
@@ -248,6 +244,7 @@ class CriticWorker(Worker):
                 micro_batches = batch.split(micro_batch_size)
             return micro_batches
         
+        preprocess_fn, postprocess_fn = self.get_microbatch_process_fn()
         with self.engine.eval_mode():
             data = self.engine.shard_data(data=data)
             micro_batches = get_micro_batches(data)
@@ -261,7 +258,11 @@ class CriticWorker(Worker):
                     # TODO: should not access module in the engine
                     use_value_head_model = hasattr(self.engine.module, "v_head")
                     ctx = {"use_value_head_model": use_value_head_model}
-                    values, ctx = self.engine.forward_backward_step(micro_batch, ctx, forward_only=True)
+                    values, ctx = self.engine.forward_backward_step(micro_batch,
+                                                                    ctx,
+                                                                    forward_only=True,
+                                                                    preprocess_fn=preprocess_fn,
+                                                                    postprocess_fn=postprocess_fn)
 
                 values_lst.append(values)
             values = torch.concat(values_lst, dim=0)
@@ -288,6 +289,7 @@ class CriticWorker(Worker):
     def update_critic(self, data: DataProto):
         # Support all hardwares
         data = data.to(get_torch_device().current_device())
+        preprocess_fn, postprocess_fn = self.get_microbatch_process_fn()
 
         # perform forward computation
         with self.engine.train_mode():
@@ -336,7 +338,11 @@ class CriticWorker(Worker):
                             use_value_head_model = hasattr(self.engine.module, "v_head")
                             ctx = {"use_value_head_model": use_value_head_model,
                                 'data_size': len(micro_batch)}
-                            vpreds, loss, metric = self.engine.forward_backward_step(micro_batch, ctx, forward_only=False)
+                            vpreds, loss, metric = self.engine.forward_backward_step(micro_batch,
+                                                                                     ctx,
+                                                                                     forward_only=False,
+                                                                                     preprocess_fn=preprocess_fn,
+                                                                                     postprocess_fn=postprocess_fn)
                             append_to_dict(metrics, metric)
 
                         grad_norm = self.engine.optimizer_step() 

--- a/verl/workers/roles/critic.py
+++ b/verl/workers/roles/critic.py
@@ -165,70 +165,13 @@ class CriticWorker(Worker):
             return loss, ctx
         self.engine.set_loss_fn(loss_fn)
 
-        # def preprocess_fn_with_rmpad(batch, ctx):
-        #     ctx["response_length"] = batch["responses"].size(-1)
-
-        #     inputs = {}
-        #     if "multi_modal_inputs" in batch.keys():
-        #         for key in batch["multi_modal_inputs"][0].keys():
-        #             inputs[key] = torch.cat([inputs[key] for inputs in batch["multi_modal_inputs"]], dim=0)
-
-        #     input_ids = batch["input_ids"]
-        #     attention_mask = batch["attention_mask"]
-        #     position_ids = batch["position_ids"]
-        #     if position_ids.dim() == 3:  # qwen2vl mrope
-        #         position_ids = position_ids.transpose(0, 1)
-
-        #     input_ids_rmpad, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask)  # input_ids_rmpad (total_nnz, ...)
-        #     input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # (1, total_nnz)
-
-        #     # unpad the position_ids to align the rotary
-        #     if position_ids.dim() == 3:
-        #         position_ids_rmpad = index_first_axis(rearrange(position_ids, "c b s ... -> (b s) c ..."), indices).transpose(0, 1).unsqueeze(1)  # (3, bsz, seqlen) -> (3, 1, bsz * seqlen)
-        #     else:
-        #         position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."), indices).transpose(0, 1)
-
-        #     # pad and slice the inputs if sp > 1
-        #     if self.ulysses_sequence_parallel_size > 1:
-        #         input_ids_rmpad, position_ids_rmpad, pad_size = ulysses_pad_and_slice_inputs(input_ids_rmpad, position_ids_rmpad, sp_size=self.ulysses_sequence_parallel_size)
-
-        #     inputs["input_ids"] = input_ids_rmpad
-        #     inputs["attention_mask"] = attention_mask
-        #     inputs["position_ids"] = position_ids_rmpad
-
-        #     ctx["pad_size"] = pad_size
-        #     ctx["indices"] = indices
-        #     ctx["seqlen"] = seqlen
-        #     ctx["batch"] = batch
-
-        #     return inputs, ctx
-
-        # def postprocess_fn_with_rmpad(outputs, ctx):
-        #     response_length = ctx["response_length"]
-        #     if hasattr(self.critic_module, "v_head"):
-        #         # For trl.AutoModelForCausalLMWithValueHead
-        #         values_rmpad = output[2].squeeze(0).unsqueeze(-1)
-        #     else:
-        #         values_rmpad = output.logits
-        #         values_rmpad = values_rmpad.squeeze(0)  # (total_nnz)
-
-        #     # gather output if sp > 1
-        #     if self.ulysses_sequence_parallel_size > 1:
-        #         values_rmpad = gather_outpus_and_unpad(values_rmpad, gather_dim=0, unpad_dim=0, padding_size=pad_size)
-
-        #     # pad it back
-        #     values = pad_input(values_rmpad, indices=indices, batch=batch, seqlen=seqlen).squeeze(-1)
-        #     values = values[:, -response_length - 1 : -1]
-        #     return values
-
-
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
         self.engine.init_model_and_optimizer()
 
 
-    def get_microbatch_preprocess_fn(self):
+    def get_microbatch_process_fn(self):
         def preprocess_fn_without_rmpad(batch, ctx):
             ctx["response_length"] = batch["responses"].size(-1)
 
@@ -244,9 +187,7 @@ class CriticWorker(Worker):
                 position_ids = position_ids.transpose(0, 1)
             inputs["position_ids"] = position_ids
             return inputs, ctx
-        return preprocess_fn_without_rmpad
         
-    def get_microbatch_postprocess_fn(self):
         def postprocess_fn_without_rmpad(outputs, ctx):
             response_length = ctx["response_length"]
             use_value_head_model = ctx["use_value_head_model"]
@@ -257,14 +198,83 @@ class CriticWorker(Worker):
                 values = outputs.logits
             values = values[:, -response_length - 1 : -1].squeeze(-1)
             return values, ctx
-        return postprocess_fn_without_rmpad
+
+
+        def preprocess_fn_with_rmpad(batch, ctx):
+            ctx["response_length"] = batch["responses"].size(-1)
+
+            inputs = {}
+            if "multi_modal_inputs" in batch.keys():
+                for key in batch["multi_modal_inputs"][0].keys():
+                    inputs[key] = torch.cat([inputs[key] for inputs in batch["multi_modal_inputs"]], dim=0)
+
+            input_ids = batch["input_ids"]
+            bs, seqlen = input_ids.shape
+            attention_mask = batch["attention_mask"]
+            position_ids = batch["position_ids"]
+            if position_ids.dim() == 3:  # qwen2vl mrope
+                position_ids = position_ids.transpose(0, 1)
+
+            input_ids_rmpad, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask)  # input_ids_rmpad (total_nnz, ...)
+            input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # (1, total_nnz)
+
+            # unpad the position_ids to align the rotary
+            if position_ids.dim() == 3:
+                position_ids_rmpad = index_first_axis(rearrange(position_ids, "c b s ... -> (b s) c ..."), indices).transpose(0, 1).unsqueeze(1)  # (3, bsz, seqlen) -> (3, 1, bsz * seqlen)
+            else:
+                position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."), indices).transpose(0, 1)
+
+            # pad and slice the inputs if sp > 1
+            if self.ulysses_sequence_parallel_size > 1:
+                input_ids_rmpad, position_ids_rmpad, pad_size = ulysses_pad_and_slice_inputs(input_ids_rmpad, position_ids_rmpad, sp_size=self.ulysses_sequence_parallel_size)
+                ctx["pad_size"] = pad_size
+
+            inputs["input_ids"] = input_ids_rmpad
+            inputs["attention_mask"] = None
+            inputs["position_ids"] = position_ids_rmpad
+
+            ctx["indices"] = indices
+            ctx["seqlen"] = seqlen
+            ctx["bs"] = bs
+            torch.cuda.synchronize()
+            torch.distributed.barrier()
+            return inputs, ctx
+
+        def postprocess_fn_with_rmpad(outputs, ctx):
+            response_length = ctx["response_length"]
+            use_value_head_model = ctx["use_value_head_model"]
+            if use_value_head_model:
+                # For trl.AutoModelForCausalLMWithValueHead
+                values_rmpad = outputs[2].squeeze(0).unsqueeze(-1)
+            else:
+                values_rmpad = outputs.logits
+                values_rmpad = values_rmpad.squeeze(0)  # (total_nnz)
+
+            # gather output if sp > 1
+            if self.ulysses_sequence_parallel_size > 1:
+                values_rmpad = gather_outpus_and_unpad(values_rmpad, gather_dim=0, unpad_dim=0, padding_size=ctx["pad_size"])
+
+            # pad it back
+            values = pad_input(values_rmpad, indices=ctx["indices"], batch=ctx["bs"], seqlen=ctx["seqlen"]).squeeze(-1)
+            values = values[:, -response_length - 1 : -1]
+            torch.cuda.synchronize()
+            torch.distributed.barrier()
+            raise ValueError
+            return values
+
+
+        self.use_remove_padding = self.config.model.get("use_remove_padding", False)
+        if self.use_remove_padding:
+            return preprocess_fn_with_rmpad, postprocess_fn_with_rmpad
+        else:
+            return preprocess_fn_without_rmpad, postprocess_fn_without_rmpad
+
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_values(self, data: DataProto):
-        self.use_remove_padding = self.config.model.get("use_remove_padding", False)
-        assert self.use_remove_padding == False
-        self.engine.set_preprocess_fn(self.get_microbatch_preprocess_fn())
-        self.engine.set_postprocess_fn(self.get_microbatch_postprocess_fn())
+        preprocess_fn, postprocess_fn = self.get_microbatch_process_fn()
+        self.engine.set_preprocess_fn(preprocess_fn)
+        self.engine.set_postprocess_fn(postprocess_fn)
         
         # Support all hardwares
         data = data.to(get_torch_device().current_device())

--- a/verl/workers/roles/critic.py
+++ b/verl/workers/roles/critic.py
@@ -36,33 +36,7 @@ from verl import DataProto
 from verl.models.transformers.monkey_patch import apply_monkey_patch
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, register
-from verl.utils import hf_processor, hf_tokenizer
-from verl.utils.activation_offload import enable_activation_offloading
-from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
-from verl.utils.debug import log_gpu_memory_usage
-from verl.utils.debug.performance import _timer, reduce_timing
-from verl.utils.device import get_device_name, get_torch_device, is_cuda_available, is_npu_available
-from verl.utils.flops_counter import FlopsCounter
-from verl.utils.fs import copy_to_local
-from verl.utils.fsdp_utils import (
-    CPUOffloadPolicy,
-    MixedPrecisionPolicy,
-    apply_fsdp2,
-    fsdp2_load_full_state_dict,
-    fsdp_version,
-    get_fsdp_wrap_policy,
-    get_init_weight_context_manager,
-    init_fn,
-    layered_summon_lora_params,
-    load_fsdp_model_to_gpu,
-    load_fsdp_optimizer,
-    offload_fsdp_model_to_cpu,
-    offload_fsdp_optimizer,
-)
-from verl.utils.import_utils import import_external_libs
-from verl.utils.model import compute_position_id_with_mask
-from verl.utils.py_functional import convert_to_regular_types
-from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
+from verl.utils.device import get_torch_device, is_cuda_available, is_npu_available
 from verl.trainer.ppo import core_algos
 from verl.workers.engine.fsdp import FSDPEngine
 from verl.utils.seqlen_balancing import (get_reverse_idx,
@@ -72,7 +46,6 @@ import itertools
 from verl.utils.torch_functional import masked_mean
 from verl.utils.ulysses import (gather_outpus_and_unpad,
                                 ulysses_pad_and_slice_inputs)
-from verl.workers.critic import BasePPOCritic
 from verl.utils.py_functional import append_to_dict
 
 if is_cuda_available:
@@ -85,8 +58,6 @@ elif is_npu_available:
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
-device_name = get_device_name()
-
 
 
 
@@ -98,25 +69,7 @@ class CriticWorker(Worker):
         if not torch.distributed.is_initialized():
             torch.distributed.init_process_group(backend="nccl" if is_cuda_available else "hccl")
         self.config = config
-
-        # # build device mesh for Ulysses Sequence Parallel
-        # world_size = torch.distributed.get_world_size()
-        # from torch.distributed.device_mesh import init_device_mesh
-
-        # fsdp_size = self.config.model.fsdp_config.fsdp_size
-        # self.device_mesh = create_device_mesh(world_size=world_size, fsdp_size=fsdp_size)
-
-        # self.ulysses_device_mesh = None
         self.ulysses_sequence_parallel_size = self.config.get("ulysses_sequence_parallel_size", 1)
-        # dp = world_size // self.ulysses_sequence_parallel_size
-        # if self.ulysses_sequence_parallel_size > 1:
-        #     self.ulysses_device_mesh = init_device_mesh(device_name, mesh_shape=(dp, self.ulysses_sequence_parallel_size), mesh_dim_names=["dp", "sp"])
-
-        # self.ulysses_sharding_manager = FSDPUlyssesShardingManager(self.ulysses_device_mesh)
-
-        # # set FSDP offload params
-        # self._is_offload_param = self.config.model.fsdp_config.param_offload
-        # self._is_offload_optimizer = self.config.model.fsdp_config.optimizer_offload
 
         # normalize config
         self.config.ppo_mini_batch_size *= self.config.rollout_n
@@ -130,10 +83,8 @@ class CriticWorker(Worker):
         if self.config.ppo_micro_batch_size_per_gpu is not None:
             assert self.config.ppo_mini_batch_size % self.config.ppo_micro_batch_size_per_gpu == 0, f"normalized ppo_mini_batch_size {self.config.ppo_mini_batch_size} should be divisible by ppo_micro_batch_size_per_gpu {self.config.ppo_micro_batch_size_per_gpu}"
             assert self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu > 0, f"normalized ppo_mini_batch_size {self.config.ppo_mini_batch_size} should be larger than ppo_micro_batch_size_per_gpu {self.config.ppo_micro_batch_size_per_gpu}"
-        # self._is_lora = self.config.model.get("lora_rank", 0) > 0
 
         self.engine = FSDPEngine(self.config)
-        self.device_name = get_device_name()
 
         def loss_fn(batch, vpreds, ctx):
             responses = batch["responses"]
@@ -308,7 +259,7 @@ class CriticWorker(Worker):
 
                 with torch.no_grad():
                     # TODO: should not access module in the engine
-                    use_value_head_model = hasattr(self.engine.critic_module, "v_head")
+                    use_value_head_model = hasattr(self.engine.module, "v_head")
                     ctx = {"use_value_head_model": use_value_head_model}
                     values, ctx = self.engine.forward_backward_step(micro_batch, ctx, forward_only=True)
 
@@ -382,7 +333,7 @@ class CriticWorker(Worker):
                                 micro_batch = micro_batch.to(get_torch_device().current_device())  # critic device is cpu when using offload
 
                             # TODO: should not access module in the engine
-                            use_value_head_model = hasattr(self.engine.critic_module, "v_head")
+                            use_value_head_model = hasattr(self.engine.module, "v_head")
                             ctx = {"use_value_head_model": use_value_head_model,
                                 'data_size': len(micro_batch)}
                             vpreds, loss, metric = self.engine.forward_backward_step(micro_batch, ctx, forward_only=False)
@@ -414,5 +365,4 @@ class CriticWorker(Worker):
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=True):
         self.engine.load_checkpoint(local_path, hdfs_path, del_local_after_load)
-        raise ValueError
 

--- a/verl/workers/roles/critic.py
+++ b/verl/workers/roles/critic.py
@@ -70,6 +70,18 @@ from verl.utils.seqlen_balancing import (get_reverse_idx,
                                          rearrange_micro_batches)
 import itertools
 
+from verl.utils.torch_functional import masked_mean
+from verl.utils.ulysses import (gather_outpus_and_unpad,
+                                ulysses_pad_and_slice_inputs)
+from verl.workers.critic import BasePPOCritic
+
+if is_cuda_available:
+    from flash_attn.bert_padding import (index_first_axis, pad_input,
+                                         rearrange, unpad_input)
+elif is_npu_available:
+    from transformers.integrations.npu_flash_attention import (
+        index_first_axis, pad_input, rearrange, unpad_input)
+
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
@@ -140,17 +152,115 @@ class CriticWorker(Worker):
         # self._is_lora = self.config.model.get("lora_rank", 0) > 0
 
         self.engine = FSDPEngine(self.config)
+        self.device_name = get_device_name()
+
+        # def preprocess_fn_with_rmpad(batch, ctx):
+        #     ctx["response_length"] = batch["responses"].size(-1)
+
+        #     inputs = {}
+        #     if "multi_modal_inputs" in batch.keys():
+        #         for key in batch["multi_modal_inputs"][0].keys():
+        #             inputs[key] = torch.cat([inputs[key] for inputs in batch["multi_modal_inputs"]], dim=0)
+
+        #     input_ids = batch["input_ids"]
+        #     attention_mask = batch["attention_mask"]
+        #     position_ids = batch["position_ids"]
+        #     if position_ids.dim() == 3:  # qwen2vl mrope
+        #         position_ids = position_ids.transpose(0, 1)
+
+        #     input_ids_rmpad, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask)  # input_ids_rmpad (total_nnz, ...)
+        #     input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # (1, total_nnz)
+
+        #     # unpad the position_ids to align the rotary
+        #     if position_ids.dim() == 3:
+        #         position_ids_rmpad = index_first_axis(rearrange(position_ids, "c b s ... -> (b s) c ..."), indices).transpose(0, 1).unsqueeze(1)  # (3, bsz, seqlen) -> (3, 1, bsz * seqlen)
+        #     else:
+        #         position_ids_rmpad = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."), indices).transpose(0, 1)
+
+        #     # pad and slice the inputs if sp > 1
+        #     if self.ulysses_sequence_parallel_size > 1:
+        #         input_ids_rmpad, position_ids_rmpad, pad_size = ulysses_pad_and_slice_inputs(input_ids_rmpad, position_ids_rmpad, sp_size=self.ulysses_sequence_parallel_size)
+
+        #     inputs["input_ids"] = input_ids_rmpad
+        #     inputs["attention_mask"] = attention_mask
+        #     inputs["position_ids"] = position_ids_rmpad
+
+        #     ctx["pad_size"] = pad_size
+        #     ctx["indices"] = indices
+        #     ctx["seqlen"] = seqlen
+        #     ctx["batch"] = batch
+
+        #     return inputs, ctx
+
+        # def postprocess_fn_with_rmpad(outputs, ctx):
+        #     response_length = ctx["response_length"]
+        #     if hasattr(self.critic_module, "v_head"):
+        #         # For trl.AutoModelForCausalLMWithValueHead
+        #         values_rmpad = output[2].squeeze(0).unsqueeze(-1)
+        #     else:
+        #         values_rmpad = output.logits
+        #         values_rmpad = values_rmpad.squeeze(0)  # (total_nnz)
+
+        #     # gather output if sp > 1
+        #     if self.ulysses_sequence_parallel_size > 1:
+        #         values_rmpad = gather_outpus_and_unpad(values_rmpad, gather_dim=0, unpad_dim=0, padding_size=pad_size)
+
+        #     # pad it back
+        #     values = pad_input(values_rmpad, indices=indices, batch=batch, seqlen=seqlen).squeeze(-1)
+        #     values = values[:, -response_length - 1 : -1]
+        #     return values
+
+
+        # def postprocess_fn(outputs, ctx):
+        #     return preds, ctx
+
+
+        # def loss_fn(data, preds, ctx):
+        #     return loss, out_ctx
+
 
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
         self.engine.init_model_and_optimizer()
-        raise ValueError
-
 
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_values(self, data: DataProto):
+        def preprocess_fn_without_rmpad(batch, ctx):
+            ctx["response_length"] = batch["responses"].size(-1)
+
+            inputs = {}
+            if "multi_modal_inputs" in batch.keys():
+                for key in batch["multi_modal_inputs"][0].keys():
+                    inputs[key] = torch.cat([inputs[key] for inputs in batch["multi_modal_inputs"]], dim=0)
+
+            inputs["input_ids"] = batch["input_ids"]
+            inputs["attention_mask"] = batch["attention_mask"]
+            position_ids = batch["position_ids"]
+            if position_ids.dim() == 3:  # qwen2vl mrope
+                position_ids = position_ids.transpose(0, 1)
+            inputs["position_ids"] = position_ids
+            return inputs, ctx
+
+
+        def postprocess_fn_without_rmpad(outputs, ctx):
+            response_length = ctx["response_length"]
+            use_value_head_model = ctx["use_value_head_model"]
+            if use_value_head_model:
+                # For trl.AutoModelForCausalLMWithValueHead
+                values = outputs[2]
+            else:
+                values = outputs.logits
+            values = values[:, -response_length - 1 : -1].squeeze(-1)
+            return values, ctx
+
+        self.use_remove_padding = self.config.model.get("use_remove_padding", False)
+        assert self.use_remove_padding == False
+        self.engine.set_preprocess_fn(preprocess_fn_without_rmpad)
+        self.engine.set_postprocess_fn(postprocess_fn_without_rmpad)
+        
+
         # Support all hardwares
         data = data.to(get_torch_device().current_device())
         micro_batch_size = self.config.forward_micro_batch_size_per_gpu
@@ -158,7 +268,9 @@ class CriticWorker(Worker):
         data.meta_info["max_token_len"] = self.config.forward_max_token_len_per_gpu
         data.meta_info["use_dynamic_bsz"] = self.config.use_dynamic_bsz
 
-        def compute_values_impl(data: DataProto) -> torch.Tensor:
+        with self.engine.eval_mode():
+            data = self.engine.shard_data(data=data)
+            
             micro_batch_size = data.meta_info["micro_batch_size"]
             select_keys = ["responses", "input_ids", "attention_mask", "position_ids"]
             batch = data.select(batch_keys=select_keys).batch
@@ -182,7 +294,10 @@ class CriticWorker(Worker):
                     micro_batch = {**micro_batch.batch, **micro_batch.non_tensor_batch}
 
                 with torch.no_grad():
-                    values = self._forward_micro_batch(micro_batch)
+                    # TODO: should not access module in the engine
+                    use_value_head_model = hasattr(self.engine.critic_module, "v_head")
+                    ctx = {"use_value_head_model": use_value_head_model}
+                    values = self.engine.forward_backward_step(micro_batch, ctx, forward_only=True)
                 values_lst.append(values)
             values = torch.concat(values_lst, dim=0)
 
@@ -197,27 +312,11 @@ class CriticWorker(Worker):
             response_length = responses.size(1)
             response_mask = attention_mask[:, -response_length:]
             values = values * response_mask # Only action tokens have values
-            return values
-
-        with self.engine.eval_mode():
-            data = self.engine.sharding_manager().preprocess_data(data=data)
-            raise ValueError
-            values = compute_values_impl(data=data)
             output = DataProto.from_dict(tensors={"values": values})
-            output = self.engine.sharding_manager().postprocess_data(data=output)
-
-        # if self._is_offload_param:
-        #     load_fsdp_model_to_gpu(self.critic_module)
-        # # perform forward computation
-        # with self.ulysses_sharding_manager:
-        #     data = self.ulysses_sharding_manager.preprocess_data(data=data)
-        #     values = self.critic.compute_values(data=data)
-        #     output = DataProto.from_dict(tensors={"values": values})
-        #     output = self.ulysses_sharding_manager.postprocess_data(data=output)
+            output = self.engine.unshard_data(output)
 
         output = output.to("cpu")
-        if self._is_offload_param:
-            offload_fsdp_model_to_cpu(self.critic_module)
+        raise ValueError
         return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)

--- a/verl/workers/roles/critic.py
+++ b/verl/workers/roles/critic.py
@@ -27,8 +27,6 @@ import torch
 import torch.distributed
 import torch.distributed as dist
 from codetiming import Timer
-from omegaconf import DictConfig, open_dict
-from peft import LoraConfig, TaskType, get_peft_model
 from safetensors.torch import save_file
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
@@ -65,6 +63,7 @@ from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.py_functional import convert_to_regular_types
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
+from verl.trainer.ppo import core_algos
 from verl.workers.engine.fsdp import FSDPEngine
 from verl.utils.seqlen_balancing import (get_reverse_idx,
                                          rearrange_micro_batches)
@@ -74,6 +73,7 @@ from verl.utils.torch_functional import masked_mean
 from verl.utils.ulysses import (gather_outpus_and_unpad,
                                 ulysses_pad_and_slice_inputs)
 from verl.workers.critic import BasePPOCritic
+from verl.utils.py_functional import append_to_dict
 
 if is_cuda_available:
     from flash_attn.bert_padding import (index_first_axis, pad_input,
@@ -87,25 +87,6 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 device_name = get_device_name()
 
-
-# def create_device_mesh(world_size, fsdp_size):
-#     if fsdp_size < 0 or fsdp_size >= world_size:
-#         device_mesh = init_device_mesh(device_name, mesh_shape=(world_size,), mesh_dim_names=["fsdp"])
-#     else:
-#         device_mesh = init_device_mesh(device_name, mesh_shape=(world_size // fsdp_size, fsdp_size), mesh_dim_names=["ddp", "fsdp"])
-#     return device_mesh
-
-
-# def get_sharding_strategy(device_mesh):
-#     from torch.distributed.fsdp import ShardingStrategy
-
-#     if device_mesh.ndim == 1:
-#         sharding_strategy = ShardingStrategy.FULL_SHARD
-#     elif device_mesh.ndim == 2:
-#         sharding_strategy = ShardingStrategy.HYBRID_SHARD
-#     else:
-#         raise NotImplementedError(f"Get device mesh ndim={device_mesh.ndim}, but only support 1 or 2")
-#     return sharding_strategy
 
 
 
@@ -153,6 +134,36 @@ class CriticWorker(Worker):
 
         self.engine = FSDPEngine(self.config)
         self.device_name = get_device_name()
+
+        def loss_fn(batch, vpreds, ctx):
+            responses = batch["responses"]
+            attention_mask = batch["attention_mask"]
+            values = batch["values"]
+            returns = batch["returns"]
+            response_length = responses.size(1)
+            response_mask = attention_mask[:, -response_length:]
+            vf_loss, vf_clipfrac = core_algos.compute_value_loss(
+                vpreds=vpreds,
+                values=values,
+                returns=returns,
+                response_mask=response_mask,
+                cliprange_value=self.config.cliprange_value,
+                loss_agg_mode=self.config.loss_agg_mode,
+            )
+            if self.config.use_dynamic_bsz:
+                # relative to the dynamic bsz
+                loss = vf_loss * (ctx["data_size"] / self.config.ppo_mini_batch_size)
+            else:
+                loss = vf_loss / self.gradient_accumulation
+
+            ctx = {
+                "critic/vf_loss": vf_loss.detach().item(),
+                "critic/vf_clipfrac": vf_clipfrac.detach().item(),
+                "critic/vpred_mean": masked_mean(vpreds, response_mask).detach().item(),
+            }
+
+            return loss, ctx
+        self.engine.set_loss_fn(loss_fn)
 
         # def preprocess_fn_with_rmpad(batch, ctx):
         #     ctx["response_length"] = batch["responses"].size(-1)
@@ -211,22 +222,13 @@ class CriticWorker(Worker):
         #     return values
 
 
-        # def postprocess_fn(outputs, ctx):
-        #     return preds, ctx
-
-
-        # def loss_fn(data, preds, ctx):
-        #     return loss, out_ctx
-
-
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
         self.engine.init_model_and_optimizer()
 
 
-    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
-    def compute_values(self, data: DataProto):
+    def get_microbatch_preprocess_fn(self):
         def preprocess_fn_without_rmpad(batch, ctx):
             ctx["response_length"] = batch["responses"].size(-1)
 
@@ -242,8 +244,9 @@ class CriticWorker(Worker):
                 position_ids = position_ids.transpose(0, 1)
             inputs["position_ids"] = position_ids
             return inputs, ctx
-
-
+        return preprocess_fn_without_rmpad
+        
+    def get_microbatch_postprocess_fn(self):
         def postprocess_fn_without_rmpad(outputs, ctx):
             response_length = ctx["response_length"]
             use_value_head_model = ctx["use_value_head_model"]
@@ -254,27 +257,27 @@ class CriticWorker(Worker):
                 values = outputs.logits
             values = values[:, -response_length - 1 : -1].squeeze(-1)
             return values, ctx
+        return postprocess_fn_without_rmpad
 
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def compute_values(self, data: DataProto):
         self.use_remove_padding = self.config.model.get("use_remove_padding", False)
         assert self.use_remove_padding == False
-        self.engine.set_preprocess_fn(preprocess_fn_without_rmpad)
-        self.engine.set_postprocess_fn(postprocess_fn_without_rmpad)
+        self.engine.set_preprocess_fn(self.get_microbatch_preprocess_fn())
+        self.engine.set_postprocess_fn(self.get_microbatch_postprocess_fn())
         
-
         # Support all hardwares
         data = data.to(get_torch_device().current_device())
         micro_batch_size = self.config.forward_micro_batch_size_per_gpu
         data.meta_info["micro_batch_size"] = micro_batch_size
         data.meta_info["max_token_len"] = self.config.forward_max_token_len_per_gpu
         data.meta_info["use_dynamic_bsz"] = self.config.use_dynamic_bsz
+        use_dynamic_bsz = data.meta_info["use_dynamic_bsz"]
 
-        with self.engine.eval_mode():
-            data = self.engine.shard_data(data=data)
-            
+        def get_micro_batches(data):
             micro_batch_size = data.meta_info["micro_batch_size"]
             select_keys = ["responses", "input_ids", "attention_mask", "position_ids"]
             batch = data.select(batch_keys=select_keys).batch
-            use_dynamic_bsz = data.meta_info["use_dynamic_bsz"]
             has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
 
             if has_multi_modal_inputs:
@@ -287,6 +290,11 @@ class CriticWorker(Worker):
                 micro_batches, indices = rearrange_micro_batches(batch=batch, max_token_len=max_token_len)
             else:
                 micro_batches = batch.split(micro_batch_size)
+            return micro_batches
+        
+        with self.engine.eval_mode():
+            data = self.engine.shard_data(data=data)
+            micro_batches = get_micro_batches(data)
 
             values_lst = []
             for micro_batch in micro_batches:
@@ -297,7 +305,8 @@ class CriticWorker(Worker):
                     # TODO: should not access module in the engine
                     use_value_head_model = hasattr(self.engine.critic_module, "v_head")
                     ctx = {"use_value_head_model": use_value_head_model}
-                    values = self.engine.forward_backward_step(micro_batch, ctx, forward_only=True)
+                    values, ctx = self.engine.forward_backward_step(micro_batch, ctx, forward_only=True)
+
                 values_lst.append(values)
             values = torch.concat(values_lst, dim=0)
 
@@ -316,44 +325,82 @@ class CriticWorker(Worker):
             output = self.engine.unshard_data(output)
 
         output = output.to("cpu")
-        raise ValueError
         return output
+
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def update_critic(self, data: DataProto):
         # Support all hardwares
         data = data.to(get_torch_device().current_device())
-        if self._is_offload_param:
-            load_fsdp_model_to_gpu(self.critic_module)
-        if self._is_offload_optimizer:
-            load_fsdp_optimizer(optimizer=self.critic_optimizer, device_id=get_torch_device().current_device())
 
         # perform forward computation
-        with self.ulysses_sharding_manager:
-            data = self.ulysses_sharding_manager.preprocess_data(data=data)
+        with self.engine.train_mode():
+            data = self.engine.shard_data(data=data)
 
             with Timer(name="update_critic", logger=None) as timer:
-                metrics = self.critic.update_critic(data=data)
+                metrics = {}
+
+                select_keys = ["input_ids", "responses", "attention_mask", "position_ids", "values", "returns"]
+                batch = data.select(batch_keys=select_keys).batch
+                has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
+
+                # Split to make minibatch iterator for updating the actor
+                # See PPO paper for details. https://arxiv.org/abs/1707.06347
+                if has_multi_modal_inputs:
+                    num_mini_batches = data.batch.batch_size[0] // self.config.ppo_mini_batch_size
+                    non_tensor_select_keys = ["multi_modal_inputs"]
+                    dataloader = data.select(select_keys, non_tensor_select_keys).chunk(num_mini_batches)
+                else:
+                    dataloader = batch.split(self.config.ppo_mini_batch_size)
+
+                for epoch in range(self.config.ppo_epochs):
+                    for batch_idx, mini_batch in enumerate(dataloader):
+                        # split batch into micro_batches
+                        if has_multi_modal_inputs:
+                            num_micro_batches = mini_batch.batch.batch_size[0] // self.config.ppo_micro_batch_size_per_gpu
+                            micro_batches = mini_batch.select(select_keys, non_tensor_select_keys).chunk(num_micro_batches)
+                            self.gradient_accumulation = self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
+                        elif self.config.use_dynamic_bsz:
+                            max_token_len = self.config.ppo_max_token_len_per_gpu * self.ulysses_sequence_parallel_size
+                            micro_batches, _ = rearrange_micro_batches(batch=mini_batch, max_token_len=max_token_len)
+                        else:
+                            micro_batches = mini_batch.split(self.config.ppo_micro_batch_size_per_gpu)
+                            self.gradient_accumulation = self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
+
+                        self.engine.optimizer_zero_grad()
+
+                        for micro_batch in micro_batches:
+                            # Support all devices
+                            if isinstance(micro_batch, DataProto):
+                                micro_batch = {**micro_batch.batch.to(get_torch_device().current_device()), **micro_batch.non_tensor_batch}
+                            else:
+                                micro_batch = micro_batch.to(get_torch_device().current_device())  # critic device is cpu when using offload
+
+                            # TODO: should not access module in the engine
+                            use_value_head_model = hasattr(self.engine.critic_module, "v_head")
+                            ctx = {"use_value_head_model": use_value_head_model,
+                                'data_size': len(micro_batch)}
+                            vpreds, loss, metric = self.engine.forward_backward_step(micro_batch, ctx, forward_only=False)
+                            append_to_dict(metrics, metric)
+
+                        grad_norm = self.engine.optimizer_step() 
+                        append_to_dict(metrics, {"critic/grad_norm": grad_norm.detach().item()})
+                self.engine.optimizer_zero_grad()
             delta_time = timer.last
 
+            # TODO: should not access engine's flops_counter
             global_num_tokens = data.meta_info["global_token_num"]
-            estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
+            estimated_flops, promised_flops = self.engine.flops_counter.estimate_flops(global_num_tokens, delta_time)
             metrics["perf/mfu/critic"] = estimated_flops * self.config.ppo_epochs / promised_flops / self.world_size
 
-            self.critic_lr_scheduler.step()
-            lr = self.critic_lr_scheduler.get_last_lr()[0]
-            metrics["critic/lr"] = lr
-
+            metrics["critic/lr"] = self.engine.lr_scheduler_step()[0]
             output = DataProto(batch=None, meta_info={"metrics": metrics})
-            output = self.ulysses_sharding_manager.postprocess_data(data=output)
-
-        if self._is_offload_param:
-            offload_fsdp_model_to_cpu(self.critic_module)
-        if self._is_offload_optimizer:
-            offload_fsdp_optimizer(optimizer=self.critic_optimizer)
+            output = self.engine.unshard_data(data=output)
 
         output = output.to("cpu")
+        raise ValueError
         return output
+
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
@@ -367,6 +414,7 @@ class CriticWorker(Worker):
         torch.distributed.barrier()
         if self._is_offload_param:
             offload_fsdp_model_to_cpu(self.critic_module)
+
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=True):

--- a/verl/workers/roles/critic.py
+++ b/verl/workers/roles/critic.py
@@ -15,25 +15,13 @@
 The main entry point to run the PPO algorithm
 """
 
-import json
 import logging
 import os
-import warnings
-from dataclasses import asdict
-from typing import Union
 
-import psutil
-import torch
 import torch.distributed
-import torch.distributed as dist
 from codetiming import Timer
-from safetensors.torch import save_file
-from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-import verl.utils.torch_functional as verl_F
 from verl import DataProto
-from verl.models.transformers.monkey_patch import apply_monkey_patch
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, register
 from verl.utils.device import get_torch_device, is_cuda_available, is_npu_available

--- a/verl/workers/roles/critic.py
+++ b/verl/workers/roles/critic.py
@@ -1,0 +1,287 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The main entry point to run the PPO algorithm
+"""
+
+import json
+import logging
+import os
+import warnings
+from dataclasses import asdict
+from typing import Union
+
+import psutil
+import torch
+import torch.distributed
+import torch.distributed as dist
+from codetiming import Timer
+from omegaconf import DictConfig, open_dict
+from peft import LoraConfig, TaskType, get_peft_model
+from safetensors.torch import save_file
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+import verl.utils.torch_functional as verl_F
+from verl import DataProto
+from verl.models.transformers.monkey_patch import apply_monkey_patch
+from verl.single_controller.base import Worker
+from verl.single_controller.base.decorator import Dispatch, register
+from verl.utils import hf_processor, hf_tokenizer
+from verl.utils.activation_offload import enable_activation_offloading
+from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
+from verl.utils.debug import log_gpu_memory_usage
+from verl.utils.debug.performance import _timer, reduce_timing
+from verl.utils.device import get_device_name, get_torch_device, is_cuda_available, is_npu_available
+from verl.utils.flops_counter import FlopsCounter
+from verl.utils.fs import copy_to_local
+from verl.utils.fsdp_utils import (
+    CPUOffloadPolicy,
+    MixedPrecisionPolicy,
+    apply_fsdp2,
+    fsdp2_load_full_state_dict,
+    fsdp_version,
+    get_fsdp_wrap_policy,
+    get_init_weight_context_manager,
+    init_fn,
+    layered_summon_lora_params,
+    load_fsdp_model_to_gpu,
+    load_fsdp_optimizer,
+    offload_fsdp_model_to_cpu,
+    offload_fsdp_optimizer,
+)
+from verl.utils.import_utils import import_external_libs
+from verl.utils.model import compute_position_id_with_mask
+from verl.utils.py_functional import convert_to_regular_types
+from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
+from verl.workers.engine.fsdp import FSDPEngine
+from verl.utils.seqlen_balancing import (get_reverse_idx,
+                                         rearrange_micro_batches)
+import itertools
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+device_name = get_device_name()
+
+
+# def create_device_mesh(world_size, fsdp_size):
+#     if fsdp_size < 0 or fsdp_size >= world_size:
+#         device_mesh = init_device_mesh(device_name, mesh_shape=(world_size,), mesh_dim_names=["fsdp"])
+#     else:
+#         device_mesh = init_device_mesh(device_name, mesh_shape=(world_size // fsdp_size, fsdp_size), mesh_dim_names=["ddp", "fsdp"])
+#     return device_mesh
+
+
+# def get_sharding_strategy(device_mesh):
+#     from torch.distributed.fsdp import ShardingStrategy
+
+#     if device_mesh.ndim == 1:
+#         sharding_strategy = ShardingStrategy.FULL_SHARD
+#     elif device_mesh.ndim == 2:
+#         sharding_strategy = ShardingStrategy.HYBRID_SHARD
+#     else:
+#         raise NotImplementedError(f"Get device mesh ndim={device_mesh.ndim}, but only support 1 or 2")
+#     return sharding_strategy
+
+
+
+class CriticWorker(Worker):
+    def __init__(self, config):
+        super().__init__()
+        import torch.distributed
+
+        if not torch.distributed.is_initialized():
+            torch.distributed.init_process_group(backend="nccl" if is_cuda_available else "hccl")
+        self.config = config
+
+        # # build device mesh for Ulysses Sequence Parallel
+        # world_size = torch.distributed.get_world_size()
+        # from torch.distributed.device_mesh import init_device_mesh
+
+        # fsdp_size = self.config.model.fsdp_config.fsdp_size
+        # self.device_mesh = create_device_mesh(world_size=world_size, fsdp_size=fsdp_size)
+
+        # self.ulysses_device_mesh = None
+        self.ulysses_sequence_parallel_size = self.config.get("ulysses_sequence_parallel_size", 1)
+        # dp = world_size // self.ulysses_sequence_parallel_size
+        # if self.ulysses_sequence_parallel_size > 1:
+        #     self.ulysses_device_mesh = init_device_mesh(device_name, mesh_shape=(dp, self.ulysses_sequence_parallel_size), mesh_dim_names=["dp", "sp"])
+
+        # self.ulysses_sharding_manager = FSDPUlyssesShardingManager(self.ulysses_device_mesh)
+
+        # # set FSDP offload params
+        # self._is_offload_param = self.config.model.fsdp_config.param_offload
+        # self._is_offload_optimizer = self.config.model.fsdp_config.optimizer_offload
+
+        # normalize config
+        self.config.ppo_mini_batch_size *= self.config.rollout_n
+        self.config.ppo_mini_batch_size //= torch.distributed.get_world_size() // self.ulysses_sequence_parallel_size
+        if self.config.ppo_micro_batch_size is not None:
+            self.config.ppo_micro_batch_size //= torch.distributed.get_world_size() // self.ulysses_sequence_parallel_size
+            self.config.forward_micro_batch_size //= torch.distributed.get_world_size() // self.ulysses_sequence_parallel_size
+            self.config.ppo_micro_batch_size_per_gpu = self.config.ppo_micro_batch_size
+            self.config.forward_micro_batch_size_per_gpu = self.config.forward_micro_batch_size
+
+        if self.config.ppo_micro_batch_size_per_gpu is not None:
+            assert self.config.ppo_mini_batch_size % self.config.ppo_micro_batch_size_per_gpu == 0, f"normalized ppo_mini_batch_size {self.config.ppo_mini_batch_size} should be divisible by ppo_micro_batch_size_per_gpu {self.config.ppo_micro_batch_size_per_gpu}"
+            assert self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu > 0, f"normalized ppo_mini_batch_size {self.config.ppo_mini_batch_size} should be larger than ppo_micro_batch_size_per_gpu {self.config.ppo_micro_batch_size_per_gpu}"
+        # self._is_lora = self.config.model.get("lora_rank", 0) > 0
+
+        self.engine = FSDPEngine(self.config)
+
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_model(self):
+        self.engine.init_model_and_optimizer()
+        raise ValueError
+
+
+
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def compute_values(self, data: DataProto):
+        # Support all hardwares
+        data = data.to(get_torch_device().current_device())
+        micro_batch_size = self.config.forward_micro_batch_size_per_gpu
+        data.meta_info["micro_batch_size"] = micro_batch_size
+        data.meta_info["max_token_len"] = self.config.forward_max_token_len_per_gpu
+        data.meta_info["use_dynamic_bsz"] = self.config.use_dynamic_bsz
+
+        def compute_values_impl(data: DataProto) -> torch.Tensor:
+            micro_batch_size = data.meta_info["micro_batch_size"]
+            select_keys = ["responses", "input_ids", "attention_mask", "position_ids"]
+            batch = data.select(batch_keys=select_keys).batch
+            use_dynamic_bsz = data.meta_info["use_dynamic_bsz"]
+            has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
+
+            if has_multi_modal_inputs:
+                num_micro_batches = data.batch.batch_size[0] // micro_batch_size
+                non_tensor_select_keys = ["multi_modal_inputs"]
+                micro_batches = data.select(select_keys, non_tensor_select_keys).chunk(num_micro_batches)
+            elif use_dynamic_bsz:
+                # split using dynamic bsz
+                max_token_len = data.meta_info["max_token_len"] * self.ulysses_sequence_parallel_size
+                micro_batches, indices = rearrange_micro_batches(batch=batch, max_token_len=max_token_len)
+            else:
+                micro_batches = batch.split(micro_batch_size)
+
+            values_lst = []
+            for micro_batch in micro_batches:
+                if isinstance(micro_batch, DataProto):
+                    micro_batch = {**micro_batch.batch, **micro_batch.non_tensor_batch}
+
+                with torch.no_grad():
+                    values = self._forward_micro_batch(micro_batch)
+                values_lst.append(values)
+            values = torch.concat(values_lst, dim=0)
+
+            if use_dynamic_bsz:
+                indices = list(itertools.chain.from_iterable(indices))
+                assert len(indices) == values.size(0), f"{len(indices)} vs. {values.size()}"
+                revert_indices = torch.tensor(get_reverse_idx(indices), dtype=torch.long)
+                values = values[revert_indices]
+                
+            responses = data.batch["responses"]
+            attention_mask = data.batch["attention_mask"]
+            response_length = responses.size(1)
+            response_mask = attention_mask[:, -response_length:]
+            values = values * response_mask # Only action tokens have values
+            return values
+
+        with self.engine.eval_mode():
+            data = self.engine.sharding_manager().preprocess_data(data=data)
+            raise ValueError
+            values = compute_values_impl(data=data)
+            output = DataProto.from_dict(tensors={"values": values})
+            output = self.engine.sharding_manager().postprocess_data(data=output)
+
+        # if self._is_offload_param:
+        #     load_fsdp_model_to_gpu(self.critic_module)
+        # # perform forward computation
+        # with self.ulysses_sharding_manager:
+        #     data = self.ulysses_sharding_manager.preprocess_data(data=data)
+        #     values = self.critic.compute_values(data=data)
+        #     output = DataProto.from_dict(tensors={"values": values})
+        #     output = self.ulysses_sharding_manager.postprocess_data(data=output)
+
+        output = output.to("cpu")
+        if self._is_offload_param:
+            offload_fsdp_model_to_cpu(self.critic_module)
+        return output
+
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def update_critic(self, data: DataProto):
+        # Support all hardwares
+        data = data.to(get_torch_device().current_device())
+        if self._is_offload_param:
+            load_fsdp_model_to_gpu(self.critic_module)
+        if self._is_offload_optimizer:
+            load_fsdp_optimizer(optimizer=self.critic_optimizer, device_id=get_torch_device().current_device())
+
+        # perform forward computation
+        with self.ulysses_sharding_manager:
+            data = self.ulysses_sharding_manager.preprocess_data(data=data)
+
+            with Timer(name="update_critic", logger=None) as timer:
+                metrics = self.critic.update_critic(data=data)
+            delta_time = timer.last
+
+            global_num_tokens = data.meta_info["global_token_num"]
+            estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
+            metrics["perf/mfu/critic"] = estimated_flops * self.config.ppo_epochs / promised_flops / self.world_size
+
+            self.critic_lr_scheduler.step()
+            lr = self.critic_lr_scheduler.get_last_lr()[0]
+            metrics["critic/lr"] = lr
+
+            output = DataProto(batch=None, meta_info={"metrics": metrics})
+            output = self.ulysses_sharding_manager.postprocess_data(data=output)
+
+        if self._is_offload_param:
+            offload_fsdp_model_to_cpu(self.critic_module)
+        if self._is_offload_optimizer:
+            offload_fsdp_optimizer(optimizer=self.critic_optimizer)
+
+        output = output.to("cpu")
+        return output
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
+        import torch
+
+        if self._is_offload_param:
+            load_fsdp_model_to_gpu(self.critic_module)
+
+        self.checkpoint_manager.save_checkpoint(local_path=local_path, hdfs_path=hdfs_path, global_step=global_step, max_ckpt_to_keep=max_ckpt_to_keep)
+
+        torch.distributed.barrier()
+        if self._is_offload_param:
+            offload_fsdp_model_to_cpu(self.critic_module)
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=True):
+        import torch
+
+        if self._is_offload_param:
+            load_fsdp_model_to_gpu(self.critic_module)
+
+        self.checkpoint_manager.load_checkpoint(local_path=local_path, hdfs_path=hdfs_path, del_local_after_load=del_local_after_load)
+
+        torch.distributed.barrier()
+        if self._is_offload_param:
+            offload_fsdp_model_to_cpu(self.critic_module)
+
+        if self._is_offload_optimizer:
+            offload_fsdp_optimizer(self.critic_optimizer)
+


### PR DESCRIPTION
# [Refactor] Training Engine Interface and Development Plan

## Motivation  
See the original RFC for background: https://github.com/volcengine/verl/issues/1371  

Modernizing our training loop requires that we:

- **Decouple** training-backend implementation from algorithm code so each can evolve independently  
- **Unify** on a single, well-defined `Engine` interface across FSDP/Megatron/etc backends  
- **Enable** unit-testing of each backend implementation in isolation  
- **Guarantee** algorithm “roles” (Critic, Actor, Rollout, Ref) remain completely engine-agnostic.
- **Preserve** the existing Roles interface exactly—so prior algorithms (e.g., `PPOTraining`) continue to work without change 

---

## Current Implementation  


### Classic Training Loop with the New Interface

```python
# 1. Build and initialize engine
engine = FSDPEngine(config)
engine.init_model()
engine.set_loss_fn(loss_fn)

# 2. Training loop
for epoch in range(config.num_epochs):
    for batch in train_loader:
        # a) zero gradients
        engine.optimizer_zero_grad()

        # b) forward + backward
        with engine.train_mode():
            preds, loss, ctx = engine.forward_backward_step(
                batch,
                ctx,
                forward_only=False,
                preprocess_fn=preprocess_fn,
                postprocess_fn=postprocess_fn
            )

        # c) update and schedule
        grad_norm = engine.optimizer_step()
        current_lr = engine.lr_scheduler_step()

# 3. Evaluation
with engine.eval_mode():
    for micro_batch in data:
        preds, ctx = engine.forward_backward_step(
            micro_batch,
            ctx,
            forward_only=True,
            preprocess_fn=preprocess_fn,
            postprocess_fn=postprocess_fn
        )
```

### Detailed BaseEngine Interface
We now introduce an abstract base class, `BaseEngine`, exposing core methods:

```python

class BaseEngine(object):
    """
    Abstract base class defining the interface for model training engines.

    Engine implementations must subclass BaseEngine and provide concrete behavior for all methods.
    """
    def __init__(self, config):
        """
        Initialize the BaseEngine.

        Args:
            config: Configuration object containing parameters for engine setup.
        """
        raise NotImplementedError

    def init_model(self):
        """
        Instantiate or load the model, optimizer, and learning rate scheduler.

        Should prepare all components necessary for training or evaluation.
        """
        raise NotImplementedError

    def train_mode(self):
        """
        Context manager entry for switching the engine and model into training mode.

        Usage:
            with engine.train_mode():
                # runs in training mode
        """
        raise NotImplementedError

    def eval_mode(self):        
        """
        Context manager entry for switching the engine and model into evaluation mode.

        Usage:
            with engine.eval_mode():
                # runs in evaluation mode
        """
        raise NotImplementedError

    def forward_backward_step(self, 
                              batch, 
                              ctx=None, 
                              forward_only=False, 
                              preprocess_fn=None, 
                              postprocess_fn=None):
        """
        Execute a forward pass (and optional backward pass) over a batch of data.

        Args:
            batch: Raw batch data (e.g., tensors or mappings) to process.
            ctx: Optional context dict passed to preprocess/postprocess functions.
            forward_only: If True, skip gradient computation and backward pass.
            preprocess_fn: Function(batch, ctx) -> (inputs, ctx), applied before model call.
            postprocess_fn: Function(outputs, ctx) -> (predictions, ctx), applied after model call.

        Returns:
            If forward_only:
                (predictions, ctx)
            Else:
                (predictions, loss, ctx)
        """
        raise NotImplementedError

    def optimizer_zero_grad(self):
        """
        Zero out gradients of all parameters before starting a new backward pass.
        """
        raise NotImplementedError

    def optimizer_step(self):
        """
        Perform an optimization step to update model parameters based on accumulated gradients.

        Returns:
            grad_norm (float): The norm of the gradients before clipping or update.
        """
        raise NotImplementedError

    def lr_scheduler_step(self):
        """
        Advance the learning rate scheduler by one step.

        Returns:
            current_lr (float or list[float]): Updated learning rate(s).
        """
        raise NotImplementedError

    def shard_data(self, data):
        """
        Shard or partition data for distributed training or parallel execution.

        Args:
            data: Data structure to be sharded across devices/workers.

        Returns:
            Sharded data in the same format as input.
        """
        raise NotImplementedError

    def unshard_data(self, data):
        """
        Reconstruct or gather sharded data back to a unified format.

        Args:
            data: Sharded data structure to reconstruct.

        Returns:
            Unsharded, combined data.
        """
        raise NotImplementedError
        

    def set_loss_fn(self, loss_fn):
        """
        Set the loss function to be used during training.

        Args:
            loss_fn: Callable(data, predictions, ctx) -> (loss_tensor, new_ctx)
        """
        raise NotImplementedError

    def to(self, device: str, model: bool = True, optimizer: bool = True):
        """
        Move model parameters, optimizer states, or both to the specified device.

        Args:
            device: Target device identifier (e.g., "cuda" or "cpu").
            model: If True, move the model.
            optimizer: If True, move the optimizer states.
        """
        raise NotImplementedError


    def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
        """
        Save model, optimizer, and scheduler states to a checkpoint.

        Args:
            local_path: Local filesystem path to save checkpoint.
            hdfs_path: Optional HDFS path to copy checkpoint.
            global_step: Integer training step number for naming.
            max_ckpt_to_keep: Maximum number of recent checkpoints to retain.
        """
        raise NotImplementedError


    def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=True):
        """
        Load model, optimizer, and scheduler states from a checkpoint.

        Args:
            local_path: Local filesystem path of the checkpoint.
            hdfs_path: Optional HDFS path where checkpoint is stored.
            del_local_after_load: Whether to delete local copy after loading.
        """
        raise NotImplementedError
```

### FSDPEngine Implementaion

A concrete `FSDPEngine` implements all methods using PyTorch FullyShardedDataParallel, supporting all the features that FSDP DPCritic Worker support:

- Multi-GPU/model sharding  
- Activation- and optimizer-offload  
- LoRA & sequence parallelism  
- Dynamic batch size and remove padding

### CriticWorker Implementation based on the FSDPEngine
- Unchanged public API 
- Each role calls only BaseEngine methods (init_model, train_mode/eval_mode, forward_backward_step, etc.)
- No modifications needed in existing algorithms (e.g., PPOTraining)
- New roles can be plugged in identically to legacy code

## Development Plan
We’ll roll this out in three gated phases, controlled by a feature-flag (`use_legacy_worker_impl`).

### Phase 1: Engine Development
> Flag: use_legacy_worker_impl = True (default)
> New interface under active development

- Refactor Critic, Actor, Rollout, Ref to use only BaseEngine APIs
- Design a hierarchical, immutable config system for engine/backends
- Ensure PPO training curves and final accuracy match legacy implementation

### Phase 2: Migration
> Flag: use_legacy_worker_impl = False (default) – legacy path logs a deprecation warning
> All new code targets the new interface; 2–3 months of integration/stress testing

- Enforce new interface for all feature work
- Gather benchmarks, bug reports, and performance data

### Phase 3: Cleanup
> After Phase 2 validation:
- Remove legacy worker code and flags
- Delete deprecated paths
- Finalize documentation, update changelogs, close deprecation notices

Please review this refactor and share any feedback or concerns!