### PR TITLE
Fix TypeError by Removing Duplicate Arguments in run_deepseek671b_math_megatron.sh

### DIFF
--- a/examples/grpo_trainer/run_deepseek671b_math_megatron.sh
+++ b/examples/grpo_trainer/run_deepseek671b_math_megatron.sh
@@ -82,8 +82,6 @@ python3 -m verl.trainer.main_ppo --config-path=./config --config-name='ppo_megat
     trainer.test_freq=5 \
     +actor_rollout_ref.actor.megatron.override_transformer_config.num_layers_in_first_pipeline_stage=3 \
     +actor_rollout_ref.actor.megatron.override_transformer_config.num_layers_in_last_pipeline_stage=2 \
-    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_router_bias_update_rate=0.0 \
-    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_aux_loss_coeff=0.0001 \
     actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=$PP \
     actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=$PP \
     actor_rollout_ref.actor.megatron.tensor_model_parallel_size=$TP \

--- a/examples/grpo_trainer/run_deepseek671b_math_megatron.sh
+++ b/examples/grpo_trainer/run_deepseek671b_math_megatron.sh
@@ -1,9 +1,10 @@
 set -x
 
 # 0. download the config
-# only need to download the configuration_deepseek.py and config.json
+# only need to download the `configuration_deepseek.py`, `config.json`, `tokenizer_config.json`, `tokenizer.json` and `generation_config.json`
 # remove the `quantization_config` in the `config.json`
 # set `num_nextn_predict_layers=0` to disable MTP, which is not currently supported
+
 huggingface-cli download deepseek-ai/DeepSeek-V3-0324 configuration_deepseek.py config.json
 
 # 1. download the dist_ckpt format model from https://huggingface.co/BearBiscuit05/dpsk-v3-671B-BF16-dist_ckpt/tree/main


### PR DESCRIPTION
### Checklist Before Starting

- [x] Searched for similar PR(s).

### What does this PR do?

> This merge request addresses a potential TypeError that arises when running run_deepseek671b_math_megatron.sh. The parameters `moe_router_bias_update_r` and `moe_aux_loss_coeff` are already present in the `hf_to_mcore_config_dpskv3` function's `_get_mla_transformer_config`. Including them again in the script leads to the error:
`
TypeError: verl.models.mcore.config_converter._get_mla_transformer_config() got multiple values for keyword argument 'moe_router_bias_update_r' and 'moe_aux_loss_coeff'.`
https://github.com/volcengine/verl/blob/13475caaa9bb1b89b1a29f850f0b54253a8c2d38/verl/models/mcore/config_converter.py#L252C19-L252C46

To resolve this issue, this PR removes the duplicate arguments from the script, ensuring that the function is called correctly without any conflicts.