### PR TITLE
modify the default value of disable_mm_preprocessor_cache

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -172,7 +172,7 @@ class AsyncvLLMServer(AsyncServerBase):
             enforce_eager=config.enforce_eager,
             gpu_memory_utilization=config.gpu_memory_utilization,
             disable_custom_all_reduce=True,
-            disable_mm_preprocessor_cache=True,
+            disable_mm_preprocessor_cache=False,
             skip_tokenizer_init=False,
             max_model_len=max_model_len,
             load_format="auto",

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -155,7 +155,7 @@ class vLLMRollout(BaseRollout):
             enforce_eager=config.enforce_eager,
             gpu_memory_utilization=config.gpu_memory_utilization,
             disable_custom_all_reduce=True,
-            disable_mm_preprocessor_cache=True,
+            disable_mm_preprocessor_cache=False,
             skip_tokenizer_init=False,
             max_model_len=max_model_len,
             load_format=load_format,


### PR DESCRIPTION
All scripts using LLM (Non-VLM + vllm rollout backend) break (Error details can be found at issue https://github.com/volcengine/verl/issues/1923, also mentioned in PR https://github.com/volcengine/verl/pull/1900)
This error currently occurs in vllm>=0.9.0).

The reason is that `disable_mm_preprocessor_cache=True` only works for VLM, and will cause errors for non-VLM models.

It appears that the default value in vllm is `False` and it's recommended to be set to False, even for VLM, according to official guidelines below:

https://github.com/vllm-project/vllm/blob/ca94d7fa007d113f2daf74e2f2278c03be676e93/vllm/config.py#L380C5-L382

Therefore, it's would be better to set `disable_mm_preprocessor_cache` to `False` here.
