### PR TITLE
[training_utils] feat: Support `assert_case` for sandbox fusion

### DIFF
--- a/tests/utils/reward_score/reward_score/test_sandbox_fusion_on_cpu.py
+++ b/tests/utils/reward_score/reward_score/test_sandbox_fusion_on_cpu.py
@@ -664,8 +664,8 @@ class Solution:
 
     assert results == [True, True]
     assert "error" not in metadata_list[0]
-    assert metadata_list[0].get("status") != "compilation error"
-    assert metadata_list[0].get("status") != "runtime error"
+    assert metadata_list[0].get("status") != "compile_error"
+    assert metadata_list[0].get("status") != "runtime_error"
 
 
 @pytest.mark.skipif(skip_condition, reason=skip_reason)
@@ -688,5 +688,60 @@ print(f"You said '{sys.stdin.readline().strip()}'")
 
     assert results == [True, True, True]
     assert "error" not in metadata_list[0]
-    assert metadata_list[0].get("status") != "compilation error"
-    assert metadata_list[0].get("status") != "runtime error"
+    assert metadata_list[0].get("status") != "compile_error"
+    assert metadata_list[0].get("status") != "runtime_error"
+
+
+@pytest.mark.skipif(skip_condition, reason=skip_reason)
+def test_assert_case_success():
+    """Tests successful execution for assert case.
+    from KodCode
+    """
+    generation_code = """
+from typing import List, Tuple
+
+def merge_intervals(intervals: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    if not intervals:
+        return []
+
+    # Sort intervals by the start time
+    intervals.sort(key=lambda x: x[0])
+
+    merged = [intervals[0]]
+
+    for current in intervals[1:]:
+        last = merged[-1]
+        # If intervals overlap, merge them
+        if current[0] <= last[1]:
+            merged[-1] = (last[0], max(last[1], current[1]))
+        else:
+            merged.append(current)
+
+    return merged
+"""
+    test_cases = {
+        "fn_name": "merge_intervals",
+        "assert_case": [
+            "assert merge_intervals([(0, 1), (3, 5), (4, 7), (6, 8), (10, 12),"
+            " (12, 14)]) == [(0, 1), (3, 8), (10, 14)]",
+            "assert merge_intervals([(1, 2), (2, 3), (3, 4)]) == [(1, 4)]",
+            "assert merge_intervals([(1, 2), (3, 4), (5, 6)]) == [(1, 2), (3, 4), (5, 5)]",
+        ],
+    }
+
+    assert_cases = test_cases.get("assert_case")
+    test_cases.setdefault("inputs", ["" for _ in assert_cases])
+    test_cases.setdefault("outputs", [None for _ in assert_cases])
+
+    # Use a short timeout for fast tests
+    results, metadata_list = check_correctness(SANDBOX_URL, test_cases, generation_code, timeout=5)
+    assert results == [True, True, -2]
+    for i in range(2):
+        assert "error" not in metadata_list[i]
+        assert metadata_list[i].get("status") == "success"
+        assert metadata_list[i].get("expected_output") is None
+        assert metadata_list[i].get("status") != "runtime_error"
+    assert "error" not in metadata_list[2]
+    assert metadata_list[2].get("status") != "success"
+    assert metadata_list[2].get("expected_output") is None
+    assert metadata_list[2].get("status") == "runtime_error"

--- a/verl/utils/reward_score/sandbox_fusion/__init__.py
+++ b/verl/utils/reward_score/sandbox_fusion/__init__.py
@@ -68,7 +68,11 @@ def compute_score(
                 logger.error(f"Failed to parse test_cases JSON: {e}")
                 return 0.0, [{"error": "Invalid test_cases JSON format"}]
 
-        if not test_cases or "inputs" not in test_cases or "outputs" not in test_cases:
+        if test_cases is not None and "assert_case" in test_cases and isinstance(test_cases.get("assert_case"), list):
+            assert_cases = test_cases.get("assert_case")
+            test_cases.setdefault("inputs", ["" for _ in assert_cases])
+            test_cases.setdefault("outputs", [None for _ in assert_cases])
+        elif not test_cases or "inputs" not in test_cases or "outputs" not in test_cases:
             logger.error("Invalid test_cases structure.")
             return 0.0, [{"error": "Invalid test_cases structure (missing inputs/outputs)"}]
 


### PR DESCRIPTION
### What does this PR do?

Support `assert_case` for sandbox fusion

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Added unit test for this one

### API and Usage Example

It can be useful to support `assert_case` in addition to `inputs` and `outputs`, which is seen in some datasets such as: https://huggingface.co/datasets/a-m-team/AM-Thinking-v1-RL-Dataset

The `assert_case` field in `ground_truth` receives a list of strings, which can be used to append additional test cases code after the rollout generated code and provides more flexibility than pure inputs and outputs checks.


### High-Level Design

Here, the design is that, `assert_case` can be used together with `inputs` and `outputs`. In this case, all the three lists should have the same length, so that, for each test case, we can append additional check code while still checking the inputs and outputs. If only `assert_case` is provided, we simply set `inputs` to a list of empty strings and `outputs` to a list of `None` type, and we set that when the expected output is None, we don't compare the output of the generated code.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
