### PR TITLE
[sglang] feat: Add multi-interaction registry support and testing

### DIFF
--- a/.github/workflows/sgl.yml
+++ b/.github/workflows/sgl.yml
@@ -65,7 +65,6 @@ on:
       - ".github/workflows/sgl.yml"
       - "tests/rollout/*sglang*"
       - "tests/rollout/async_rollout_utils.py"
-      - "tests/interactions/**"
       - "tests/workers/rollout/*interaction*"
 
 # Cancel jobs on the same ref if a new one is triggered
@@ -104,14 +103,6 @@ jobs:
           huggingface-cli download 'Qwen/Qwen2-7B-Instruct'
           huggingface-cli download 'Qwen/Qwen2.5-0.5B'
           export HF_HUB_OFFLINE=1
-      - name: Test GSM8K Interaction
-        run: |
-          cd tests/interactions
-          pytest -s test_gsm8k_interaction.py
-      - name: Test Interaction Registry
-        run: |
-          cd tests/interactions
-          pytest -s test_interaction_registry.py
       - name: Test the latest SGLang
         run: |
           cd tests/workers/rollout

--- a/.github/workflows/sgl.yml
+++ b/.github/workflows/sgl.yml
@@ -65,6 +65,8 @@ on:
       - ".github/workflows/sgl.yml"
       - "tests/rollout/*sglang*"
       - "tests/rollout/async_rollout_utils.py"
+      - "tests/interactions/**"
+      - "tests/workers/rollout/*interaction*"
 
 # Cancel jobs on the same ref if a new one is triggered
 concurrency:
@@ -100,11 +102,28 @@ jobs:
       - name: Download Model to Use
         run: |
           huggingface-cli download 'Qwen/Qwen2-7B-Instruct'
+          huggingface-cli download 'Qwen/Qwen2.5-0.5B'
           export HF_HUB_OFFLINE=1
+      - name: Test GSM8K Interaction
+        run: |
+          cd tests/interactions
+          pytest -s test_gsm8k_interaction.py
+      - name: Test Interaction Registry
+        run: |
+          cd tests/interactions
+          pytest -s test_interaction_registry.py
       - name: Test the latest SGLang
         run: |
           cd tests/workers/rollout
           torchrun --nnodes=1 --nproc_per_node=2 $(which pytest) -s test_sglang_spmd.py
+      - name: Test the latest SGLang Rollout async with interaction
+        run: |
+          cd tests/workers/rollout
+          torchrun --nnodes=1 --nproc_per_node=2 $(which pytest) -s test_sglang_async_rollout_w_interaction.py
+      - name: Test the latest SGLang Multi Interaction
+        run: |
+          cd tests/workers/rollout
+          torchrun --nnodes=1 --nproc_per_node=2 $(which pytest) -s test_sglang_multi_interaction.py
       - name: Test the latest SGLang Rollout async with tool
         run: |
           cd tests/workers/rollout

--- a/examples/data_preprocess/gsm8k_multiturn_w_interaction.py
+++ b/examples/data_preprocess/gsm8k_multiturn_w_interaction.py
@@ -78,6 +78,7 @@ if __name__ == "__main__":
                     "answer": answer_raw,
                     "question": question_raw,
                     "interaction_kwargs": {
+                        "name": "gsm8k",
                         "query": question,
                         "ground_truth": solution,
                     },

--- a/examples/sglang_multiturn/config/interaction_config/gsm8k_interaction_config.yaml
+++ b/examples/sglang_multiturn/config/interaction_config/gsm8k_interaction_config.yaml
@@ -1,3 +1,4 @@
 interaction:
-  - class_name: "verl.interactions.gsm8k_interaction.Gsm8kInteraction"
+  - name: "gsm8k"
+    class_name: "verl.interactions.gsm8k_interaction.Gsm8kInteraction"
     config: {}

--- a/tests/interactions/test_gsm8k_interaction.py
+++ b/tests/interactions/test_gsm8k_interaction.py
@@ -26,13 +26,14 @@ class TestGsm8kInteraction:
 
     def setup_method(self):
         """Set up test environment before each test method."""
-        self.config = {}
+        self.config = {"name": "gsm8k"}
         self.interaction = Gsm8kInteraction(self.config)
 
     def test_init(self):
         """Test Gsm8kInteraction initialization."""
         assert self.interaction._instance_dict == {}
         assert self.interaction.config == self.config
+        assert self.interaction.name == "gsm8k"
 
     @pytest.mark.asyncio
     async def test_start_interaction_with_instance_id(self):
@@ -378,3 +379,19 @@ class TestGsm8kInteraction:
         assert callable(self.interaction.generate_response)
         assert callable(self.interaction.calculate_score)
         assert callable(self.interaction.finalize_interaction)
+
+    def test_name_attribute_initialization(self):
+        """Test name attribute initialization with different configs."""
+        # Test with explicit name in config
+        config_with_name = {"name": "custom_gsm8k"}
+        interaction_with_name = Gsm8kInteraction(config_with_name)
+        assert interaction_with_name.name == "custom_gsm8k"
+
+        # Test with default name when not provided in config
+        config_without_name = {}
+        interaction_without_name = Gsm8kInteraction(config_without_name)
+        assert interaction_without_name.name == "interaction_agent"  # Default from BaseInteraction
+
+        # Test that name is accessible as attribute
+        assert hasattr(self.interaction, "name")
+        assert self.interaction.name == "gsm8k"

