### PR TITLE
[rollout, data] fix: force chat to end with EOS when add_generation_prompt==False

### DIFF
--- a/recipe/spin/fsdp_workers.py
+++ b/recipe/spin/fsdp_workers.py
@@ -47,6 +47,7 @@ from verl.utils.fsdp_utils import (
 from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
 from verl.workers.fsdp_workers import ActorRolloutRefWorker
+from verl.workers.rollout.schemas import force_chat_end_with_eos
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
 
 logger = logging.getLogger(__file__)
@@ -505,8 +506,9 @@ class RewardModelWorker(Worker):
 
             chat.append({"role": "assistant", "content": response})
 
-            prompt_with_chat_template = target_tokenizer.apply_chat_template(
-                chat, add_generation_prompt=False, tokenize=False
+            prompt_with_chat_template = force_chat_end_with_eos(
+                target_tokenizer.apply_chat_template(chat, add_generation_prompt=False, tokenize=False),
+                eos_token=target_tokenizer.eos_token,
             )
             if self.rank == 0 and i == 0:
                 # for debugging purpose

--- a/tests/workers/rollout/test_sglang_async_rollout_mcp_tools.py
+++ b/tests/workers/rollout/test_sglang_async_rollout_mcp_tools.py
@@ -29,7 +29,12 @@ from utils_sglang import get_rollout_config, prepare_inputs
 from verl.protocol import DataProto
 from verl.tools.mcp_search_tool import MCPSearchTool
 from verl.tools.utils.mcp_clients.McpClientManager import MCPClientManager
-from verl.workers.rollout.schemas import AsyncRolloutRequest, AsyncRolloutRequestStateEnum, Message
+from verl.workers.rollout.schemas import (
+    AsyncRolloutRequest,
+    AsyncRolloutRequestStateEnum,
+    Message,
+    force_chat_end_with_eos,
+)
 from verl.workers.rollout.sglang_rollout.sglang_rollout import SGLangRollout
 
 DEFAULT_USER_CONTENT_PREFIX = (
@@ -133,7 +138,10 @@ class TestRolloutWithMCPSearchTools:
         user_prompt, expect_turn_array, tool_return_array = get_search_messages()
         prompts = [[message] for message in user_prompt]
         preencode_turn_array = [
-            qwen_tokenizer.apply_chat_template([turn], tokenize=False, add_generation_prompt=False)
+            force_chat_end_with_eos(
+                qwen_tokenizer.apply_chat_template([turn], tokenize=False, add_generation_prompt=False),
+                eos_token=qwen_tokenizer.eos_token,
+            )
             for turn in expect_turn_array
         ]
         preencode_tool_return_array = [

--- a/tests/workers/rollout/test_sglang_async_rollout_search_tools.py
+++ b/tests/workers/rollout/test_sglang_async_rollout_search_tools.py
@@ -33,7 +33,12 @@ from verl.tools.schemas import (
     OpenAIFunctionToolSchema,
 )
 from verl.tools.search_tool import SearchTool
-from verl.workers.rollout.schemas import AsyncRolloutRequest, AsyncRolloutRequestStateEnum, Message
+from verl.workers.rollout.schemas import (
+    AsyncRolloutRequest,
+    AsyncRolloutRequestStateEnum,
+    Message,
+    force_chat_end_with_eos,
+)
 from verl.workers.rollout.sglang_rollout.sglang_rollout import SGLangRollout
 
 DEFAULT_USER_CONTENT_PREFIX = (
@@ -105,7 +110,10 @@ class TestRolloutWithSearchTools:
         user_prompt, expect_turn_array, tool_return_array = get_search_messages()
         prompts = [[message] for message in user_prompt]
         preencode_turn_array = [
-            qwen_tokenizer.apply_chat_template([turn], tokenize=False, add_generation_prompt=False)
+            force_chat_end_with_eos(
+                qwen_tokenizer.apply_chat_template([turn], tokenize=False, add_generation_prompt=False),
+                eos_token=qwen_tokenizer.eos_token,
+            )
             for turn in expect_turn_array
         ]
         preencode_tool_return_array = [

--- a/tests/workers/rollout/test_sglang_async_rollout_sf_tools.py
+++ b/tests/workers/rollout/test_sglang_async_rollout_sf_tools.py
@@ -40,6 +40,7 @@ from verl.tools.schemas import (
 )
 from verl.workers.rollout.schemas import AsyncRolloutRequest, AsyncRolloutRequestStateEnum, Message
 from verl.workers.rollout.sglang_rollout.sglang_rollout import SGLangRollout
+from verl.workers.rollout.schemas import force_chat_end_with_eos
 
 sandbox_url = ""
 
@@ -165,14 +166,8 @@ class TestRolloutWithTools:
     def sandbox_fusion_data(self, qwen_tokenizer):
         user_prompt, expect_turn_array, tool_return_array = get_sandbox_fusion_messages()
         prompts = [[message] for message in user_prompt]
-        preencode_turn_array = [
-            qwen_tokenizer.apply_chat_template([turn], tokenize=False, add_generation_prompt=False)
-            for turn in expect_turn_array
-        ]
-        preencode_tool_return_array = [
-            qwen_tokenizer.apply_chat_template([turn], tokenize=False, add_generation_prompt=True)
-            for turn in tool_return_array
-        ]
+        preencode_turn_array = [force_chat_end_with_eos(qwen_tokenizer.apply_chat_template([turn], tokenize=False, add_generation_prompt=False),eos_token=qwen_tokenizer.eos_token) for turn in expect_turn_array]
+        preencode_tool_return_array = [qwen_tokenizer.apply_chat_template([turn], tokenize=False, add_generation_prompt=True) for turn in tool_return_array]
         return prompts, preencode_turn_array, preencode_tool_return_array
 
     @pytest.fixture

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -112,7 +112,9 @@ class ToolAgentLoop(AgentLoopBase):
 
         cls.prompt_length = config.actor_rollout_ref.rollout.prompt_length
         cls.response_length = config.actor_rollout_ref.rollout.response_length
-        cls.system_prompt = tokenizer.apply_chat_template([{}], add_generation_prompt=False, tokenize=True)
+        cls.system_prompt = tokenizer.apply_chat_template(
+            [{}], tools=cls.tool_schemas, add_generation_prompt=True, tokenize=True
+        )
 
     async def run(self, messages: List[Dict[str, Any]], sampling_params: Dict[str, Any]) -> AgentLoopOutput:
         metrics = {}

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -71,6 +71,7 @@ from verl.utils.fsdp_utils import (
 from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.py_functional import convert_to_regular_types
+from verl.workers.rollout.schemas import force_chat_end_with_eos
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
 
 logger = logging.getLogger(__file__)
@@ -1540,8 +1541,9 @@ class RewardModelWorker(Worker, DistProfilerExtension):
 
             chat.append({"role": "assistant", "content": response})
 
-            prompt_with_chat_template = target_tokenizer.apply_chat_template(
-                chat, add_generation_prompt=False, tokenize=False
+            prompt_with_chat_template = force_chat_end_with_eos(
+                target_tokenizer.apply_chat_template(chat, add_generation_prompt=False, tokenize=False),
+                eos_token=target_tokenizer.eos_token,
             )
             if self.rank == 0 and i == 0:
                 # for debugging purpose

--- a/verl/workers/rollout/chat_scheduler.py
+++ b/verl/workers/rollout/chat_scheduler.py
@@ -35,6 +35,7 @@ from verl.protocol import DataProto
 from verl.tools.utils.tool_registry import initialize_tools_from_config
 from verl.utils import hf_tokenizer
 from verl.utils.fs import copy_to_local
+from verl.workers.rollout.schemas import force_chat_end_with_eos
 
 logger = logging.getLogger(__file__)
 
@@ -175,8 +176,11 @@ class ToolCompletionCallback(CompletionCallback):
 
         # sequences: [prompt + response]
         sequences = [
-            self.tokenizer.apply_chat_template(
-                conversation, tools=self.tool_schemas, add_generation_prompt=False, tokenize=False
+            force_chat_end_with_eos(
+                self.tokenizer.apply_chat_template(
+                    conversation, tools=self.tool_schemas, add_generation_prompt=False, tokenize=False
+                ),
+                eos_token=self.tokenizer.eos_token,
             )
             for conversation in batch_conversations
         ]


### PR DESCRIPTION
### What does this PR do?

Removing everything after the last `EOS` when `apply_chat_template(add_generation_prompt=False)`

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### API and Usage Example

```python
def force_chat_end_with_eos(rendered_chat, eos_token):
    idx = rendered_chat.rfind(eos_token)
    if idx == -1:
        # This should never happen
        raise ValueError("No EOS found in the rendered chat.")
    return rendered_chat[: idx + len(eos_token)]

raw_prompt = tokenizer.apply_chat_template(
              messages,
              add_generation_prompt=False,
              tokenize=False,
          )
raw_prompt = force_chat_end_with_eos(raw_prompt, eos_token=tokenizer.eos_token)
```

### High-Level Design

We use `tokenizer/processor.apply_chat_template(messages, add_generation_prompt=False)` followed by encoding to reconstruct the tokens in previous turns/ the complete history and expect them to be identical to what llm has generated. However, some templates add `\n` after `EOS`, which may cause discrepancies especially when postprocessing messages in `CompletionCallback`and getting `generation_prompt_ids/text` in `AsyncRolloutRequest` and `MultiTurnSFTDataset`. A general solution is to manually strip everything that follows the last `EOS`, regardless of whether the chat template appends extra content after it.

You can run the following code to see the difference:

```python
from vllm import LLM, SamplingParams
from transformers import AutoTokenizer

model_path = "Qwen/Qwen3-0.6B"
llm = LLM(
    model=model_path,
    dtype="float16",
    max_model_len=256
)
sampling_params = SamplingParams(
    temperature=0.7,
    top_p=0.95,
    max_tokens=512,
)
messages = [
    {"role": "user", "content": "Introduce yourself."}
]
outputs = llm.chat(messages, sampling_params)

generated_ids = outputs[0].prompt_token_ids + list(outputs[0].outputs[0].token_ids)

tokenizer = AutoTokenizer.from_pretrained(model_path)

messages.append({"role":"assistant","content":outputs[0].outputs[0].text})
ids = tokenizer.apply_chat_template(messages,add_generation_prompt=False,tokenize=True)
print(ids[:-1] == generated_ids) #differ in the last \n

def force_chat_end_with_eos(rendered_chat, eos_token):
    idx = rendered_chat.rfind(eos_token)
    if idx == -1:
        # This should never happen
        raise ValueError("No EOS found in the rendered chat.")
    return rendered_chat[: idx + len(eos_token)]

raw_prompts = tokenizer.apply_chat_template(messages,add_generation_prompt=False,tokenize=False)
raw_prompts = force_chat_end_with_eos(raw_prompts,eos_token=tokenizer.eos_token)
ids = tokenizer(raw_prompts)["input_ids"]
print(ids == generated_ids)

```

### Specific Changes

* applying `force_chat_end_with_eos` for all `apply_chat_template(add_generation_prompt=False)`
* btw, In `ToolAgentLoop`, the system prompt may depend on `tools` (e.g. [[qwen3 system prompt need tools](https://huggingface.co/Qwen/Qwen3-8B?chat_template=default)](https://huggingface.co/Qwen/Qwen3-8B?chat_template=default))

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [[Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide)](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [[pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting)](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [[the documentation](https://github.com/volcengine/verl/tree/main/docs)](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [[the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows)](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).