### PR TITLE
[single_controller] fix: replace unittest.mock.patch with context manager for env var handling

### DIFF
--- a/tests/utils/test_temp_env_on_cpu.py
+++ b/tests/utils/test_temp_env_on_cpu.py
@@ -19,10 +19,10 @@ import pytest
 from verl.utils.py_functional import temp_env_var
 
 
-def setup_function():
-    """Set up function called before each test function."""
-    # Store original environment state to restore after each test
-    global original_env
+@pytest.fixture(autouse=True)
+def clean_env():
+    """Fixture to clean up environment variables before and after each test."""
+    # Store original environment state
     original_env = dict(os.environ)
 
     # Clean up any test variables that might exist
@@ -31,10 +31,10 @@ def setup_function():
         if var in os.environ:
             del os.environ[var]
 
+    # Yield control to the test function
+    yield
 
-def teardown_function():
-    """Tear down function called after each test function."""
-    # Restore original environment state
+    # Restore original environment state after test
     os.environ.clear()
     os.environ.update(original_env)
 

--- a/tests/utils/test_temp_env_on_cpu.py
+++ b/tests/utils/test_temp_env_on_cpu.py
@@ -1,0 +1,145 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from verl.utils.py_functional import temp_env_var
+
+
+class TestTempEnvVarOnCPU(unittest.TestCase):
+    """Test cases for temp_env_var context manager on CPU.
+
+    Test Plan:
+    1. Test setting and restoring environment variables that didn't exist before
+    2. Test setting and restoring environment variables that already existed
+    3. Test that environment variables are restored even when exceptions occur
+    4. Test multiple nested context managers
+    5. Test that original environment state is preserved after context exit
+    """
+
+    def setUp(self):
+        # Store original environment state to restore after each test
+        self.original_env = dict(os.environ)
+
+        # Clean up any test variables that might exist
+        test_vars = ["TEST_VAR", "TEST_VAR_2", "EXISTING_VAR"]
+        for var in test_vars:
+            if var in os.environ:
+                del os.environ[var]
+
+    def tearDown(self):
+        # Restore original environment state
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    def test_set_new_env_var(self):
+        """Test setting a new environment variable that didn't exist before."""
+        # Ensure variable doesn't exist
+        self.assertNotIn("TEST_VAR", os.environ)
+
+        with temp_env_var("TEST_VAR", "test_value"):
+            # Variable should be set inside context
+            self.assertEqual(os.environ["TEST_VAR"], "test_value")
+            self.assertIn("TEST_VAR", os.environ)
+
+        # Variable should be removed after context
+        self.assertNotIn("TEST_VAR", os.environ)
+
+    def test_restore_existing_env_var(self):
+        """Test restoring an environment variable that already existed."""
+        # Set up existing variable
+        os.environ["EXISTING_VAR"] = "original_value"
+
+        with temp_env_var("EXISTING_VAR", "temporary_value"):
+            # Variable should be temporarily changed
+            self.assertEqual(os.environ["EXISTING_VAR"], "temporary_value")
+
+        # Variable should be restored to original value
+        self.assertEqual(os.environ["EXISTING_VAR"], "original_value")
+
+    def test_env_var_restored_on_exception(self):
+        """Test that environment variables are restored even when exceptions occur."""
+        # Set up existing variable
+        os.environ["EXISTING_VAR"] = "original_value"
+
+        with self.assertRaises(ValueError):
+            with temp_env_var("EXISTING_VAR", "temporary_value"):
+                # Verify variable is set
+                self.assertEqual(os.environ["EXISTING_VAR"], "temporary_value")
+                # Raise exception
+                raise ValueError("Test exception")
+
+        # Variable should still be restored despite exception
+        self.assertEqual(os.environ["EXISTING_VAR"], "original_value")
+
+    def test_nested_context_managers(self):
+        """Test nested temp_env_var context managers."""
+        # Set up original variable
+        os.environ["TEST_VAR"] = "original"
+
+        with temp_env_var("TEST_VAR", "level1"):
+            self.assertEqual(os.environ["TEST_VAR"], "level1")
+
+            with temp_env_var("TEST_VAR", "level2"):
+                self.assertEqual(os.environ["TEST_VAR"], "level2")
+
+            # Should restore to level1
+            self.assertEqual(os.environ["TEST_VAR"], "level1")
+
+        # Should restore to original
+        self.assertEqual(os.environ["TEST_VAR"], "original")
+
+    def test_multiple_different_vars(self):
+        """Test setting multiple different environment variables."""
+        # Set up one existing variable
+        os.environ["EXISTING_VAR"] = "existing_value"
+
+        with temp_env_var("EXISTING_VAR", "modified"):
+            with temp_env_var("TEST_VAR", "new_value"):
+                self.assertEqual(os.environ["EXISTING_VAR"], "modified")
+                self.assertEqual(os.environ["TEST_VAR"], "new_value")
+
+        # Check restoration
+        self.assertEqual(os.environ["EXISTING_VAR"], "existing_value")
+        self.assertNotIn("TEST_VAR", os.environ)
+
+    def test_empty_string_value(self):
+        """Test setting environment variable to empty string."""
+        with temp_env_var("TEST_VAR", ""):
+            self.assertEqual(os.environ["TEST_VAR"], "")
+            self.assertIn("TEST_VAR", os.environ)
+
+        # Should be removed after context
+        self.assertNotIn("TEST_VAR", os.environ)
+
+    def test_overwrite_with_empty_string(self):
+        """Test overwriting existing variable with empty string."""
+        os.environ["EXISTING_VAR"] = "original"
+
+        with temp_env_var("EXISTING_VAR", ""):
+            self.assertEqual(os.environ["EXISTING_VAR"], "")
+
+        # Should restore original value
+        self.assertEqual(os.environ["EXISTING_VAR"], "original")
+
+    def test_context_manager_returns_none(self):
+        """Test that context manager yields None."""
+        with temp_env_var("TEST_VAR", "value") as result:
+            self.assertIsNone(result)
+            self.assertEqual(os.environ["TEST_VAR"], "value")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -16,7 +16,7 @@ import inspect
 import logging
 import time
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import ray
 from ray.experimental.state.api import get_actor

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -14,9 +14,7 @@
 
 import inspect
 import logging
