### PR TITLE
[sglang] chore: Upgrade SGLang 0.4.8 with multi-stage awake feature

### DIFF
--- a/docs/workers/sglang_worker.rst
+++ b/docs/workers/sglang_worker.rst
@@ -21,18 +21,15 @@ Please always follow the following command to install SGLang with verl.
 .. code-block:: bash
     
     pip install --upgrade pip
-    # Currently 0.4.6.post5, subject to updates at any time, please refer to the latest version specified in `setup.py`
+    # Currently 0.4.8, subject to updates at any time, please refer to the latest version specified in `setup.py`
     pip install -e ".[sglang]"
 
 You can check the following dependencies are in your environment:
 
 .. note::
 
-    - **PyTorch**: 2.6.0+cu124
-    - **CUDA**: 12.4
-    - **flashinfer-python**: 0.2.5+cu124torch2.6
-    - **sgLang**: 0.4.6.post5
-    - **sgl-kernel**: 0.1.4
+    - **flashinfer-python**: 0.2.6.post1
+    - **sglang**: 0.4.8
 
 Using SGLang as the Inference Backend for PPO Training on a Single Machine
 -------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,8 @@ MATH_REQUIRES = ["math-verify"]  # Add math-verify as an optional dependency
 VLLM_REQUIRES = ["tensordict<=0.6.2", "vllm<=0.8.5"]
 SGLANG_REQUIRES = [
     "tensordict<=0.6.2",
-    "sglang[srt,openai]==0.4.6.post5",
-    "torch-memory-saver>=0.0.5",
-    "torch==2.6.0",
+    "sglang[srt,openai]==0.4.8",
+    "torch-memory-saver>=0.0.8",
 ]
 TRL_REQUIRES = ["trl<=0.9.6"]
 

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -465,7 +465,7 @@ actor_rollout_ref:
     # number of responses (i.e. num sample times). > 1 for grpo
     n: 1
 
-    # Whether to wake up inference engine in multi-stage. (Wake up model weights first, then resume kv cache)
+    # Whether to wake up inference engine in multi-stage to reduce peak memory during training-rollout transition.
     multi_stage_wake_up: false
 
     # Extra inference engine arguments (vllm, sglang).

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -30,12 +30,12 @@ import sglang.srt.entrypoints.engine
 import torch
 import torch.distributed as dist
 from omegaconf import DictConfig
+from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.managers.tokenizer_manager import (
     ReleaseMemoryOccupationReqInput,
     ResumeMemoryOccupationReqInput,
     UpdateWeightsFromTensorReqInput,
 )
-from sglang.srt.openai_api.protocol import Tool
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import (


### PR DESCRIPTION
### What does this PR do?
Upgrade SGLang 0.4.8 with multi-stage awake function

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

GRPO Test with SGLang works as expected
```
(TaskRunner pid=3043098) step:5 - global_seqlen/min:53826.000 - global_seqlen/max:59368.000 - global_seqlen/minmax_diff:5542.000 - global_seqlen/balanced_min:55522.000 - global_seqlen/balanced_max:55551.000 - global_seqlen/mean:55525.625 - actor/entropy:0.152 - actor/kl_loss:0.003 - actor/kl_coef:0.001 - actor/pg_loss:0.039 - actor/pg_clipfrac:0.000 - actor/ppo_kl:0.000 - actor/pg_clipfrac_lower:0.000 - actor/grad_norm:0.098 - perf/mfu/actor:0.332 - perf/max_memory_allocated_gb:25.143 - perf/max_memory_reserved_gb:44.846 - perf/cpu_memory_used_gb:79.942 - actor/lr:0.000 - val-core/openai/gsm8k/reward/mean@1:0.895 - training/global_step:5.000 - training/epoch:0.000 - critic/score/mean:0.925 - critic/score/max:1.000 - critic/score/min:0.000 - critic/rewards/mean:0.925 - critic/rewards/max:1.000 - critic/rewards/min:0.000 - critic/advantages/mean:-0.008 - critic/advantages/max:1.789 - critic/advantages/min:-1.789 - critic/returns/mean:-0.008 - critic/returns/max:1.789 - critic/returns/min:-1.789 - response_length/mean:247.129 - response_length/max:878.000 - response_length/min:93.000 - response_length/clip_ratio:0.000 - prompt_length/mean:99.906 - prompt_length/max:256.000 - prompt_length/min:66.000 - prompt_length/clip_ratio:0.000 - timing_s/generate_sequences:5.777 - timing_s/reshard:1.795 - timing_s/gen:8.290 - timing_s/reward:0.225 - timing_s/old_log_prob:1.973 - timing_s/ref:1.997 - timing_s/adv:0.021 - timing_s/update_actor:7.820 - timing_s/testing:10.669 - timing_s/step:31.018 - timing_per_token_ms/gen:0.026 - timing_per_token_ms/adv:0.000 - timing_per_token_ms/ref:0.004 - timing_per_token_ms/update_actor:0.018 - perf/total_num_tokens:444205.000 - perf/time_per_step:31.018 - perf/throughput:1790.105
```

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
