### PR TITLE
[trainer] feat: Support resume from checkpoint, manage the number of CKPTS in keep, compatible with previously saved CKPTS

### DIFF
--- a/verl/trainer/config/sft_trainer.yaml
+++ b/verl/trainer/config/sft_trainer.yaml
@@ -64,4 +64,4 @@ trainer:
   test_freq: -1
   nnodes: 1
   n_gpus_per_node: 8
-  max_ckpt_to_keep: null # TODO
+  max_ckpt_to_keep: null  # Maximum number of checkpoints to keep, set to null to keep all


### PR DESCRIPTION
[trainer] feat: Support resume from checkpoint, manage the number of CKPTS in keep, compatible with previously saved CKPTS

### What does this PR do?

This PR adds checkpoint resume functionality to the FSDP SFT trainer, enabling training continuation from saved checkpoints with full state restoration (model weights, optimizer, scheduler, training progress). For older checkpoints missing optimizer/scheduler states, it gracefully degrades by using fresh optimizer states while restoring model weights and correct scheduler positioning. Also includes automatic checkpoint cleanup management.

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

To use the resume functionality, add the following configuration to your trainer config:

```yaml
trainer:
  resume_path: "/path/to/checkpoint/global_step_1000"  # Path to checkpoint directory
  max_ckpt_to_keep: 5  # Optional: Maximum number of checkpoints to keep (null to keep all)
```

Example Python usage:
```python
# Add these options to your existing script 
config.trainer.resume_path = "/path/to/checkpoint/global_step_1000"  # Required: checkpoint directory path
config.trainer.max_ckpt_to_keep = 5  # Optional: limit number of saved checkpoints (null for unlimited)
```

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).