### PR TITLE
[trainer] fix: maybe_filter_out_long_prompts on image and video

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -157,10 +157,10 @@ class RLHFDataset(Dataset):
                         messages, add_generation_prompt=True, tokenize=False
                     )
                     images = (
-                        [process_image(image) for image in doc.pop(image_key)] if image_key in doc else None
+                        [process_image(image) for image in doc[image_key]] if image_key in doc else None
                     )
                     videos = (
-                        [process_video(video) for video in doc.pop(video_key)] if video_key in doc else None
+                        [process_video(video) for video in doc[video_key]] if video_key in doc else None
                     )
 
                     return len(processor(text=[raw_prompt], images=images, videos=videos)["input_ids"][0])

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -156,12 +156,8 @@ class RLHFDataset(Dataset):
                     raw_prompt = self.processor.apply_chat_template(
                         messages, add_generation_prompt=True, tokenize=False
                     )
-                    images = (
-                        [process_image(image) for image in doc[image_key]] if image_key in doc else None
-                    )
-                    videos = (
-                        [process_video(video) for video in doc[video_key]] if video_key in doc else None
-                    )
+                    images = [process_image(image) for image in doc[image_key]] if image_key in doc else None
+                    videos = [process_video(video) for video in doc[video_key]] if video_key in doc else None
 
                     return len(processor(text=[raw_prompt], images=images, videos=videos)["input_ids"][0])
 

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -157,10 +157,10 @@ class RLHFDataset(Dataset):
                         messages, add_generation_prompt=True, tokenize=False
                     )
                     images = (
-                        [process_image(image) for image in messages.pop(image_key)] if image_key in messages else None
+                        [process_image(image) for image in doc.pop(image_key)] if image_key in doc else None
                     )
                     videos = (
-                        [process_video(video) for video in messages.pop(video_key)] if video_key in messages else None
+                        [process_video(video) for video in doc.pop(video_key)] if video_key in doc else None
                     )
 
                     return len(processor(text=[raw_prompt], images=images, videos=videos)["input_ids"][0])


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

The `filter_out_long_prompts` function incorrectly used the `messages` variable when it should have used `doc`. This led to prompts with images or videos not being filtered correctly based on length.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

The variable messages is of type list[dict], for example:
```python
[
  {"type": "text", "content": "xxx"},
  {"type": "image", "content": "xxx"}
]
```
The variable doc is a dict, for example:
```python
{
  "data_source": xxx.
  "prompt": xxx,
  "images": xxx,
}
```
We need to retrieve the image or video column from the dataset, load the actual images or videos, and then pass them into the tokenizer to obtain the sequence length.

Using messages here is incorrect — both the type and semantics are inappropriate. We should be using doc instead.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