--- a/tests/interactions/test_interaction_registry.py
+++ b/tests/interactions/test_interaction_registry.py
@@ -158,7 +158,7 @@ class TestInteractionRegistry:
         config_content = {
             "interaction": [
                 {"class_name": "verl.interactions.base.BaseInteraction", "config": {}},
-                {"class_name": "some.module.CustomAgent", "config": {}},
+                {"class_name": "verl.interactions.gsm8k_interaction.Gsm8kInteraction", "config": {}},
             ]
         }
 
@@ -172,6 +172,6 @@ class TestInteractionRegistry:
             # Check that names were generated correctly
             assert len(interaction_map) == 2
             assert "base" in interaction_map  # BaseInteraction -> base
-            assert "customagent" in interaction_map  # CustomAgent -> customagent
+            assert "gsm8k" in interaction_map  # Gsm8kInteraction -> gsm8k
         finally:
             os.unlink(temp_config_path)

--- a/tests/interactions/test_interaction_registry.py
+++ b/tests/interactions/test_interaction_registry.py
@@ -1,0 +1,177 @@
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 ModelBest Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.interactions.base import BaseInteraction
+from verl.interactions.gsm8k_interaction import Gsm8kInteraction
+from verl.interactions.utils.interaction_registry import (
+    get_interaction_class,
+    initialize_interactions_from_config,
+)
+
+
+class TestInteractionRegistry:
+    def test_get_interaction_class(self):
+        """Test getting interaction class by name."""
+        # Test getting base interaction class
+        base_cls = get_interaction_class("verl.interactions.base.BaseInteraction")
+        assert base_cls == BaseInteraction
+
+        # Test getting gsm8k interaction class
+        gsm8k_cls = get_interaction_class("verl.interactions.gsm8k_interaction.Gsm8kInteraction")
+        assert gsm8k_cls == Gsm8kInteraction
+
+    def test_initialize_single_interaction_from_config(self):
+        """Test initializing single interaction from config."""
+        # Create temporary config file
+        config_content = {"interaction": [{"name": "test_gsm8k", "class_name": "verl.interactions.gsm8k_interaction.Gsm8kInteraction", "config": {}}]}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            OmegaConf.save(config_content, f.name)
+            temp_config_path = f.name
+
+        try:
+            interaction_map = initialize_interactions_from_config(temp_config_path)
+
+            # Check that interaction was created
+            assert len(interaction_map) == 1
+            assert "test_gsm8k" in interaction_map
+            assert isinstance(interaction_map["test_gsm8k"], Gsm8kInteraction)
+            assert interaction_map["test_gsm8k"].name == "test_gsm8k"
+        finally:
+            os.unlink(temp_config_path)
+
+    def test_initialize_multiple_interactions_from_config(self):
+        """Test initializing multiple interactions from config."""
+        config_content = {"interaction": [{"name": "gsm8k_solver", "class_name": "verl.interactions.gsm8k_interaction.Gsm8kInteraction", "config": {}}, {"name": "base_agent", "class_name": "verl.interactions.base.BaseInteraction", "config": {"custom_param": "test_value"}}]}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            OmegaConf.save(config_content, f.name)
+            temp_config_path = f.name
+
+        try:
+            interaction_map = initialize_interactions_from_config(temp_config_path)
+
+            # Check that both interactions were created
+            assert len(interaction_map) == 2
+            assert "gsm8k_solver" in interaction_map
+            assert "base_agent" in interaction_map
+
+            # Check types
+            assert isinstance(interaction_map["gsm8k_solver"], Gsm8kInteraction)
+            assert isinstance(interaction_map["base_agent"], BaseInteraction)
+
+            # Check names were injected
+            assert interaction_map["gsm8k_solver"].name == "gsm8k_solver"
+            assert interaction_map["base_agent"].name == "base_agent"
+
+            # Check custom config was passed
+            assert interaction_map["base_agent"].config.get("custom_param") == "test_value"
+        finally:
+            os.unlink(temp_config_path)
+
+    def test_initialize_interaction_without_explicit_name(self):
+        """Test that interaction name is derived from class name when not specified."""
+        config_content = {"interaction": [{"class_name": "verl.interactions.gsm8k_interaction.Gsm8kInteraction", "config": {}}]}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            OmegaConf.save(config_content, f.name)
+            temp_config_path = f.name
+
+        try:
+            interaction_map = initialize_interactions_from_config(temp_config_path)
+
+            # Check that interaction name was derived from class name
+            assert len(interaction_map) == 1
+            assert "gsm8k" in interaction_map  # Should be "gsm8k" after removing "interaction" suffix
+            assert isinstance(interaction_map["gsm8k"], Gsm8kInteraction)
+            assert interaction_map["gsm8k"].name == "gsm8k"
+        finally:
+            os.unlink(temp_config_path)
+
+    def test_initialize_empty_config(self):
+        """Test initializing from empty config."""
+        config_content = {"interaction": []}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            OmegaConf.save(config_content, f.name)
+            temp_config_path = f.name
+
+        try:
+            interaction_map = initialize_interactions_from_config(temp_config_path)
+            assert len(interaction_map) == 0
+        finally:
+            os.unlink(temp_config_path)
+
+    def test_invalid_class_name(self):
+        """Test handling of invalid class name."""
+        config_content = {"interaction": [{"name": "invalid", "class_name": "invalid.module.InvalidClass", "config": {}}]}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            OmegaConf.save(config_content, f.name)
+            temp_config_path = f.name
+
+        try:
+            with pytest.raises(ModuleNotFoundError):
+                initialize_interactions_from_config(temp_config_path)
+        finally:
+            os.unlink(temp_config_path)
+
+    def test_duplicate_interaction_names(self):
+        """Test handling of duplicate interaction names."""
+        config_content = {
+            "interaction": [
+                {"name": "duplicate", "class_name": "verl.interactions.base.BaseInteraction", "config": {}},
+                {"name": "duplicate", "class_name": "verl.interactions.gsm8k_interaction.Gsm8kInteraction", "config": {}},
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            OmegaConf.save(config_content, f.name)
+            temp_config_path = f.name
+
+        try:
+            with pytest.raises(ValueError, match="Duplicate interaction name 'duplicate' found"):
+                initialize_interactions_from_config(temp_config_path)
+        finally:
+            os.unlink(temp_config_path)
+
+    def test_auto_name_generation_edge_cases(self):
+        """Test automatic name generation for various class name patterns."""
+        config_content = {
+            "interaction": [
+                {"class_name": "verl.interactions.base.BaseInteraction", "config": {}},
+                {"class_name": "some.module.CustomAgent", "config": {}},
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            OmegaConf.save(config_content, f.name)
+            temp_config_path = f.name
+
+        try:
+            interaction_map = initialize_interactions_from_config(temp_config_path)
+
+            # Check that names were generated correctly
+            assert len(interaction_map) == 2
+            assert "base" in interaction_map  # BaseInteraction -> base
+            assert "customagent" in interaction_map  # CustomAgent -> customagent
+        finally:
+            os.unlink(temp_config_path)

--- a/tests/workers/rollout/test_sglang_multi_interaction.py
+++ b/tests/workers/rollout/test_sglang_multi_interaction.py
@@ -99,8 +99,8 @@ class TestSGLangMultiInteraction:
         config, temp_config_path = create_mock_config_with_multi_interactions()
 
         try:
-            # Mock only the SGLang engine - keep real distributed environment
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"):
+            # Mock SGLang engine and initialization methods like the reference test
+            with patch.object(SGLangRollout, "_init_distributed_env", return_value=None), patch.object(SGLangRollout, "_init_inference_engine", return_value=None), patch.object(SGLangRollout, "_init_sampling_params", return_value=None):
                 # Create a mock tokenizer
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
@@ -133,7 +133,7 @@ class TestSGLangMultiInteraction:
         config, temp_config_path = create_mock_config_with_multi_interactions()
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"):
+            with patch.object(SGLangRollout, "_init_distributed_env", return_value=None), patch.object(SGLangRollout, "_init_inference_engine", return_value=None), patch.object(SGLangRollout, "_init_sampling_params", return_value=None):
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
                 mock_tokenizer.eos_token_id = 2
@@ -213,7 +213,7 @@ class TestSGLangMultiInteraction:
         )
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"):
+            with patch.object(SGLangRollout, "_init_distributed_env", return_value=None), patch.object(SGLangRollout, "_init_inference_engine", return_value=None), patch.object(SGLangRollout, "_init_sampling_params", return_value=None):
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
                 mock_tokenizer.eos_token_id = 2
@@ -238,7 +238,7 @@ class TestSGLangMultiInteraction:
         config, temp_config_path = create_mock_config_with_multi_interactions()
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"):
+            with patch.object(SGLangRollout, "_init_distributed_env", return_value=None), patch.object(SGLangRollout, "_init_inference_engine", return_value=None), patch.object(SGLangRollout, "_init_sampling_params", return_value=None):
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
                 mock_tokenizer.eos_token_id = 2
@@ -283,7 +283,7 @@ class TestSGLangMultiInteraction:
             }
         )
 
-        with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"):
+        with patch.object(SGLangRollout, "_init_distributed_env", return_value=None), patch.object(SGLangRollout, "_init_inference_engine", return_value=None), patch.object(SGLangRollout, "_init_sampling_params", return_value=None):
             mock_tokenizer = MagicMock()
             mock_tokenizer.pad_token_id = 0
             mock_tokenizer.eos_token_id = 2

--- a/tests/workers/rollout/test_sglang_multi_interaction.py
+++ b/tests/workers/rollout/test_sglang_multi_interaction.py
@@ -90,7 +90,8 @@ class TestSGLangMultiInteraction:
 
         try:
             # Mock the SGLang engine and other dependencies
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+                mock_dist.get_world_size.return_value = 1
                 # Create a mock tokenizer
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
@@ -122,7 +123,8 @@ class TestSGLangMultiInteraction:
         config, temp_config_path = create_mock_config_with_multi_interactions()
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+                mock_dist.get_world_size.return_value = 1
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
                 mock_tokenizer.eos_token_id = 2
@@ -201,7 +203,8 @@ class TestSGLangMultiInteraction:
         )
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+                mock_dist.get_world_size.return_value = 1
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
                 mock_tokenizer.eos_token_id = 2
