### PR TITLE
[cfg] fix: pickleing error in multiprocessing in the reward_fn

### DIFF
--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -21,10 +21,12 @@ import ray
 from verl import DataProto
 from verl.utils.reward_score import default_compute_score
 
+
 # This function is used to merge additional keyword arguments with the original function's arguments.
 def _call_with_kwargs(raw_fn, extra_kwargs, *args, **kwargs):
     merged_kwargs = {**kwargs, **extra_kwargs}
     return raw_fn(*args, **merged_kwargs)
+
 
 def get_custom_reward_fn(config):
     import importlib.util
@@ -55,11 +57,7 @@ def get_custom_reward_fn(config):
 
     reward_kwargs = dict(reward_fn_config.get("reward_kwargs", {}))
 
-    return partial(
-        _call_with_kwargs,
-        raw_fn,
-        reward_kwargs
-    )
+    return partial(_call_with_kwargs, raw_fn, reward_kwargs)
 
 
 def load_reward_manager(config, tokenizer, num_examine, **reward_kwargs):

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -57,8 +57,8 @@ def get_custom_reward_fn(config):
 
     return partial(
         _call_with_kwargs,
-        raw_fn=raw_fn,
-        extra_kwargs=reward_kwargs
+        raw_fn,
+        reward_kwargs
     )
 
 

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -21,6 +21,10 @@ import ray
 from verl import DataProto
 from verl.utils.reward_score import default_compute_score
 
+# This function is used to merge additional keyword arguments with the original function's arguments.
+def _call_with_kwargs(raw_fn, extra_kwargs, *args, **kwargs):
+    merged_kwargs = {**kwargs, **extra_kwargs}
+    return raw_fn(*args, **merged_kwargs)
 
 def get_custom_reward_fn(config):
     import importlib.util
@@ -51,10 +55,11 @@ def get_custom_reward_fn(config):
 
     reward_kwargs = dict(reward_fn_config.get("reward_kwargs", {}))
 
-    def wrapped_fn(*args, **kwargs):
-        return raw_fn(*args, **kwargs, **reward_kwargs)
-
-    return wrapped_fn
+    return partial(
+        _call_with_kwargs,
+        raw_fn=raw_fn,
+        extra_kwargs=reward_kwargs
+    )
 
 
 def load_reward_manager(config, tokenizer, num_examine, **reward_kwargs):

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -22,8 +22,8 @@ from verl import DataProto
 from verl.utils.reward_score import default_compute_score
 
 
-# This function is used to merge additional keyword arguments with the original function's arguments.
 def _call_with_kwargs(raw_fn, extra_kwargs, *args, **kwargs):
+    """This function is used to merge additional keyword arguments with the original function's arguments."""
     merged_kwargs = {**kwargs, **extra_kwargs}
     return raw_fn(*args, **merged_kwargs)
 

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -23,7 +23,10 @@ from verl.utils.reward_score import default_compute_score
 
 
 def _call_with_kwargs(raw_fn, extra_kwargs, *args, **kwargs):
-    """This function is used to merge additional keyword arguments with the original function's arguments."""
+    """Calls `raw_fn` by merging `extra_kwargs` into call-time `kwargs`, with `extra_kwargs` taking precedence.
+
+    This function is used to merge additional keyword arguments with the original function's arguments.
+    """
     merged_kwargs = {**kwargs, **extra_kwargs}
     return raw_fn(*args, **merged_kwargs)
 


### PR DESCRIPTION
### What does this PR do?

> Fix "Can't pickle local object" error when using custom reward functions in multiprocessing


When I import `compute_score` from my own Python file, the `file_path` is not None and it will call the `wrapped_fn ` method.
You can view the relevant code at the following：
https://github.com/volcengine/verl/blob/e96f0fbf44a50a302ddea0118e76d40cc9aa4fff/verl/trainer/ppo/reward.py#L25-L57

When  I set` reward_model.reward_manager=prime`, it will call the `ProcessPoolExecutor` to use asyncio, leading to the error:

`"Can't pickle local object 'get_custom_reward_fn.<locals>.wrapped_fn'".`

Root Cause:

The nested closure `wrapped_fn` created in `get_custom_reward_fn() `is unpicklable for the following reasons:

- Python's `pickle` cannot serialize local functions (functions defined inside another function).

- The closure dynamically captures variables (`raw_fn` and `reward_kwargs`) from its outer scope.

This breaks multiprocessing workflows (e.g., `SubprocVecEnv`, `multiprocessing.Pool)` that rely on pickling.