### PR TITLE
[doc] fix: add show source option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
 ]
 # Use Google style docstrings instead of NumPy docstrings.
 napoleon_google_docstring = True


### PR DESCRIPTION
### What does this PR do?

Enable API docs with [source code] option
