### PR TITLE
Enable Generation of Wheel File During Docker Build 

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -49,7 +49,8 @@ RUN pip install "tensordict==0.6.2" --no-deps && \
     wandb \
     orjson \
     pybind11 && \
-    pip install -e . --no-deps
-
+    pip install -e . --no-deps && \
+    python setup.py bdist_wheel
+    
 # Install torch_memory_saver
 RUN pip install git+https://github.com/ExtremeViscent/torch_memory_saver.git --no-deps


### PR DESCRIPTION
### What does this PR do?

The PR enhances the Dockerfile.rocm by generating a Python wheel (.whl) as a part of Docker build process.
Changes introduced:
 - Add python setup.py bdist_wheel immediately after pip install -e . --no-deps
 - The wheel is created inside the container under the dist/ directory
 