@@ -225,7 +228,8 @@ class TestSGLangMultiInteraction:
         config, temp_config_path = create_mock_config_with_multi_interactions()
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+                mock_dist.get_world_size.return_value = 1
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
                 mock_tokenizer.eos_token_id = 2
@@ -269,7 +273,8 @@ class TestSGLangMultiInteraction:
             }
         )
 
-        with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+        with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+            mock_dist.get_world_size.return_value = 1
             mock_tokenizer = MagicMock()
             mock_tokenizer.pad_token_id = 0
             mock_tokenizer.eos_token_id = 2

--- a/tests/workers/rollout/test_sglang_multi_interaction.py
+++ b/tests/workers/rollout/test_sglang_multi_interaction.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 """
 Test for multi-interaction support in SGLangRollout.
 usage: torchrun --standalone --nnodes=1 \
@@ -89,11 +90,8 @@ class TestSGLangMultiInteraction:
         config, temp_config_path = create_mock_config_with_multi_interactions()
 
         try:
-            # Mock the SGLang engine and other dependencies
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"), patch.dict(
-                os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}
-            ):
-                mock_dist.get_world_size.return_value = 1
+            # Mock only the SGLang engine - keep real distributed environment
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"):
                 # Create a mock tokenizer
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
@@ -125,10 +123,7 @@ class TestSGLangMultiInteraction:
         config, temp_config_path = create_mock_config_with_multi_interactions()
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"), patch.dict(
-                os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}
-            ):
-                mock_dist.get_world_size.return_value = 1
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"):
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
                 mock_tokenizer.eos_token_id = 2
@@ -207,10 +202,7 @@ class TestSGLangMultiInteraction:
         )
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"), patch.dict(
-                os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}
-            ):
-                mock_dist.get_world_size.return_value = 1
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"):
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
                 mock_tokenizer.eos_token_id = 2
@@ -234,10 +226,7 @@ class TestSGLangMultiInteraction:
         config, temp_config_path = create_mock_config_with_multi_interactions()
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"), patch.dict(
-                os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}
-            ):
-                mock_dist.get_world_size.return_value = 1
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"):
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
                 mock_tokenizer.eos_token_id = 2
@@ -281,8 +270,7 @@ class TestSGLangMultiInteraction:
             }
         )
 
-        with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"), patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}):
-            mock_dist.get_world_size.return_value = 1
+        with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"):
             mock_tokenizer = MagicMock()
             mock_tokenizer.pad_token_id = 0
             mock_tokenizer.eos_token_id = 2

--- a/tests/workers/rollout/test_sglang_multi_interaction.py
+++ b/tests/workers/rollout/test_sglang_multi_interaction.py
@@ -117,8 +117,14 @@ class TestSGLangMultiInteraction:
                 assert len(rollout.interaction_map) == 2
                 assert "mock_agent1" in rollout.interaction_map
                 assert "mock_agent2" in rollout.interaction_map
-                assert isinstance(rollout.interaction_map["mock_agent1"], MockInteraction)
-                assert isinstance(rollout.interaction_map["mock_agent2"], MockInteraction)
+
+                # Use class name comparison instead of isinstance for multi-process compatibility
+                assert rollout.interaction_map["mock_agent1"].__class__.__name__ == "MockInteraction"
+                assert rollout.interaction_map["mock_agent2"].__class__.__name__ == "MockInteraction"
+
+                # Also check that they are instances of BaseInteraction (which should work across processes)
+                assert isinstance(rollout.interaction_map["mock_agent1"], BaseInteraction)
+                assert isinstance(rollout.interaction_map["mock_agent2"], BaseInteraction)
 
                 # Check that names were set correctly
                 assert rollout.interaction_map["mock_agent1"].name == "mock_agent1"

--- a/tests/workers/rollout/test_sglang_multi_interaction.py
+++ b/tests/workers/rollout/test_sglang_multi_interaction.py
@@ -213,14 +213,13 @@ class TestSGLangMultiInteraction:
 
         try:
             with patch.object(SGLangRollout, "_init_distributed_env", return_value=None), patch.object(SGLangRollout, "_init_inference_engine", return_value=None), patch.object(SGLangRollout, "_init_sampling_params", return_value=None):
-                mock_tokenizer = MagicMock()
-                mock_tokenizer.pad_token_id = 0
-                mock_tokenizer.eos_token_id = 2
+                tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B", padding_side="left")
+                tokenizer.pad_token = tokenizer.eos_token
 
                 mock_model_config = MagicMock()
                 mock_model_config.max_position_embeddings = 2048
 
-                rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=mock_tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
+                rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
 
                 # Test that default interaction name works
                 interaction_kwargs_without_name = {"test_param": "value"}
@@ -238,14 +237,13 @@ class TestSGLangMultiInteraction:
 
         try:
             with patch.object(SGLangRollout, "_init_distributed_env", return_value=None), patch.object(SGLangRollout, "_init_inference_engine", return_value=None), patch.object(SGLangRollout, "_init_sampling_params", return_value=None):
-                mock_tokenizer = MagicMock()
-                mock_tokenizer.pad_token_id = 0
-                mock_tokenizer.eos_token_id = 2
+                tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B", padding_side="left")
+                tokenizer.pad_token = tokenizer.eos_token
 
                 mock_model_config = MagicMock()
                 mock_model_config.max_position_embeddings = 2048
 
-                rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=mock_tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
+                rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
 
                 # Test error when requesting non-existent interaction
                 non_existent_name = "non_existent_interaction"
@@ -283,16 +281,13 @@ class TestSGLangMultiInteraction:
         )
 
         with patch.object(SGLangRollout, "_init_distributed_env", return_value=None), patch.object(SGLangRollout, "_init_inference_engine", return_value=None), patch.object(SGLangRollout, "_init_sampling_params", return_value=None):
-            mock_tokenizer = MagicMock()
-            mock_tokenizer.pad_token_id = 0
-            mock_tokenizer.eos_token_id = 2
+            tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B", padding_side="left")
+            tokenizer.pad_token = tokenizer.eos_token
 
             mock_model_config = MagicMock()
             mock_model_config.max_position_embeddings = 2048
 
-            rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=mock_tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
+            rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
 
             # Check that no interactions were initialized
             assert len(rollout.interaction_map) == 0
-
-            # Should work without errors (backward compatibility)

--- a/tests/workers/rollout/test_sglang_multi_interaction.py
+++ b/tests/workers/rollout/test_sglang_multi_interaction.py
@@ -1,0 +1,285 @@
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 ModelBest Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test for multi-interaction support in SGLangRollout.
+usage: torchrun --standalone --nnodes=1 \
+    --nproc_per_node=2 $(which pytest) \
+    -s test_sglang_multi_interaction.py
+"""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from omegaconf import DictConfig, OmegaConf
+
+from verl.interactions.base import BaseInteraction
+from verl.workers.rollout.sglang_rollout.sglang_rollout import SGLangRollout
+
+
+class MockInteraction(BaseInteraction):
+    """Mock interaction for testing."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.started_instances = set()
+
+    async def start_interaction(self, instance_id=None, **kwargs):
+        if instance_id is None:
+            instance_id = "mock_instance"
+        self.started_instances.add(instance_id)
+        return instance_id
+
+    async def generate_response(self, instance_id, messages, **kwargs):
+        return False, f"Mock response from {self.name}", 1.0, {}
+
+
+def create_mock_config_with_multi_interactions():
+    """Create a mock configuration with multiple interactions."""
+    # Create temporary interaction config file
+    interaction_config = {
+        "interaction": [
+            {"name": "mock_agent1", "class_name": "tests.workers.rollout.test_sglang_multi_interaction.MockInteraction", "config": {"param1": "value1"}},
+            {"name": "mock_agent2", "class_name": "tests.workers.rollout.test_sglang_multi_interaction.MockInteraction", "config": {"param2": "value2"}},
+        ]
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        OmegaConf.save(interaction_config, f.name)
+        interaction_config_path = f.name
+
+    # Create mock SGLangRollout config
+    config = DictConfig(
+        {
+            "multi_turn": {"interaction_config_path": interaction_config_path, "tool_config_path": None, "enable": True, "max_assistant_turns": 5, "max_user_turns": 3, "use_inference_chat_template": True, "tokenization_sanity_check_mode": "off"},
+            "prompt_length": 32,
+            "response_length": 16,
+            "max_model_len": 512,
+            "dtype": "bfloat16",
+            "gpu_memory_utilization": 0.8,
+            "load_format": "dummy",
+            "enforce_eager": True,
+            "free_cache_engine": False,
+            "calculate_log_probs": False,
+            "tensor_model_parallel_size": 1,
+            "n": 1,
+            "val_kwargs": {"top_k": 1, "top_p": 1.0, "temperature": 0.0},
+        }
+    )
+
+    return config, interaction_config_path
+
+
+class TestSGLangMultiInteraction:
+    def test_initialize_multiple_interactions(self):
+        """Test that SGLangRollout can initialize multiple interactions."""
+        config, temp_config_path = create_mock_config_with_multi_interactions()
+
+        try:
+            # Mock the SGLang engine and other dependencies
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+                # Create a mock tokenizer
+                mock_tokenizer = MagicMock()
+                mock_tokenizer.pad_token_id = 0
+                mock_tokenizer.eos_token_id = 2
+
+                # Mock model config
+                mock_model_config = MagicMock()
+                mock_model_config.max_position_embeddings = 2048
+
+                # Create SGLangRollout instance
+                rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=mock_tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
+
+                # Check that interactions were initialized
+                assert len(rollout.interaction_map) == 2
+                assert "mock_agent1" in rollout.interaction_map
+                assert "mock_agent2" in rollout.interaction_map
+                assert isinstance(rollout.interaction_map["mock_agent1"], MockInteraction)
+                assert isinstance(rollout.interaction_map["mock_agent2"], MockInteraction)
+
+                # Check that names were set correctly
+                assert rollout.interaction_map["mock_agent1"].name == "mock_agent1"
+                assert rollout.interaction_map["mock_agent2"].name == "mock_agent2"
+
+        finally:
+            os.unlink(temp_config_path)
+
+    def test_interaction_selection_by_name(self):
+        """Test that interactions are selected by name from interaction_kwargs."""
+        config, temp_config_path = create_mock_config_with_multi_interactions()
+
+        try:
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+                mock_tokenizer = MagicMock()
+                mock_tokenizer.pad_token_id = 0
+                mock_tokenizer.eos_token_id = 2
+
+                mock_model_config = MagicMock()
+                mock_model_config.max_position_embeddings = 2048
+
+                rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=mock_tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
+
+                # Test interaction selection logic
+                from verl.workers.rollout.schemas import AsyncRolloutRequest, AsyncRolloutRequestStateEnum, Message
+
+                # Create a mock request with specific interaction name
+                req = AsyncRolloutRequest(
+                    request_id="test_req",
+                    state=AsyncRolloutRequestStateEnum.INTERACTING,
+                    messages=[Message(role="user", content="test message")],
+                    interaction_kwargs={"name": "mock_agent2", "test_param": "value"},
+                    input_ids=[],
+                    prompt_ids=[],
+                    response_ids=[],
+                    attention_mask=[],
+                    prompt_attention_mask=[],
+                    response_attention_mask=[],
+                    position_ids=[],
+                    prompt_position_ids=[],
+                    response_position_ids=[],
+                    loss_mask=[],
+                    prompt_loss_mask=[],
+                    response_loss_mask=[],
+                    reward_scores={},
+                    max_prompt_len=32,
+                    max_response_len=16,
+                    max_model_len=512,
+                    use_inference_chat_template=True,
+                    tokenization_sanity_check_mode="off",
+                    processing_class=mock_tokenizer,
+                )
+
+                # Test that the correct interaction is selected
+                interaction_name = req.interaction_kwargs.get("name", "gsm8k")
+                assert interaction_name == "mock_agent2"
+                assert interaction_name in rollout.interaction_map
+
+                selected_interaction = rollout.interaction_map[interaction_name]
+                assert selected_interaction.name == "mock_agent2"
+
+        finally:
+            os.unlink(temp_config_path)
+
+    def test_fallback_to_default_interaction(self):
+        """Test fallback to default interaction when name is not specified."""
+        # Create config with gsm8k interaction
+        interaction_config = {"interaction": [{"name": "gsm8k", "class_name": "tests.workers.rollout.test_sglang_multi_interaction.MockInteraction", "config": {}}]}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            OmegaConf.save(interaction_config, f.name)
+            interaction_config_path = f.name
+
+        config = DictConfig(
+            {
+                "multi_turn": {"interaction_config_path": interaction_config_path, "tool_config_path": None, "enable": True, "max_assistant_turns": 5, "max_user_turns": 3, "use_inference_chat_template": True, "tokenization_sanity_check_mode": "off"},
+                "prompt_length": 32,
+                "response_length": 16,
+                "max_model_len": 512,
+                "dtype": "bfloat16",
+                "gpu_memory_utilization": 0.8,
+                "load_format": "dummy",
+                "enforce_eager": True,
+                "free_cache_engine": False,
+                "calculate_log_probs": False,
+                "tensor_model_parallel_size": 1,
+                "n": 1,
+                "val_kwargs": {"top_k": 1, "top_p": 1.0, "temperature": 0.0},
+            }
+        )
+
+        try:
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+                mock_tokenizer = MagicMock()
+                mock_tokenizer.pad_token_id = 0
+                mock_tokenizer.eos_token_id = 2
+
+                mock_model_config = MagicMock()
+                mock_model_config.max_position_embeddings = 2048
+
+                rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=mock_tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
+
+                # Test that default interaction name works
+                interaction_kwargs_without_name = {"test_param": "value"}
+                default_name = interaction_kwargs_without_name.get("name", "gsm8k")
+                assert default_name == "gsm8k"
+                assert default_name in rollout.interaction_map
+
+        finally:
+            os.unlink(interaction_config_path)
+
+    def test_error_on_missing_interaction(self):
+        """Test that error is raised when requested interaction is not found."""
+        config, temp_config_path = create_mock_config_with_multi_interactions()
+
+        try:
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+                mock_tokenizer = MagicMock()
+                mock_tokenizer.pad_token_id = 0
+                mock_tokenizer.eos_token_id = 2
+
+                mock_model_config = MagicMock()
+                mock_model_config.max_position_embeddings = 2048
+
+                rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=mock_tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
+
+                # Test error when requesting non-existent interaction
+                non_existent_name = "non_existent_interaction"
+                assert non_existent_name not in rollout.interaction_map
+
+                # This should raise ValueError in actual usage
+                available_interactions = list(rollout.interaction_map.keys())
+                assert "mock_agent1" in available_interactions
+                assert "mock_agent2" in available_interactions
+                assert non_existent_name not in available_interactions
+
+        finally:
+            os.unlink(temp_config_path)
+
+    def test_backward_compatibility_no_interaction_config(self):
+        """Test backward compatibility when no interaction config is provided."""
+        # Create config without interaction config
+        config = DictConfig(
+            {
+                "multi_turn": {"interaction_config_path": None, "tool_config_path": None, "enable": True, "max_assistant_turns": 5, "max_user_turns": 3, "use_inference_chat_template": True, "tokenization_sanity_check_mode": "off"},
+                "prompt_length": 32,
+                "response_length": 16,
+                "max_model_len": 512,
+                "dtype": "bfloat16",
+                "gpu_memory_utilization": 0.8,
+                "load_format": "dummy",
+                "enforce_eager": True,
+                "free_cache_engine": False,
+                "calculate_log_probs": False,
+                "tensor_model_parallel_size": 1,
+                "n": 1,
+                "val_kwargs": {"top_k": 1, "top_p": 1.0, "temperature": 0.0},
+            }
+        )
+
+        with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+            mock_tokenizer = MagicMock()
+            mock_tokenizer.pad_token_id = 0
+            mock_tokenizer.eos_token_id = 2
+
+            mock_model_config = MagicMock()
+            mock_model_config.max_position_embeddings = 2048
+
+            rollout = SGLangRollout(actor_module="mock_model", config=config, processing_class=mock_tokenizer, model_hf_config=mock_model_config, port=None, trust_remote_code=False, device_mesh=None)
+
+            # Check that no interactions were initialized
+            assert len(rollout.interaction_map) == 0
+
+            # Should work without errors (backward compatibility)

--- a/tests/workers/rollout/test_sglang_multi_interaction.py
+++ b/tests/workers/rollout/test_sglang_multi_interaction.py
@@ -90,7 +90,9 @@ class TestSGLangMultiInteraction:
 
         try:
             # Mock the SGLang engine and other dependencies
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"), patch.dict(
+                os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}
+            ):
                 mock_dist.get_world_size.return_value = 1
                 # Create a mock tokenizer
                 mock_tokenizer = MagicMock()
@@ -123,7 +125,9 @@ class TestSGLangMultiInteraction:
         config, temp_config_path = create_mock_config_with_multi_interactions()
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"), patch.dict(
+                os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}
+            ):
                 mock_dist.get_world_size.return_value = 1
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
@@ -203,7 +207,9 @@ class TestSGLangMultiInteraction:
         )
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"), patch.dict(
+                os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}
+            ):
                 mock_dist.get_world_size.return_value = 1
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
@@ -228,7 +234,9 @@ class TestSGLangMultiInteraction:
         config, temp_config_path = create_mock_config_with_multi_interactions()
 
         try:
-            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+            with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"), patch.dict(
+                os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}
+            ):
                 mock_dist.get_world_size.return_value = 1
                 mock_tokenizer = MagicMock()
                 mock_tokenizer.pad_token_id = 0
@@ -273,7 +281,7 @@ class TestSGLangMultiInteraction:
             }
         )
 
-        with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"):
+        with patch("verl.workers.rollout.sglang_rollout.sglang_rollout.AsyncEngine"), patch("verl.workers.rollout.sglang_rollout.sglang_rollout.dist") as mock_dist, patch("verl.workers.rollout.sglang_rollout.sglang_rollout.init_device_mesh"), patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}):
             mock_dist.get_world_size.return_value = 1
             mock_tokenizer = MagicMock()
             mock_tokenizer.pad_token_id = 0

--- a/verl/interactions/utils/__init__.py
+++ b/verl/interactions/utils/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 ModelBest Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/verl/interactions/utils/interaction_registry.py
+++ b/verl/interactions/utils/interaction_registry.py
@@ -1,0 +1,85 @@
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 ModelBest Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import logging
+import os
+import sys
+
+from omegaconf import OmegaConf
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+def get_interaction_class(cls_name):
+    """Dynamically import and return the interaction class."""
+    module_name, class_name = cls_name.rsplit(".", 1)
+    if module_name not in sys.modules:
+        spec = importlib.util.find_spec(module_name)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    else:
+        module = sys.modules[module_name]
+
+    interaction_cls = getattr(module, class_name)
+    return interaction_cls
+
+
+def initialize_interactions_from_config(interaction_config_file):
+    """Initialize interactions from configuration file.
+
+    Args:
+        interaction_config_file: Path to the interaction configuration file.
+
+    Returns:
+        dict: A dictionary mapping interaction names to BaseInteraction instances.
+    """
+    interaction_config = OmegaConf.load(interaction_config_file)
+    interaction_map = {}
+
+    for interaction_item in interaction_config.interaction:
+        cls_name = interaction_item.class_name
+        interaction_cls = get_interaction_class(cls_name)
+
+        # Extract config and name
+        config = OmegaConf.to_container(interaction_item.config, resolve=True)
+
+        # Get the interaction name - either from config or derive from class name
+        name = interaction_item.get("name", None)
+        if name is None:
+            # If no name is specified, use the class name as default
+            class_simple_name = cls_name.split(".")[-1]
+            # Remove "Interaction" suffix if present, otherwise use full class name
+            if class_simple_name.endswith("Interaction"):
+                name = class_simple_name[:-11].lower()  # Remove "Interaction" (11 chars)
+            else:
+                name = class_simple_name.lower()
+
+        # Check for duplicate names
+        if name in interaction_map:
+            raise ValueError(f"Duplicate interaction name '{name}' found. Each interaction must have a unique name.")
+
+        # Inject the name into the config
+        config["name"] = name
+
+        # Create the interaction instance
+        interaction = interaction_cls(config=config)
+        interaction_map[name] = interaction
+
+        logger.info(f"Initialized interaction '{name}' with class '{cls_name}'")
+
+    return interaction_map

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -55,6 +55,7 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, Processor
 
 from verl import DataProto
 from verl.interactions.base import BaseInteraction
+from verl.interactions.utils.interaction_registry import initialize_interactions_from_config
 from verl.third_party.sglang import parallel_state as sglang_ps
 from verl.tools.base_tool import BaseTool
 from verl.tools.schemas import OpenAIFunctionCallSchema, OpenAIFunctionParsedSchema, OpenAIFunctionToolCall
@@ -282,7 +283,7 @@ class SGLangRollout(BaseRollout):
             self._sgl_tools,
             self._function_call_parser,
         ) = self._initialize_tools(config, processing_class)
-        self.interaction: dict[str, BaseInteraction] = self._intitalize_interaction(config)
+        self.interaction_map: dict[str, BaseInteraction] = self._initialize_interactions(config)
         # If turn on `free_cache_engine`, SGLang engine's KV cache
         # will be freed after each `generate_sequences` call.
         assert not (not config.enforce_eager and config.free_cache_engine), "disable CUDA graph (enforce_eager = False) if free cache engine"
@@ -480,30 +481,20 @@ class SGLangRollout(BaseRollout):
             function_call_parser,
         )
 
-    def _intitalize_interaction(self, config):
-        import importlib.util
-        import sys
+    def _initialize_interactions(self, config):
+        """Initialize interactions from configuration.
 
