### PR TITLE
[rollout] feat: Allow customization of async server class

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -194,9 +194,10 @@ Actor/Rollout/Reference Policy
         n: 1
         do_sample: False # default eager for validation
 
-      custom_async_server: # Use custom async server implementation for rollout
-        path: null
-        name: null
+      agent:
+        custom_async_server: # Use custom async server implementation for rollout
+          path: null
+          name: null
 
 **Common config for actor, rollout and reference model**
 

--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -194,6 +194,10 @@ Actor/Rollout/Reference Policy
         n: 1
         do_sample: False # default eager for validation
 
+      custom_async_server: # Use custom async server implementation for rollout
+        path: null
+        name: null
+
 **Common config for actor, rollout and reference model**
 
 - ``actor_rollout_ref.hybrid_engine``: Whether it's a hybrid engine,

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -329,11 +329,11 @@ class AgentLoopManager:
         self.async_llm_servers = [None] * self.rollout_dp_size
         self.server_addresses = [None] * self.rollout_dp_size
 
-        if self.config.actor_rollout_ref.rollout.custom_async_server:
+        if self.config.actor_rollout_ref.rollout.agent.custom_async_server:
             server_class = async_server_class(
                 rollout_backend=self.config.actor_rollout_ref.rollout.name,
-                rollout_backend_module=self.config.actor_rollout_ref.rollout.custom_async_server.path,
-                rollout_backend_class=self.config.actor_rollout_ref.rollout.custom_async_server.name,
+                rollout_backend_module=self.config.actor_rollout_ref.rollout.agent.custom_async_server.path,
+                rollout_backend_class=self.config.actor_rollout_ref.rollout.agent.custom_async_server.name,
             )
         else:
             server_class = async_server_class(rollout_backend=self.config.actor_rollout_ref.rollout.name)

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -329,9 +329,16 @@ class AgentLoopManager:
         self.async_llm_servers = [None] * self.rollout_dp_size
         self.server_addresses = [None] * self.rollout_dp_size
 
-        server_class = async_server_class(
-            rollout_backend=self.config.actor_rollout_ref.rollout.name,
-        )
+        if self.config.actor_rollout_ref.rollout.custom_async_server:
+            server_class = async_server_class(
+                rollout_backend=self.config.actor_rollout_ref.rollout.name,
+                rollout_backend_module=self.config.actor_rollout_ref.rollout.custom_async_server.path,
+                rollout_backend_class=self.config.actor_rollout_ref.rollout.custom_async_server.name,
+            )
+        else:
+            server_class = async_server_class(
+                rollout_backend=self.config.actor_rollout_ref.rollout.name
+            )
 
         # Start all server instances, restart if address already in use.
         unready_dp_ranks = set(range(self.rollout_dp_size))

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -336,9 +336,7 @@ class AgentLoopManager:
                 rollout_backend_class=self.config.actor_rollout_ref.rollout.custom_async_server.name,
             )
         else:
-            server_class = async_server_class(
-                rollout_backend=self.config.actor_rollout_ref.rollout.name
-            )
+            server_class = async_server_class(rollout_backend=self.config.actor_rollout_ref.rollout.name)
 
         # Start all server instances, restart if address already in use.
         unready_dp_ranks = set(range(self.rollout_dp_size))

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -253,6 +253,10 @@ actor_rollout_ref:
       # Number of agent loop workers
       num_workers: 8
 
+      custom_async_server:
+        path: null
+        name: null
+
     # support logging rollout prob for debugging purpose
     calculate_log_probs: False
     # Nsight system profiler configs
@@ -260,9 +264,6 @@ actor_rollout_ref:
       discrete: False
       all_ranks: False
       ranks: null
-    custom_async_server:
-      path: null
-      name: null
 
 critic:
   rollout_n: ${actor_rollout_ref.rollout.n}

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -260,6 +260,10 @@ actor_rollout_ref:
       discrete: False
       all_ranks: False
       ranks: null
+    custom_async_server:
+      path: null
+      name: null
+
 critic:
   rollout_n: ${actor_rollout_ref.rollout.n}
   strategy: ${actor_rollout_ref.actor.strategy}

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -576,14 +576,14 @@ actor_rollout_ref:
       # Number of agent loop workers
       num_workers: 8
 
-    # [Experimental] custom async server configs
-    custom_async_server:
+      # custom async server configs
+      custom_async_server:
 
-      # Path to the custom async server implementation
-      path: null
+        # Path to the custom async server implementation
+        path: null
 
