### PR TITLE
Config NCCL Timeout for Megatron Backend Model Loading

### DIFF
--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -22,6 +22,7 @@ data:
 
 actor_rollout_ref:
   hybrid_engine: True
+  nccl_timeout: 600 # seconds, default is 10 minutes for torch, you can set it to a larger value if you have long-running operations like 32B or 72B model using megatron
   model:
     path: ~/models/deepseek-llm-7b-chat
     external_lib: null
@@ -196,6 +197,7 @@ actor_rollout_ref:
 critic:
   rollout_n: ${actor_rollout_ref.rollout.n}
   strategy: megatron
+  nccl_timeout: 600 # seconds, default is 10 minutes for torch, you can set it to a larger value if you have long-running operations like 32B or 72B model using megatron
   optim:
     optimizer: adam
     lr: 1e-6
@@ -267,6 +269,7 @@ critic:
 reward_model:
   enable: False
   strategy: megatron
+  nccl_timeout: 600 # seconds, default is 10 minutes for torch, you can set it to a larger value if you have long-running operations like 32B or 72B model using megatron
   megatron:
     param_offload: False
     tensor_model_parallel_size: 1

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -20,7 +20,7 @@ import os
 import time
 import warnings
 from typing import Union
-
+import datetime
 import torch
 import torch.distributed
 from codetiming import Timer
@@ -88,7 +88,7 @@ class ActorRolloutRefWorker(MegatronWorker):
         # 3. and apply the following patch in ray==2.10, https://github.com/ray-project/ray/pull/44385
         if not torch.distributed.is_initialized():
             rank = int(os.environ["LOCAL_RANK"])
-            torch.distributed.init_process_group(backend="nccl")
+            torch.distributed.init_process_group(backend="nccl", timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600)))
             torch.cuda.set_device(rank)
 
             if self.config.actor.megatron.sequence_parallel:
@@ -621,7 +621,7 @@ class CriticWorker(MegatronWorker):
         # 3. and apply the following patch in ray==2.10, https://github.com/ray-project/ray/pull/44385
         if not torch.distributed.is_initialized():
             rank = int(os.environ["LOCAL_RANK"])
-            torch.distributed.init_process_group(backend="nccl")
+            torch.distributed.init_process_group(backend="nccl", timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600)))
             torch.cuda.set_device(rank)
 
             if self.config.megatron.sequence_parallel:
@@ -835,7 +835,7 @@ class RewardModelWorker(MegatronWorker):
         # 3. and apply the following patch in ray==2.10, https://github.com/ray-project/ray/pull/44385
         if not torch.distributed.is_initialized():
             rank = int(os.environ["LOCAL_RANK"])
-            torch.distributed.init_process_group(backend="nccl")
+            torch.distributed.init_process_group(backend="nccl", timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600)))
             torch.cuda.set_device(rank)
 
             if self.config.megatron.sequence_parallel:


### PR DESCRIPTION
### Checklist Before Starting

- [x] Searched for similar PR(s).

### What does this PR do?

> This merge request addresses an issue encountered when using Megatron as the backend for loading models with `load_state_dict_to_megatron_gptmodel`. Specifically, when loading 32B or larger models on 64 or more GPUs, it is common to exceed the default NCCL timeout of 10 minutes(default 10 mins for [torch.distributed.init_process_group("nccl")](https://docs.pytorch.org/docs/stable/distributed.html), leading to errors during the[ dist.barrier() ](https://github.com/none0663/verl/blob/a1a152ee4ad93c1511ebdfb53df6687e272e2e76/verl/models/mcore/loader.py#L463)call.

https://github.com/none0663/verl/blob/a1a152ee4ad93c1511ebdfb53df6687e272e2e76/verl/models/mcore/loader.py#L360

https://github.com/none0663/verl/blob/a1a152ee4ad93c1511ebdfb53df6687e272e2e76/verl/models/mcore/loader.py#L463


To mitigate this issue, this PR introduces a configuration option to increase the NCCL timeout. This enhancement allows users to easily adjust the timeout duration when encountering errors, improving the robustness of model loading in distributed settings.

Thank you for considering this change!
