### PR TITLE
[ci] chore: add documentation coverage test

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -85,3 +85,5 @@ jobs:
             echo "Please use verl instead of veRL in the codebase"
             exit 1
           fi
+      - name: Assert documentation requirement for functions
+        run: python3 tests/special_sanity/validate_imported_docs.py

--- a/tests/special_sanity/validate_imported_docs.py
+++ b/tests/special_sanity/validate_imported_docs.py
@@ -1,0 +1,136 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+verify_imported_docs.py
+
+Assert that every function or class *explicitly imported* (via
+`from <module> import <name>`) in a given Python file has a docstring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib
+import inspect
+import pathlib
+import sys
+from typing import List
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Verify that imported functions/classes have docstrings."
+    )
+    p.add_argument(
+        "--target-file",
+        default='verl/trainer/ppo/ray_trainer.py',
+        help="Path to the Python source file to analyse "
+             "(e.g. verl/trainer/ppo/ray_trainer.py)",
+    )
+    p.add_argument(
+        "--allow-list",
+        default=['omegaconf.open_dict'],
+        help="a list of third_party dependencies that do not have proper docs :(",
+    )
+    p.add_argument(
+        "--project-root",
+        default=".",
+        help="Directory to prepend to PYTHONPATH so local packages resolve (default: .)",
+    )
+    p.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress success message (still prints errors).",
+    )
+    return p.parse_args()
+
+
+def _import_attr(module_name: str, attr_name: str):
+    """Import `module_name` then return `getattr(module, attr_name)`."""
+    module = importlib.import_module(module_name)
+    return getattr(module, attr_name)
+
+
+def _check_file(py_file: pathlib.Path, project_root: pathlib.Path, allow_list: List[str]) -> List[str]:
+    """Return a list of error strings (empty == success)."""
+    # Ensure local packages resolve
+    sys.path.insert(0, str(project_root.resolve()))
+
+    tree = ast.parse(py_file.read_text(), filename=str(py_file))
+    problems: List[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+
+        # Relative imports (level > 0) get the leading dots stripped
+        module_name = "." * node.level + (node.module or "")
+        for alias in node.names:
+            if alias.name == "*":
+                problems.append(
+                    f"{py_file}:{node.lineno} - wildcard import "
+                    f"`from {module_name} import *` cannot be verified."
+                )
+                continue
+
+            imported_name = alias.name
+
+            try:
+                obj = _import_attr(module_name, imported_name)
+            except Exception as exc:  # pragma: no cover – wide net for import quirks
+                pass
+                # For some reason the module cannot be imported, skip for now
+                # problems.append(
+                #     f"{py_file}:{node.lineno} - could not resolve "
+                #     f"`{imported_name}` from `{module_name}` ({exc})"
+                # )
+                continue
+
+            if f"{module_name}.{imported_name}" in allow_list:
+                continue
+            if inspect.isfunction(obj) or inspect.isclass(obj):
+                doc = inspect.getdoc(obj)
+                if not (doc and doc.strip()):
+                    kind = "class" if inspect.isclass(obj) else "function"
+                    problems.append(
+                        f"{py_file}:{node.lineno} - {kind} "
+                        f"`{module_name}.{imported_name}` is missing a docstring."
+                    )
+
+    return problems
+
+
+def main() -> None:
+    args = _parse_args()
+    target_path = pathlib.Path(args.target_file).resolve()
+    project_root = pathlib.Path(args.project_root).resolve()
+
+    if not target_path.is_file():
+        raise Exception(f"❌ Target file not found: {target_path}")
+
+    errors = _check_file(target_path, project_root, args.allow_list)
+
+    if errors:
+        print("Docstring verification failed:\n")
+        print("\n".join(f" • {e}" for e in errors))
+        raise Exception("❌ Docstring verification failed.")
+
+    if not args.quiet:
+        print(f"✅ All explicitly imported functions/classes in {target_path} have docstrings.")
+
+
+if __name__ == "__main__":
+    main()

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -96,6 +96,7 @@ def pad_dataproto_to_divisor(data: "DataProto", size_divisor: int):
 
 
 def unpad_dataproto(data: "DataProto", pad_size):
+    """Unpad the data proto with pad_size. i.e. `data[:-pad_size]`"""
     if pad_size != 0:
         data = data[:-pad_size]
     return data

--- a/verl/utils/seqlen_balancing.py
+++ b/verl/utils/seqlen_balancing.py
@@ -187,13 +187,27 @@ def get_seqlen_balanced_partitions(seqlen_list: List[int], k_partitions: int, eq
 
 
 def log_seqlen_unbalance(seqlen_list: List[int], partitions: List[List[int]], prefix):
-    # add some metrics of seqlen sum on dp ranks
+    """
+    Calculate and log metrics related to sequence length imbalance before and after partitioning.
+
+    Args:
+        seqlen_list (List[int]): A list of sequence lengths for each item.
+        partitions (List[List[int]]): A list of partitions, where each inner list contains indices
+                                      from seqlen_list assigned to that partition.
+        prefix (str): A prefix to be added to each metric key in the returned dictionary.
+
+    Returns:
+        dict: A dictionary containing metrics related to sequence length imbalance.
+    """
+    # Get the number of partitions
     k_partition = len(partitions)
     # assert len(seqlen_list) % k_partition == 0
     batch_size = len(seqlen_list) // k_partition
     min_sum_seqlen = None
     max_sum_seqlen = None
     total_sum_seqlen = 0
+
+    # Iterate over each batch of sequence lengths
     for offset in range(0, len(seqlen_list), batch_size):
         cur_sum_seqlen = sum(seqlen_list[offset : offset + batch_size])
         if min_sum_seqlen is None or cur_sum_seqlen < min_sum_seqlen:


### PR DESCRIPTION
### Checklist Before Starting

- [x] Searched for similar PR(s).
- [x] Checked PR Title format
  - [ ] In format of: [modules] type: Title
  - [ ] modules are in `fsdp, megatron, sglang, vllm, rollout, trainer, tests, training_utils, recipe, hardware, deployment, ray, worker, single_controller, misc, perf, model, algo, env, tool, ckpt, doc`
  - [ ] type is in `feat, fix, refactor, chore`
  - [ ] can involve multiple modules, seperated by `,` or space, like `[megatron, fsdp, doc] feat: xxx`

### What does this PR do?

Added a test that asserts every function and class imported by a target file verl/trainer/ppo/ray_trainer.py. We may extend this test further for all frequently inspected/extended modules.



### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title `description` if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] New CI unit test(s) are added to cover the code path.
- [ ] Rely on existing unit tests on CI that covers the code path.
