### PR TITLE
[BUG] fix bug for #2506, when passing as response_mask to policy_loss_fn

### DIFF
--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -513,7 +513,7 @@ class DataParallelPPOActor(BasePPOActor):
                             old_log_prob=old_log_prob,
                             log_prob=log_prob,
                             advantages=advantages,
-                            response_mask=advantages,
+                            response_mask=response_mask,
                             loss_agg_mode=loss_agg_mode,
                             config=self.config,
                         )


### PR DESCRIPTION
### What does this PR do?

[BUG] advantages is incorrectly passed as response_mask to policy_loss_fn in dp_actor.py #2506
fix https://github.com/volcengine/verl/issues/2506