-import os
 import time
-from contextlib import contextmanager
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -29,6 +27,7 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy, Place
 from verl.protocol import DataProto, _padding_size_key
 from verl.single_controller.base import ClassWithInitArgs, ResourcePool, Worker, WorkerGroup
 from verl.single_controller.base.decorator import MAGIC_ATTR, Dispatch
+from verl.utils.py_functional import temp_env_var
 
 __all__ = ["Worker"]
 
@@ -751,28 +750,6 @@ def _determine_fsdp_megatron_base_class(mros: List):
         if cls.__name__ == "Worker":
             return cls
     raise ValueError(f"Cannot determine base class for {mros}")
-
-
-@contextmanager
-def temp_env_var(key: str, value: str):
-    """Context manager for temporarily setting an environment variable.
-
-    Args:
-        key: Environment variable name
-        value: Environment variable value
-
-    Yields:
-        None
-    """
-    original = os.environ.get(key)
-    os.environ[key] = value
-    try:
-        yield
-    finally:
-        if original is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = original
 
 
 # deprecated, switching to FusedWorker

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -752,14 +752,15 @@ def _determine_fsdp_megatron_base_class(mros: List):
             return cls
     raise ValueError(f"Cannot determine base class for {mros}")
 
+
 @contextmanager
 def temp_env_var(key: str, value: str):
     """Context manager for temporarily setting an environment variable.
-    
+
     Args:
         key: Environment variable name
         value: Environment variable value
-        
+
     Yields:
         None
     """
@@ -772,6 +773,7 @@ def temp_env_var(key: str, value: str):
             os.environ.pop(key, None)
         else:
             os.environ[key] = original
+
 
 # deprecated, switching to FusedWorker
 def create_colocated_worker_cls(class_dict: dict[str, RayClassWithInitArgs]):

--- a/verl/utils/py_functional.py
+++ b/verl/utils/py_functional.py
@@ -20,6 +20,7 @@ import multiprocessing
 import os
 import queue  # Import the queue module for exception type hint
 import signal
+from contextlib import contextmanager
 from functools import wraps
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, Iterator, Optional, Tuple
@@ -270,6 +271,37 @@ class DynamicEnum(metaclass=DynamicEnumMeta):
     @classmethod
     def from_name(cls, name: str) -> Optional["DynamicEnum"]:
         return cls._registry.get(name.upper())
+
+
+@contextmanager
+def temp_env_var(key: str, value: str):
+    """Context manager for temporarily setting an environment variable.
+
+    This context manager ensures that environment variables are properly set and restored,
+    even if an exception occurs during the execution of the code block.
+
+    Args:
+        key: Environment variable name to set
+        value: Value to set the environment variable to
+
+    Yields:
+        None
+
+    Example:
+        >>> with temp_env_var("MY_VAR", "test_value"):
+        ...     # MY_VAR is set to "test_value"
+        ...     do_something()
+        ... # MY_VAR is restored to its original value or removed if it didn't exist
+    """
+    original = os.environ.get(key)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original
 
 
 def convert_to_regular_types(obj):


### PR DESCRIPTION
### What does this PR do?

Fixes a critical issue in the Ray worker initialization where environment variables were not being properly preserved when using `unittest.mock.patch`. This could lead to environment variables being unexpectedly deleted after worker initialization. The fix replaces the `patch` usage with a proper context manager for safer environment variable management.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=is%3Apr+environment+variables+patch
- [x] Format the PR title as `[single_controller] fix: replace unittest.mock.patch with context manager for env var handling`

### Test

This change can be tested through the CI system since it affects core worker initialization functionality. The following test scenarios should be covered:
- Worker initialization with pre-existing environment variables
- Worker initialization without pre-existing environment variables
- Multiple worker initializations in sequence
- Error cases during worker initialization

### API and Usage Example

No API changes. Internal implementation change only. The fix uses a new context manager:

```python
@contextmanager
def temp_env_var(key: str, value: str):
    """Context manager for temporarily setting an environment variable."""
    original = os.environ.get(key)
    os.environ[key] = value
    try:
        yield
    finally:
        if original is None:
            os.environ.pop(key, None)
        else:
            os.environ[key] = original

# Usage in worker initialization
with temp_env_var("DISABLE_WORKER_INIT", "1"):
    worker = user_defined_cls(*args, **kwargs)
```

### Design & Code Changes

Changes made:
1. Removed dependency on `unittest.mock.patch`
2. Added new `temp_env_var` context manager for safe environment variable handling
3. Updated worker initialization code in two locations to use the context manager:
   - In `WorkerDict.__init__` for regular worker initialization
   - In `FusedWorker.__init__` for fused worker initialization
4. Ensures environment variables are properly restored even if initialization fails

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md)
- [x] Apply pre-commit checks
- [ ] Add / Update the documentation - N/A (internal implementation change)
- [x] Add unit tests to verify environment variable handling in worker initialization
- [ ] Request CI via Slack channel