### PR TITLE
[trainer] Fix trainer config for `val_only`

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -935,6 +935,9 @@ trainer:
   # Whether to run validation before training begins
   val_before_train: True
 
+  # Whether to run validation only
+  val_only: False
+
   # Validation frequency (in training iterations)
   test_freq: -1
 


### PR DESCRIPTION
### Checklist Before Starting

- [x] Searched for similar PR(s).
- [x] Checked PR Title format
  - In format of: [modules] type: Title
  - modules are in `fsdp, megatron, sglang, vllm, rollout, trainer, ci, training_utils, recipe, hardware, deployment, ray, worker, single_controller, misc, perf, model, algo, env, tool, ckpt, doc, data`
  - type is in `feat, fix, refactor, chore, test`
  - can involve multiple modules, seperated by `,` or space, like `[megatron, fsdp, doc] feat: xxx`

### What does this PR do?

fix: val_only not in trainer structure

### Test

no need.

### High-Level Design

no need.

### Specific Changes

- verl/trainer/config/ppo_trainer.yaml

### API

no need.

### Usage Example

> For eval only

```python
python3 -m verl.trainer.main_ppo \
...
trainer.val_before_train=True \
trainer.val_only=True \
...
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).