### PR TITLE
[worker] feat: add support for dynamic batch size of multimodal data

### DIFF
--- a/examples/grpo_trainer/run_qwen2_5_vl-7b_seq_balance.sh
+++ b/examples/grpo_trainer/run_qwen2_5_vl-7b_seq_balance.sh
@@ -1,0 +1,47 @@
+set -x
+ENGINE=${1:-vllm}
+# If you are using vllm<=0.6.3, you might need to set the following environment variable to avoid bugs:
+# export VLLM_ATTENTION_BACKEND=XFORMERS
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files=$HOME/data/geo3k/train.parquet \
+    data.val_files=$HOME/data/geo3k/test.parquet \
+    data.train_batch_size=512 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=2048 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    data.image_key=images \
+    actor_rollout_ref.model.path=Qwen/Qwen2.5-VL-7B-Instruct \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.ppo_mini_batch_size=128 \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=6144 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.01 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=False \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.n=5 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=6144 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.use_kl_in_reward=False \
+    trainer.critic_warmup=0 \
+    trainer.logger=['console','wandb'] \
+    trainer.project_name='verl_grpo_example_geo3k' \
+    trainer.experiment_name='qwen2_5_vl_7b_function_rm' \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=20 \
+    trainer.test_freq=5 \
+    trainer.total_epochs=15 $@

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -193,12 +193,12 @@ class RLHFDataset(Dataset):
             multi_modal_data = {}
 
             images = None
-            if self.image_key in row_dict:
+            if self.image_key in row_dict and row_dict.get(self.image_key, None) is not None:
                 images = [process_image(image) for image in row_dict.pop(self.image_key)]
                 multi_modal_data["image"] = images
 
             videos = None
-            if self.video_key in row_dict:
+            if self.video_key in row_dict and row_dict.get(self.video_key, None) is not None:
                 videos = [process_video(video) for video in row_dict.pop(self.video_key)]
                 multi_modal_data["video"] = [video.numpy() for video in videos]
 

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -289,16 +289,43 @@ class DataParallelPPOActor(BasePPOActor):
         batch = data.select(batch_keys=select_keys).batch
         has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
 
-        if has_multi_modal_inputs:
-            num_micro_batches = data.batch.batch_size[0] // micro_batch_size
-            non_tensor_select_keys = ["multi_modal_inputs"]
-            micro_batches = data.select(select_keys, non_tensor_select_keys).chunk(num_micro_batches)
-        elif use_dynamic_bsz:
-            # split using dynamic bsz
-            max_token_len = data.meta_info["max_token_len"] * self.ulysses_sequence_parallel_size
-            micro_batches, indices = rearrange_micro_batches(batch=batch, max_token_len=max_token_len)
-        else:
-            micro_batches = batch.split(micro_batch_size)
+        def _get_micro_batches(data: DataProto) -> Tuple[list, list | None]:
+            micro_batch_size_config = data.meta_info.get("micro_batch_size")  # Used for non-dynamic
+            use_dynamic_bsz = data.meta_info.get("use_dynamic_bsz", False)
+
+            batch_tensordict = data.batch  # This is a TensorDict
+            has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch
+
+            if has_multi_modal_inputs:
+                all_multi_modal_inputs_list = data.non_tensor_batch["multi_modal_inputs"]
+                if use_dynamic_bsz:
+                    max_token_len = data.meta_info["max_token_len"] * self.ulysses_sequence_parallel_size
+                    rearranged_text_micro_batches_tds, textual_indices = rearrange_micro_batches(
+                        batch=batch_tensordict, max_token_len=max_token_len
+                    )
+
+                    final_micro_batches_list = []
+                    for i, text_mb_td in enumerate(rearranged_text_micro_batches_tds):
+                        current_original_indices = textual_indices[i]
+                        current_mm_inputs_list = [all_multi_modal_inputs_list[idx] for idx in current_original_indices]
+
+                        mb_dict = {k: v for k, v in text_mb_td.items()}
+                        mb_dict["multi_modal_inputs"] = current_mm_inputs_list
+                        final_micro_batches_list.append(mb_dict)
+                    return final_micro_batches_list, textual_indices
+                else:
+                    num_micro_batches = batch_tensordict.batch_size[0] // micro_batch_size_config
+                    micro_batches_dp = data.chunk(num_micro_batches)  # Returns List[DataProto]
+                    return micro_batches_dp, None
+            elif use_dynamic_bsz:
+                max_token_len = data.meta_info["max_token_len"] * self.ulysses_sequence_parallel_size
+                micro_batches_tds, indices = rearrange_micro_batches(batch=batch_tensordict, max_token_len=max_token_len)
+                return micro_batches_tds, indices
+            else:
+                micro_batches_tds = batch_tensordict.split(micro_batch_size_config)
+                return micro_batches_tds, None
+
+        micro_batches, indices = _get_micro_batches(data)
 
         log_probs_lst = []
         entropy_lst = []
