### PR TITLE
[ckpt] fix: conditionally import fsdp/megatron backend

### DIFF
--- a/verl/model_merger/__main__.py
+++ b/verl/model_merger/__main__.py
@@ -37,9 +37,6 @@ https://verl.readthedocs.io/en/latest/advance/checkpoint.html#convert-fsdp-and-m
 """
 
 from .base_model_merger import generate_config_from_args, parse_args
-from .fsdp_model_merger import FSDPModelMerger
-from .megatron_model_merger import MegatronModelMerger
-
 
 def main():
     args = parse_args()
@@ -47,8 +44,10 @@ def main():
     print(f"config: {config}")
 
     if config.backend == "fsdp":
+        from .fsdp_model_merger import FSDPModelMerger
         merger = FSDPModelMerger(config)
     elif config.backend == "megatron":
+        from .megatron_model_merger import MegatronModelMerger
         merger = MegatronModelMerger(config)
     else:
         raise NotImplementedError(f"Unknown backend: {config.backend}")

--- a/verl/model_merger/__main__.py
+++ b/verl/model_merger/__main__.py
@@ -38,6 +38,7 @@ https://verl.readthedocs.io/en/latest/advance/checkpoint.html#convert-fsdp-and-m
 
 from .base_model_merger import generate_config_from_args, parse_args
 
+
 def main():
     args = parse_args()
     config = generate_config_from_args(args)
@@ -45,9 +46,11 @@ def main():
 
     if config.backend == "fsdp":
         from .fsdp_model_merger import FSDPModelMerger
+
         merger = FSDPModelMerger(config)
     elif config.backend == "megatron":
         from .megatron_model_merger import MegatronModelMerger
+
         merger = MegatronModelMerger(config)
     else:
         raise NotImplementedError(f"Unknown backend: {config.backend}")


### PR DESCRIPTION
### What does this PR do?

`verl/model_merger/__main__.py` allows the user to specify either the FSDP backend or the Megatron backend, but it forces the user to have both backends installed. This change moves those imports under the backend conditional, relieving that requirement.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=merger+is%3Aopen+
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: hard to check these conditionals in the CI environment, since both dependencies are in the runner's image 
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
