### PR TITLE
[cfg] chore: add non-negative expected_len assertion

### DIFF
--- a/verl/workers/reward_manager/dapo.py
+++ b/verl/workers/reward_manager/dapo.py
@@ -45,6 +45,9 @@ class DAPORewardManager:
             assert self.max_resp_len is not None, (
                 f"max_resp_len must be provided if {overlong_buffer_cfg=}, but got None"
             )
+            assert self.max_resp_len >= self.overlong_buffer_cfg.len, (
+                "max_resp_len must be larger than overlong_buffer.len"
+            )
 
     def __call__(self, data: DataProto, return_dict: bool = False):
         """We will expand this function gradually based on the available datasets"""


### PR DESCRIPTION
#### Summary
Added a assertion when the overlong buffer configuration is invalid, specifically when `overlong_buffer_len > max_response_length` which causes `expected_len` to be negative.

#### Problem
When `overlong_buffer_len` is greater than `max_response_length`, the calculated `expected_len` becomes negative:
```
expected_len = max_resp_len - overlong_buffer_len  # Results in negative value
```
This causes all reasonable response lengths to be penalized.

#### Solution
Added a `assert self.max_resp_len >= self.overlong_buffer_cfg.len` in DAPORewardManager


#### Changes Made
1. File: `verl/workers/reward_manager/dapo.py`