@@ -356,9 +383,25 @@ class DataParallelPPOActor(BasePPOActor):
                 # split batch into micro_batches
                 mini_batch = data
                 if has_multi_modal_inputs:
-                    self.gradient_accumulation = self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
-                    num_micro_batches = mini_batch.batch.batch_size[0] // self.config.ppo_micro_batch_size_per_gpu
-                    micro_batches = data.select(select_keys, non_tensor_select_keys).chunk(num_micro_batches)
+                    micro_batches = []
+                    if self.config.use_dynamic_bsz:
+                        all_multi_modal_inputs_list = data.non_tensor_batch["multi_modal_inputs"]
+                        batch_tensordict_for_rearrange = data.batch
+
+                        max_token_len = self.config.ppo_max_token_len_per_gpu * self.ulysses_sequence_parallel_size
+                        rearranged_text_micro_batches_tds, textual_indices = rearrange_micro_batches(
+                            batch=batch_tensordict_for_rearrange, max_token_len=max_token_len
+                        )
+
+                        for current_original_indices, text_mb_td in zip(textual_indices, rearranged_text_micro_batches_tds):
+                            current_mm_inputs_list = [all_multi_modal_inputs_list[idx] for idx in current_original_indices]
+                            mb_dict = {k: v for k, v in text_mb_td.items()}
+                            mb_dict["multi_modal_inputs"] = current_mm_inputs_list
+                            micro_batches.append(mb_dict)
+                    else:
+                        self.gradient_accumulation = self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
+                        num_micro_batches = mini_batch.batch.batch_size[0] // self.config.ppo_micro_batch_size_per_gpu
+                        micro_batches = data.select(select_keys, non_tensor_select_keys).chunk(num_micro_batches)
                 elif self.config.use_dynamic_bsz:
                     max_token_len = self.config.ppo_max_token_len_per_gpu * self.ulysses_sequence_parallel_size
                     micro_batches, _ = rearrange_micro_batches(batch=mini_batch, max_token_len=max_token_len)
@@ -373,6 +416,17 @@ class DataParallelPPOActor(BasePPOActor):
                     # Support all hardwares
                     if isinstance(data, DataProto):
                         data = {**data.batch.to(get_device_id()), **data.non_tensor_batch}
+                    elif isinstance(data, dict):
+                        for k, v in data.items():
+                            if isinstance(v, torch.Tensor):
+                                data[k] = v.to(get_device_id())
+                            elif k == "multi_modal_inputs" and v is not None:
+                                data[k] = [
+                                    {kk: vv.to(get_device_id()) for kk, vv in item_dict.items()}
+                                    for item_dict in v
+                                ]
+                            else:
+                                data[k] = v
                     else:
                         data = data.to(get_device_id())  # actor device is cpu when using offload
                     responses = data["responses"]


### PR DESCRIPTION
### Checklist Before Starting