-      # Class name of the custom async server class (e.g. AsyncvLLMServer)
-      name: null
+        # Class name of the custom async server class (e.g. AsyncvLLMServer)
+        name: null
 
 # configs for the critic
 critic:

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -576,6 +576,15 @@ actor_rollout_ref:
       # Number of agent loop workers
       num_workers: 8
 
+    # [Experimental] custom async server configs
+    custom_async_server:
+
+      # Path to the custom async server implementation
+      path: null
+
+      # Class name of the custom async server class (e.g. AsyncvLLMServer)
+      name: null
+
 # configs for the critic
 critic:
 

--- a/verl/workers/rollout/async_server.py
+++ b/verl/workers/rollout/async_server.py
@@ -18,7 +18,7 @@ import socket
 import threading
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
-from typing import Any, Dict, List, Tuple, Type, Optional
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import fastapi
 import ray
@@ -142,9 +142,7 @@ class AsyncLLMServerManager:
                 rollout_backend_class=self.config.rollout.custom_async_server.name,
             )
         else:
-            server_class = async_server_class(
-                rollout_backend=self.config.rollout.name
-            )
+            server_class = async_server_class(rollout_backend=self.config.rollout.name)
 
         # Start all server instances, restart if address already in use.
         unready_dp_ranks = set(range(self.rollout_dp_size))
@@ -240,7 +238,9 @@ class AsyncLLMServerManager:
         return future.result()
 
 
-def async_server_class(rollout_backend: str, rollout_backend_module: Optional[str] = None, rollout_backend_class: Optional[str] = None) -> Type[AsyncServerBase]:
+def async_server_class(
+    rollout_backend: str, rollout_backend_module: Optional[str] = None, rollout_backend_class: Optional[str] = None
+) -> Type[AsyncServerBase]:
     """Get async server class.
 
     Args:
@@ -271,4 +271,5 @@ def async_server_class(rollout_backend: str, rollout_backend_module: Optional[st
         raise ValueError("rollout_backend_module and rollout_backend_class must be both provided for customization")
 
     from verl.utils.import_utils import load_extern_type
+
     return load_extern_type(rollout_backend_module, rollout_backend_class)

--- a/verl/workers/rollout/async_server.py
+++ b/verl/workers/rollout/async_server.py
@@ -135,11 +135,11 @@ class AsyncLLMServerManager:
         self.async_llm_servers = [None] * self.rollout_dp_size
         self.server_addresses = [None] * self.rollout_dp_size
 
-        if self.config.rollout.custom_async_server:
+        if self.config.rollout.agent.custom_async_server:
             server_class = async_server_class(
                 rollout_backend=self.config.rollout.name,
-                rollout_backend_module=self.config.rollout.custom_async_server.path,
-                rollout_backend_class=self.config.rollout.custom_async_server.name,
+                rollout_backend_module=self.config.rollout.agent.custom_async_server.path,
+                rollout_backend_class=self.config.rollout.agent.custom_async_server.name,
             )
         else:
             server_class = async_server_class(rollout_backend=self.config.rollout.name)


### PR DESCRIPTION
### What does this PR do?

This PR contains two aspects:

1. Introduction of a new configuration option `actor_rollout_ref.rollout.custom_async_server` to allow users to customize the async server class.
2. Make `load_extern_type` more robust and support prefix like `pkg://` or `file://`, while non-breaking to any existing features and supported paths.

Without this PR, it's impossible to use a customized version of AsyncvLLMServer in customized use case. We are currently using a set of ugly monkey patch to achieve this goal.
Ultimately I believe `rollout.name` and `rollout.custom_async_server` can be combined. But `rollout.name` is currently referenced in too many places. It's quite difficult for me to handle all of them.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [link](https://github.com/volcengine/verl/pulls?q=is%3Apr+is%3Aopen+async+server)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

I have tested on our internal pipelines. The new patch works as expected and the old async servers still work as usual.

### API and Usage Example

Our config is something like this:

```yaml
hydra:
  searchpath:
    - pkg://verl/trainer/config

defaults:
  - ppo_trainer
  - _self_

data:
  filter_overlong_prompts: false

actor_rollout_ref:
  rollout:
    mode: async
    custom_async_server:
      path: pkg://mypackage.verl.async_server
      name: CustomizedvLLMServer
```

### High-Level Design

This PR is pretty straightforward.

### Specific Changes

Update the docs. Update behavior in agent loop and async server manager. Update `load_extern_type` implementation.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: I think it's quite troublesome to add a CI for this feature. I can add one if you feel necessary.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
