### PR TITLE
[fsdp] refactor: set actor's strategy as default for critic and ref

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -316,7 +316,7 @@ actor_rollout_ref:
   ref:
 
     # actor_rollout_ref.ref: FSDP config same as actor. For models larger than 7B, it’s recommended to turn on offload for ref by default
-    strategy: fsdp
+    strategy: ${actor_rollout_ref.actor.strategy}
 
     # config for FSDP strategy
     fsdp_config:
@@ -551,7 +551,7 @@ critic:
   rollout_n: ${actor_rollout_ref.rollout.n}
 
   # fsdp or fsdp2 strategy used for critic model training
-  strategy: fsdp
+  strategy: ${actor_rollout_ref.actor.strategy}
 
   # optimizer configs
   optim:
@@ -716,7 +716,7 @@ reward_model:
   enable: False
 
   # FSDP strategy: "fsdp" or "fsdp2"
-  strategy: fsdp
+  strategy: ${actor_rollout_ref.actor.strategy}
 
   # model config for reward scoring
   model:


### PR DESCRIPTION
### What does this PR do?

Set actor's strategy as the default strategy for critic, ref and reward model. In principle, all actors should use the same strategy. With this change, we can set `STRATEGY=fsdp2` in `run_function_reward.sh` and all models can use fsdp2 as strategy, instead of setting it for each role individually.

### Checklist Before Describing the Details

- [x] Searched for similar PR(s).
- [x] PR title is in the format of: `[modules] type: Title`
  - modules are in `fsdp, megatron, sglang, vllm, rollout, trainer, ci, training_utils, recipe, hardware, deployment, ray, worker, single_controller, misc, perf, model, algo, env, tool, ckpt, doc, data, cfg`
  - type is in `feat, fix, refactor, chore, test`
  - multiple modules are seperated by `,` or space, such as `[megatron, fsdp, doc] feat: xxx`

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit run --show-diff-on-failure --color=always --all-files`
- [x] Add `[BREAKING]` to the PR title `description` if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] New CI unit test(s) are added to cover the code path.
- [x] Rely on existing unit tests on CI that covers the code path.