- [x] Searched for similar PR(s).
- [x] Checked PR Title format
  - In format of: [modules] type: Title
  - modules are in `fsdp, megatron, sglang, vllm, rollout, trainer, ci, training_utils, recipe, hardware, deployment, ray, worker, single_controller, misc, perf, model, algo, env, tool, ckpt, doc, data`
  - type is in `feat, fix, refactor, chore`
  - can involve multiple modules, seperated by `,` or space, like `[megatron, fsdp, doc] feat: xxx`

### What does this PR do?

Add support for dynamic batch size (data packing) of multimodal dataset.

Add an example script `examples/grpo_trainer/run_qwen2_5_vl-7b_seq_balance.sh`.
### Test

The console log from training Qwen2.5-VL-7B with PPO on the Geo3K dataset (`examples/grpo_trainer/run_qwen2_5_vl-7b_seq_balance.sh`). The experiment was conducted on a single node
with 8 NVIDIA A800 GPUs.  

```
[2025-06-17 02:42:10] (WorkerDict pid=13539) Skipping monkey patch for Qwen2_5_VLForConditionalGeneration as use_fused_kernels is False or fused_kernels_backend is torch [repeated 7x across cluster]
[2025-06-17 02:42:10] (WorkerDict pid=13361) Model config after override: Qwen2_5_VLConfig {
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "architectures": [
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "Qwen2_5_VLForConditionalGeneration"
[2025-06-17 02:42:10] (WorkerDict pid=13361)   ],
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "attention_dropout": 0.0,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "eos_token_id": 151645,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "hidden_act": "silu",
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "hidden_size": 3584,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "image_token_id": 151655,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "initializer_range": 0.02,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "intermediate_size": 18944,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "max_position_embeddings": 128000,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "max_window_layers": 28,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "model_type": "qwen2_5_vl",
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "num_attention_heads": 28,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "num_hidden_layers": 28,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "num_key_value_heads": 4,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "pad_token_id": 151643,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "rms_norm_eps": 1e-06,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "rope_scaling": {
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "mrope_section": [
[2025-06-17 02:42:10] (WorkerDict pid=13361)       16,
[2025-06-17 02:42:10] (WorkerDict pid=13361)       24,
[2025-06-17 02:42:10] (WorkerDict pid=13361)       24
[2025-06-17 02:42:10] (WorkerDict pid=13361)     ],
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "rope_type": "default",
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "type": "default"
[2025-06-17 02:42:10] (WorkerDict pid=13361)   },
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "rope_theta": 1000000.0,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "sliding_window": 32768,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "tie_word_embeddings": false,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "torch_dtype": "bfloat16",
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "transformers_version": "4.51.0",
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "use_cache": true,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "use_sliding_window": false,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "video_token_id": 151656,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "vision_config": {
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "depth": 32,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "fullatt_block_indexes": [
[2025-06-17 02:42:10] (WorkerDict pid=13361)       7,
[2025-06-17 02:42:10] (WorkerDict pid=13361)       15,
[2025-06-17 02:42:10] (WorkerDict pid=13361)       23,
[2025-06-17 02:42:10] (WorkerDict pid=13361)       31
[2025-06-17 02:42:10] (WorkerDict pid=13361)     ],
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "hidden_act": "silu",
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "hidden_size": 1280,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "in_channels": 3,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "in_chans": 3,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "intermediate_size": 3420,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "model_type": "qwen2_5_vl",
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "num_heads": 16,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "out_hidden_size": 3584,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "patch_size": 14,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "spatial_merge_size": 2,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "spatial_patch_size": 14,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "temporal_patch_size": 2,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "tokens_per_second": 2,
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "torch_dtype": "float32",
[2025-06-17 02:42:10] (WorkerDict pid=13361)     "window_size": 112
[2025-06-17 02:42:10] (WorkerDict pid=13361)   },
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "vision_end_token_id": 151653,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "vision_start_token_id": 151652,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "vision_token_id": 151654,
[2025-06-17 02:42:10] (WorkerDict pid=13361)   "vocab_size": 152064
[2025-06-17 02:42:10] (WorkerDict pid=13361) }
[2025-06-17 02:42:10] (WorkerDict pid=13361) 
[2025-06-17 02:42:10] (WorkerDict pid=13361) Monkey patch FlashAttention2.forward in Qwen2.5VL
[2025-06-17 02:42:10] (WorkerDict pid=13361) Monkey patch _flash_attention_forward in transformers.models.qwen2_5_vl.modeling_qwen2_5_vl
[2025-06-17 02:42:10] (WorkerDict pid=13361) Skipping monkey patch for Qwen2_5_VLForConditionalGeneration as use_fused_kernels is False or fused_kernels_backend is torch
[2025-06-17 02:42:10] (WorkerDict pid=13541) Monkey patch FlashAttention2.forward in Qwen2.5VL
[2025-06-17 02:42:10] (WorkerDict pid=13541) Monkey patch _flash_attention_forward in transformers.models.qwen2_5_vl.modeling_qwen2_5_vl
[2025-06-17 02:42:10] (WorkerDict pid=13541) Skipping monkey patch for Qwen2_5_VLForConditionalGeneration as use_fused_kernels is False or fused_kernels_backend is torch
[2025-06-17 02:42:10] (WorkerDict pid=13361) Qwen2_5_VLForConditionalGeneration contains 8.29B parameters
[2025-06-17 02:42:10] (WorkerDict pid=13361) wrap_policy: functools.partial(<function _or_policy at 0x7f8504485b40>, policies=[functools.partial(<function transformer_auto_wrap_policy at 0x7f8504485a20>, transformer_layer_cls={<class 'transformers.models.qwen2_5_vl.modeling_qwen2_5_vl.Qwen2_5_VLDecoderLayer'>, <class 'transformers.models.qwen2_5_vl.modeling_qwen2_5_vl.Qwen2_5_VLVisionBlock'>})])
[2025-06-17 02:42:10] (WorkerDict pid=13361) Total steps: 60, num_warmup_steps: 0
[2025-06-17 02:42:10] (WorkerDict pid=13361) Actor use_remove_padding=True
[2025-06-17 02:42:10] (WorkerDict pid=13361) Actor use_fused_kernels=False
[2025-06-17 02:42:10] (WorkerDict pid=13543) Monkey patch FlashAttention2.forward in Qwen2.5VL [repeated 6x across cluster]
[2025-06-17 02:42:10] (WorkerDict pid=13543) Monkey patch _flash_attention_forward in transformers.models.qwen2_5_vl.modeling_qwen2_5_vl [repeated 6x across cluster]
[2025-06-17 02:42:10] (WorkerDict pid=13543) Skipping monkey patch for Qwen2_5_VLForConditionalGeneration as use_fused_kernels is False or fused_kernels_backend is torch [repeated 6x across cluster]
[2025-06-17 02:42:10] (WorkerDict pid=13361) WARNING 06-16 18:40:12 [utils.py:2444] Methods determine_num_available_blocks,device_config,get_cache_block_size_bytes,initialize_cache not implemented in <vllm.v1.worker.gpu_worker.Worker object at 0x7f830d065330>
[2025-06-17 02:42:10] (WorkerDict pid=13540) NCCL version 2.21.5+cuda12.4
Training Progress:   0%|          | 0/60 [00:00<?, ?it/s]
[2025-06-17 02:42:18] (WorkerDict pid=13539) /**********/envs/verl/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:690: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html . [repeated 5x across cluster]
[2025-06-17 02:42:18] (WorkerDict pid=13539)   warnings.warn( [repeated 5x across cluster]
Training Progress:   2%|▏         | 1/60 [04:09<4:05:26, 249.60s/it]
[2025-06-17 02:46:27] (WorkerDict pid=13537) /**********/envs/verl/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:690: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html . [repeated 2x across cluster]
[2025-06-17 02:46:27] (WorkerDict pid=13537)   warnings.warn( [repeated 2x across cluster]
```

### Usage Example

```bash
bash examples/grpo_trainer/run_qwen2_5_vl-7b_seq_balance.sh
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title `description` if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] New CI unit test(s) are added to cover the code path.
- [ ] Rely on existing unit tests on CI that covers the code path.
