### PR TITLE
[sglang] fix: update response handling and scoring method in GSM8K interaction

### DIFF
--- a/docs/sglang_multiturn/interaction_system.rst
+++ b/docs/sglang_multiturn/interaction_system.rst
@@ -189,7 +189,6 @@ The GSM8K interaction demonstrates a complete implementation for math problem-so
 
             # Ensure GSM8K format (#### prefix)
             self._instance_dict[instance_id]["response"] = content
-            self._instance_dict[instance_id]["response"] = content
 
             reward = await self.calculate_score(instance_id)
             if reward == 1.0:
@@ -300,7 +299,7 @@ Comprehensive testing is essential for interaction systems:
         # Test complete workflow
         instance_id = await interaction.start_interaction(ground_truth="expected_answer")
         
-        messages = [{"role": "user", "content": "user_response"}]
+        messages = [{"role": "user", "content": "user_content"}, {"role": "assistant", "content": "assistant_response"}]
         should_terminate, response, reward, metadata = await interaction.generate_response(instance_id, messages)
         
         assert should_terminate in [True, False]

--- a/docs/sglang_multiturn/interaction_system.rst
+++ b/docs/sglang_multiturn/interaction_system.rst
@@ -183,15 +183,13 @@ The GSM8K interaction demonstrates a complete implementation for math problem-so
             # Extract last user message content
             content = ""
             for item in reversed(messages):
-                if item.get("role") == "user":
+                if item.get("role") == "assistant":
                     content = item.get("content", "")
                     break
 
             # Ensure GSM8K format (#### prefix)
-            if content.startswith("#### "):
-                self._instance_dict[instance_id]["response"] = content
-            else:
-                self._instance_dict[instance_id]["response"] = "#### " + content
+            self._instance_dict[instance_id]["response"] = content
+            self._instance_dict[instance_id]["response"] = content
 
             reward = await self.calculate_score(instance_id)
             if reward == 1.0:
@@ -203,7 +201,7 @@ The GSM8K interaction demonstrates a complete implementation for math problem-so
             return gsm8k.compute_score(
                 self._instance_dict[instance_id]["response"],
                 self._instance_dict[instance_id]["ground_truth"],
-                method="flexible", format_score=0.0, score=1.0,
+                method="strict", format_score=0.0, score=1.0,
             )
 
         async def finalize_interaction(self, instance_id, **kwargs):

--- a/verl/interactions/gsm8k_interaction.py
+++ b/verl/interactions/gsm8k_interaction.py
@@ -58,14 +58,11 @@ class Gsm8kInteraction(BaseInteraction):
         content = ""
         for i in range(len(messages) - 1, -1, -1):
             item = messages[i]
-            if item.get("role") == "user":
+            if item.get("role") == "assistant":
                 content = item.get("content")
                 break
 
-        if content and content.startswith("#### "):
-            self._instance_dict[instance_id]["response"] = content
-        else:
-            self._instance_dict[instance_id]["response"] = "#### " + (content or "")
+        self._instance_dict[instance_id]["response"] = content
 
         reward = await self.calculate_score(instance_id)
         if reward == 1.0:
@@ -81,7 +78,7 @@ class Gsm8kInteraction(BaseInteraction):
         return gsm8k.compute_score(
             self._instance_dict[instance_id]["response"],
             self._instance_dict[instance_id]["ground_truth"],
-            method="flexible",
+            method="strict",
             format_score=0.0,
             score=1.0,
         )


### PR DESCRIPTION
### What does this PR do?

This PR corrects a mistake when calculating rewards during training with the `gsm8k_w_interaction` setting.

- Changed the role check from "user" to "assistant" when extracting the last message content.
- Simplified response assignment by removing unnecessary prefix checks.
- Updated scoring method from "flexible" to "strict" for improved accuracy in GSM8K interactions.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

Docs update has been included in the PR.

### Design & Code Changes

No change for the design.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