-        from omegaconf import OmegaConf
-
+        Returns:
+            dict[str, BaseInteraction]: A dictionary mapping interaction names to interaction instances.
+        """
         if config.multi_turn.interaction_config_path is None:
-            return None
+            return {}
+
         interaction_config_file = config.multi_turn.interaction_config_path
-        interaction_config = OmegaConf.load(interaction_config_file).interaction[0]
-        cls_name = interaction_config.class_name
-        module_name, class_name = cls_name.rsplit(".", 1)
-        if module_name not in sys.modules:
-            spec = importlib.util.find_spec(module_name)
-            module = importlib.util.module_from_spec(spec)
-            sys.modules[module_name] = module
-            spec.loader.exec_module(module)
-        else:
-            module = sys.modules[module_name]
+        interaction_map = initialize_interactions_from_config(interaction_config_file)
 
-        interaction_cls = getattr(module, class_name)
-
-        interaction = interaction_cls(config=OmegaConf.to_container(interaction_config.config, resolve=True))
-        return interaction
+        logger.info(f"Initialize interactions from configuration: interaction_map: {list(interaction_map.keys())}")
+        return interaction_map
 
     @GPUMemoryLogger(role="sglang rollout", logger=logger)
     @torch.no_grad()
@@ -863,14 +854,21 @@ class SGLangRollout(BaseRollout):
                             self.processing_class,
                             content,
                         )
-                        if _req.interaction_kwargs and user_turns < self.config.multi_turn.max_user_turns and current_turns < self.config.multi_turn.max_assistant_turns:
+                        if _req.interaction_kwargs and self.interaction_map and user_turns < self.config.multi_turn.max_user_turns and current_turns < self.config.multi_turn.max_assistant_turns:
                             _req.state = AsyncRolloutRequestStateEnum.INTERACTING
                         else:
                             break
             elif _req.state == AsyncRolloutRequestStateEnum.INTERACTING:
                 user_turns += 1
                 messages = [{"role": x.role, "content": x.content} for x in _req.messages]
-                should_terminate_sequence, content, reward, metrics = await self.interaction.generate_response(_req.request_id, messages, **_req.interaction_kwargs)
+
+                # Get interaction by name from interaction_kwargs
+                interaction_name = _req.interaction_kwargs.get("name", "gsm8k")  # Default to gsm8k for backward compatibility
+                if interaction_name not in self.interaction_map:
+                    raise ValueError(f"Interaction '{interaction_name}' not found in interaction_map. Available interactions: {list(self.interaction_map.keys())}")
+
+                interaction = self.interaction_map[interaction_name]
+                should_terminate_sequence, content, reward, metrics = await interaction.generate_response(_req.request_id, messages, **_req.interaction_kwargs)
                 user_turn_rewards.append(reward)
                 if should_terminate_sequence:
                     finish_reason_type = FinishReasonTypeEnum.STOP
@@ -926,9 +924,15 @@ class SGLangRollout(BaseRollout):
                 create_kwargs = _req.tools_kwargs[tool.name].get("create_kwargs", {})
                 tool_creation_coroutines.append(tool.create(_req.request_id, **create_kwargs))
             await asyncio.gather(*tool_creation_coroutines)
-        if _req.interaction_kwargs:
+        if _req.interaction_kwargs and self.interaction_map:
             interaction_kwargs = _req.interaction_kwargs
-            await self.interaction.start_interaction(_req.request_id, **interaction_kwargs)
+            # Get interaction by name from interaction_kwargs
+            interaction_name = interaction_kwargs.get("name", "gsm8k")  # Default to gsm8k for backward compatibility
+            if interaction_name not in self.interaction_map:
+                raise ValueError(f"Interaction '{interaction_name}' not found in interaction_map. Available interactions: {list(self.interaction_map.keys())}")
+
+            interaction = self.interaction_map[interaction_name]
+            await interaction.start_interaction(_req.request_id, **interaction_kwargs)
 
     @GPUMemoryLogger(role="sglang rollout", logger=logger)
     @torch.no_grad()
@@ -1093,7 +1097,7 @@ class SGLangRollout(BaseRollout):
                     _tools_kwargs = {}
                     _tool_schemas = None
 
-                if self.interaction is not None:
+                if self.interaction_map:
                     _interaction_kwargs = prompts.non_tensor_batch["interaction_kwargs"][data_idx]
                 else:
                     _interaction_kwargs = {}


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

  This PR implements multi-interaction support in SGLangRollout, enabling sample-level interaction selection similar to the existing tools system. The implementation includes a new interaction registry system that allows multiple named
  interactions to be configured and used within a single rollout instance. #1630 

Core Implementation

  - New Interaction Registry System: Created verl/interactions/utils/interaction_registry.py with functions to dynamically load and manage multiple interaction instances from configuration files
  - Enhanced SGLangRollout:
    - Replaced single interaction attribute with interaction_map: dict[str, BaseInteraction]
    - Updated _initialize_interactions() method to support multiple interactions via registry
    - Modified interaction selection logic to use interaction_kwargs.name for sample-level binding
  - Configuration Updates: Added name field support in interaction config format with automatic name generation fallback

  Data Processing

  - Updated GSM8K Preprocessing: Modified examples/data_preprocess/gsm8k_multiturn_w_interaction.py to inject name field in interaction_kwargs
  - Enhanced Configuration: Updated examples/sglang_multiturn/config/interaction_config/gsm8k_interaction_config.yaml with explicit name field

  Testing & Quality

  - Comprehensive Test Suite: Added tests/interactions/test_interaction_registry.py with full coverage of registry functionality
  - Integration Tests: Created tests/workers/rollout/test_sglang_multi_interaction.py for multi-interaction scenarios
  - Updated Existing Tests: Modified existing interaction tests to support new name attribute and configuration format
  - Error Handling: Added validation for duplicate names, missing interactions, and edge cases

  Backward Compatibility

  - Graceful Degradation: When no interaction config is provided, system works without interactions (empty interaction_map)
  - Default Name Handling: Falls back to "gsm8k" when no name is specified in interaction_kwargs
  - Existing API Preservation: All existing interaction functionality remains unchanged

 Key Features

  1. Sample-Level Selection: Each sample can specify which interaction to use via interaction_kwargs.name
  2. Registry Pattern: Similar architecture to existing tools system for consistency
  3. Automatic Naming: Intelligent name generation from class names (e.g., Gsm8kInteraction → gsm8k)
  4. Duplicate Prevention: Runtime validation prevents naming conflicts
  5. Flexible Configuration: Supports both explicit names and automatic derivation

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

  - Unit tests for interaction registry functionality
  - Integration tests for multi-interaction rollout scenarios
  - Backward compatibility tests for existing single-interaction workflows
  - Error handling tests for edge cases and invalid configurations
  - Updated existing GSM8K interaction tests

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

 Configuration (interaction_config.yaml):
  interaction:
    - name: "gsm8k"
      class_name: "verl.interactions.gsm8k_interaction.Gsm8kInteraction"
      config: {}
    - name: "custom_solver"
      class_name: "custom.interactions.CustomInteraction"
      config: {"solver_type": "advanced"}

  Data Sample:


```python
  {
      "interaction_kwargs": {
          "name": "gsm8k",
          "query": "What is 2+2?",
          "ground_truth": "4"
      }
  }
```

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
