### PR TITLE
[cfg] refactor: add flatten megatron trainer config generation and verification script

### DIFF
--- a/scripts/generate_trainer_config.sh
+++ b/scripts/generate_trainer_config.sh
@@ -1,50 +1,50 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
-# 1. Dump the full config to a temp file for ppo_trainer
-target_cfg=verl/trainer/config/_generated_ppo_trainer.yaml
-tmp_header=$(mktemp)
-tmp_cfg=$(mktemp)
-echo "# This reference configration yaml is automatically generated via 'scripts/generate_trainer_config.sh'" > "$tmp_header"
-echo "# in which it invokes 'python3 scripts/print_cfg.py --cfg job' to flatten the 'verl/trainer/config/ppo_trainer.yaml' config fields into a single file." >> "$tmp_header"
-echo "# Do not modify this file directly." >> "$tmp_header"
-echo "# The file is usually only for reference and never used." >> "$tmp_header"
-echo "" >> "$tmp_header"
-python3 scripts/print_cfg.py --cfg job > "$tmp_cfg"
+# Define config specifications: "config_name:output_file:config_arg"
+CONFIG_SPECS=(
+    "ppo_trainer:_generated_ppo_trainer.yaml:"
+    "ppo_megatron_trainer:_generated_ppo_megatron_trainer.yaml:--config-name=ppo_megatron_trainer.yaml"
+)
 
-# 2. Extract from the line starting with "actor_rollout_ref" onward
-cat $tmp_header > $target_cfg
-sed -n '/^actor_rollout_ref/,$p' "$tmp_cfg" >> $target_cfg
+generate_config() {
+    local config_name="$1"
+    local output_file="$2"
+    local config_arg="$3"
+    
+    local target_cfg="verl/trainer/config/${output_file}"
+    local tmp_header=$(mktemp)
+    local tmp_cfg=$(mktemp)
+    
+    echo "# This reference configration yaml is automatically generated via 'scripts/generate_trainer_config.sh'" > "$tmp_header"
+    echo "# in which it invokes 'python3 scripts/print_cfg.py --cfg job ${config_arg}' to flatten the 'verl/trainer/config/${config_name}.yaml' config fields into a single file." >> "$tmp_header"
+    echo "# Do not modify this file directly." >> "$tmp_header"
+    echo "# The file is usually only for reference and never used." >> "$tmp_header"
+    echo "" >> "$tmp_header"
+    
+    python3 scripts/print_cfg.py --cfg job ${config_arg} > "$tmp_cfg"
+    
+    cat "$tmp_header" > "$target_cfg"
+    sed -n '/^actor_rollout_ref/,$p' "$tmp_cfg" >> "$target_cfg"
+    
+    rm "$tmp_cfg" "$tmp_header"
+    
+    echo "Generated: $target_cfg"
+}
 
-# 3. Clean up
-rm "$tmp_cfg" "$tmp_header"
+for spec in "${CONFIG_SPECS[@]}"; do
+    IFS=':' read -r config_name output_file config_arg <<< "$spec"
+    generate_config "$config_name" "$output_file" "$config_arg"
+done
 
-target_megatron_cfg=verl/trainer/config/_generated_ppo_megatron_trainer.yaml
-tmp_megatron_header=$(mktemp)
-tmp_megatron_cfg=$(mktemp)
-echo "# This reference configration yaml is automatically generated via 'scripts/generate_trainer_config.sh'" > "$tmp_megatron_header"
-echo "# in which it invokes 'python3 scripts/print_cfg.py --cfg job --config-name='ppo_megatron_trainer.yaml'' to flatten the 'verl/trainer/config/ppo_megatron_trainer.yaml' config fields into a single file." >> "$tmp_megatron_header"
-echo "# Do not modify this file directly." >> "$tmp_megatron_header"
-echo "# The file is usually only for reference and never used." >> "$tmp_megatron_header"
-echo "" >> "$tmp_megatron_header"
-python3 scripts/print_cfg.py --cfg job --config-name='ppo_megatron_trainer.yaml' > "$tmp_megatron_cfg"
-
-cat $tmp_megatron_header > $target_megatron_cfg
-sed -n '/^actor_rollout_ref/,$p' "$tmp_megatron_cfg" >> $target_megatron_cfg
-
-rm "$tmp_megatron_cfg" "$tmp_megatron_header"
-
-# 7. Verify that verl/trainer/config/_generated_ppo_trainer.yaml wasn't changed on disk
-if ! git diff --exit-code -- "$target_cfg" >/dev/null; then
-  echo "✖ $target_cfg is out of date.  Please regenerate via 'scripts/generate_trainer_config.sh' and commit the changes."
-  exit 1
-fi
-
-# 8. Verify that verl/trainer/config/_generated_ppo_megatron_trainer.yaml wasn't changed on disk
-if ! git diff --exit-code -- "$target_megatron_cfg" >/dev/null; then
-  echo "✖ $target_megatron_cfg is out of date.  Please regenerate via 'scripts/generate_trainer_config.sh' and commit the changes."
-  exit 1
-fi
+for spec in "${CONFIG_SPECS[@]}"; do
+    IFS=':' read -r config_name output_file config_arg <<< "$spec"
+    target_cfg="verl/trainer/config/${output_file}"
+    if ! git diff --exit-code -- "$target_cfg" >/dev/null; then
+        echo "✖ $target_cfg is out of date. Please regenerate via 'scripts/generate_trainer_config.sh' and commit the changes."
+        exit 1
+    fi
+done
 
 echo "All good"
 exit 0

--- a/scripts/generate_trainer_config.sh
+++ b/scripts/generate_trainer_config.sh
@@ -2,7 +2,6 @@
 set -euox pipefail
 
 
-
 # Define config specifications: "config_name:output_file:config_arg"
 CONFIG_SPECS=(
     "ppo_trainer:_generated_ppo_trainer.yaml:"

--- a/scripts/generate_trainer_config.sh
+++ b/scripts/generate_trainer_config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
-# 1. Dump the full config to a temp file
+# 1. Dump the full config to a temp file for ppo_trainer
 target_cfg=verl/trainer/config/_generated_ppo_trainer.yaml
 tmp_header=$(mktemp)
 tmp_cfg=$(mktemp)
@@ -19,10 +19,32 @@ sed -n '/^actor_rollout_ref/,$p' "$tmp_cfg" >> $target_cfg
 # 3. Clean up
 rm "$tmp_cfg" "$tmp_header"
 
-# 4. Verify that verl/trainer/config/_generated_ppo_trainer.yaml wasn't changed on disk
+target_megatron_cfg=verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+tmp_megatron_header=$(mktemp)
+tmp_megatron_cfg=$(mktemp)
+echo "# This reference configration yaml is automatically generated via 'scripts/generate_trainer_config.sh'" > "$tmp_megatron_header"
+echo "# in which it invokes 'python3 scripts/print_cfg.py --cfg job --config-name='ppo_megatron_trainer.yaml'' to flatten the 'verl/trainer/config/ppo_megatron_trainer.yaml' config fields into a single file." >> "$tmp_megatron_header"
+echo "# Do not modify this file directly." >> "$tmp_megatron_header"
+echo "# The file is usually only for reference and never used." >> "$tmp_megatron_header"
+echo "" >> "$tmp_megatron_header"
+python3 scripts/print_cfg.py --cfg job --config-name='ppo_megatron_trainer.yaml' > "$tmp_megatron_cfg"
+
+cat $tmp_megatron_header > $target_megatron_cfg
+sed -n '/^actor_rollout_ref/,$p' "$tmp_megatron_cfg" >> $target_megatron_cfg
+
+rm "$tmp_megatron_cfg" "$tmp_megatron_header"
+
+# 7. Verify that verl/trainer/config/_generated_ppo_trainer.yaml wasn't changed on disk
 if ! git diff --exit-code -- "$target_cfg" >/dev/null; then
   echo "✖ $target_cfg is out of date.  Please regenerate via 'scripts/generate_trainer_config.sh' and commit the changes."
   exit 1
 fi
+
+# 8. Verify that verl/trainer/config/_generated_ppo_megatron_trainer.yaml wasn't changed on disk
+if ! git diff --exit-code -- "$target_megatron_cfg" >/dev/null; then
+  echo "✖ $target_megatron_cfg is out of date.  Please regenerate via 'scripts/generate_trainer_config.sh' and commit the changes."
+  exit 1
+fi
+
 echo "All good"
 exit 0

--- a/scripts/generate_trainer_config.sh
+++ b/scripts/generate_trainer_config.sh
@@ -2,6 +2,7 @@
 set -euox pipefail
 
 
+
 # Define config specifications: "config_name:output_file:config_arg"
 CONFIG_SPECS=(
     "ppo_trainer:_generated_ppo_trainer.yaml:"

--- a/scripts/generate_trainer_config.sh
+++ b/scripts/generate_trainer_config.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
+
 # Define config specifications: "config_name:output_file:config_arg"
 CONFIG_SPECS=(
     "ppo_trainer:_generated_ppo_trainer.yaml:"

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -279,7 +279,7 @@ data:
     path: null
     name: null
 critic:
-  rollout_n: ${actor_rollout_ref.rollout.n}
+  rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
   strategy: megatron
   optim:
     lr_warmup_steps_ratio: 0.0
@@ -299,28 +299,28 @@ critic:
     use_checkpoint_opt_param_scheduler: false
   model:
     path: ~/models/deepseek-llm-7b-chat
-    tokenizer_path: ${actor_rollout_ref.model.path}
+    tokenizer_path: ${oc.select:actor_rollout_ref.model.path,"~/models/deepseek-llm-7b-chat"}
     override_config:
       model_config: {}
       moe_config:
         freeze_moe_router: false
-    external_lib: ${actor_rollout_ref.model.external_lib}
+    external_lib: ${oc.select:actor_rollout_ref.model.external_lib,null}
     enable_gradient_checkpointing: false
-    trust_remote_code: ${actor_rollout_ref.model.trust_remote_code}
+    trust_remote_code: ${oc.select:actor_rollout_ref.model.trust_remote_code,false}
     gradient_checkpointing_kwargs:
       activations_checkpoint_method: null
       activations_checkpoint_granularity: null
       activations_checkpoint_num_layers: null
-  ppo_mini_batch_size: ${actor_rollout_ref.actor.ppo_mini_batch_size}
+  ppo_mini_batch_size: ${oc.select:actor_rollout_ref.actor.ppo_mini_batch_size,256}
   ppo_micro_batch_size: null
-  ppo_micro_batch_size_per_gpu: null
-  use_dynamic_bsz: ${actor_rollout_ref.actor.use_dynamic_bsz}
+  ppo_micro_batch_size_per_gpu: ${oc.select:.ppo_micro_batch_size,null}
+  use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
   ppo_max_token_len_per_gpu: 32768
   forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
-  ppo_epochs: ${actor_rollout_ref.actor.ppo_epochs}
-  shuffle: ${actor_rollout_ref.actor.shuffle}
+  ppo_epochs: ${oc.select:actor_rollout_ref.actor.ppo_epochs,1}
+  shuffle: ${oc.select:actor_rollout_ref.actor.shuffle,false}
   cliprange_value: 0.5
-  loss_agg_mode: ${actor_rollout_ref.actor.loss_agg_mode}
+  loss_agg_mode: ${oc.select:actor_rollout_ref.actor.loss_agg_mode,token-mean}
   checkpoint:
     save_contents:
     - model
@@ -333,6 +333,7 @@ critic:
     discrete: false
     all_ranks: false
     ranks: []
+  _target_: verl.trainer.config.MegatronCriticConfig
   nccl_timeout: 600
   megatron:
     param_offload: false
@@ -348,15 +349,12 @@ critic:
     use_distributed_optimizer: true
     use_dist_checkpointing: false
     dist_checkpointing_path: null
-    seed: ${actor_rollout_ref.actor.megatron.seed}
-    override_ddp_config: ${actor_rollout_ref.actor.megatron.override_ddp_config}
-    override_transformer_config: ${actor_rollout_ref.actor.megatron.override_transformer_config}
-    use_mbridge: ${actor_rollout_ref.actor.megatron.use_mbridge}
+    seed: ${oc.select:actor_rollout_ref.actor.megatron.seed,42}
+    override_ddp_config: ${oc.select:actor_rollout_ref.actor.megatron.override_ddp_config,{}}
+    override_transformer_config: ${oc.select:actor_rollout_ref.actor.megatron.override_transformer_config,{}}
+    use_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.use_mbridge,False}
   load_weight: true
-  data_loader_seed: ${actor_rollout_ref.actor.data_loader_seed}
-  kl_ctrl:
-    type: fixed
-    kl_coef: 0.001
+  data_loader_seed: ${oc.select:actor_rollout_ref.actor.data_loader_seed,null}
 reward_model:
   enable: false
   strategy: megatron
@@ -394,9 +392,9 @@ reward_model:
     use_distributed_optimizer: false
     use_dist_checkpointing: false
     dist_checkpointing_path: null
-    seed: ${actor_rollout_ref.actor.megatron.seed}
+    seed: ${oc.select:actor_rollout_ref.actor.megatron.seed,42}
     override_transformer_config: {}
-    use_mbridge: ${actor_rollout_ref.actor.megatron.use_mbridge}
+    use_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.use_mbridge,False}
   load_weight: true
 custom_reward_function:
   path: null

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -1,0 +1,425 @@
+# This reference configration yaml is automatically generated via 'scripts/generate_trainer_config.sh'
+# in which it invokes 'python3 scripts/print_cfg.py --cfg job --config-name='ppo_megatron_trainer.yaml'' to flatten the 'verl/trainer/config/ppo_megatron_trainer.yaml' config fields into a single file.
+# Do not modify this file directly.
+# The file is usually only for reference and never used.
+
+actor_rollout_ref:
+  actor:
+    strategy: megatron
+    ppo_mini_batch_size: 256
+    ppo_micro_batch_size: null
+    ppo_micro_batch_size_per_gpu: null
+    use_dynamic_bsz: false
+    ppo_max_token_len_per_gpu: 16384
+    clip_ratio: 0.2
+    clip_ratio_low: 0.2
+    clip_ratio_high: 0.2
+    policy_loss:
+      loss_mode: vanilla
+      clip_cov_ratio: 0.0002
+      clip_cov_lb: 1.0
+      clip_cov_ub: 5.0
+      kl_cov_ratio: 0.0002
+      ppo_kl_coef: 0.1
+    clip_ratio_c: 3.0
+    loss_agg_mode: token-mean
+    entropy_coeff: 0
+    use_kl_loss: false
+    use_torch_compile: true
+    kl_loss_coef: 0.001
+    kl_loss_type: low_var_kl
+    ppo_epochs: 1
+    shuffle: false
+    checkpoint:
+      save_contents:
+      - model
+      - optimizer
+      - extra
+      load_contents: ${.save_contents}
+      async_save: false
+    optim:
+      lr: 1.0e-06
+      lr_warmup_steps_ratio: 0.0
+      total_training_steps: -1
+      weight_decay: 0.01
+      optimizer: adam
+      clip_grad: 1.0
+      lr_warmup_init: 0.0
+      lr_warmup_steps: null
+      lr_decay_steps: null
+      lr_decay_style: constant
+      min_lr: 0.0
+      weight_decay_incr_style: constant
+      lr_wsd_decay_style: exponential
+      lr_wsd_decay_steps: null
+      use_checkpoint_opt_param_scheduler: false
+    data_loader_seed: null
+    load_weight: true
+    megatron:
+      param_offload: false
+      grad_offload: false
+      optimizer_offload: false
+      tensor_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      expert_tensor_parallel_size: null
+      pipeline_model_parallel_size: 1
+      virtual_pipeline_model_parallel_size: null
+      context_parallel_size: 1
+      sequence_parallel: true
+      use_distributed_optimizer: true
+      use_dist_checkpointing: false
+      dist_checkpointing_path: null
+      seed: 42
+      override_ddp_config: {}
+      override_transformer_config: {}
+      use_mbridge: false
+    profile:
+      use_profile: false
+      profile_ranks: null
+      step_start: -1
+      step_end: -1
+      save_path: null
+  ref:
+    strategy: megatron
+    use_torch_compile: ${oc.select:actor_rollout_ref.actor.use_torch_compile,true}
+    log_prob_micro_batch_size: null
+    log_prob_micro_batch_size_per_gpu: null
+    log_prob_use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
+    log_prob_max_token_len_per_gpu: ${oc.select:actor_rollout_ref.actor.ppo_max_token_len_per_gpu,16384}
+    megatron:
+      param_offload: false
+      tensor_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      expert_tensor_parallel_size: None
+      pipeline_model_parallel_size: 1
+      virtual_pipeline_model_parallel_size: null
+      context_parallel_size: 1
+      sequence_parallel: true
+      use_distributed_optimizer: false
+      use_dist_checkpointing: false
+      dist_checkpointing_path: null
+      seed: ${oc.select:actor_rollout_ref.actor.megatron.seed,42}
+      override_transformer_config: ${oc.select:actor_rollout_ref.actor.megatron.override_transformer_config,{}}
+      use_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.use_mbridge,False}
+    profile:
+      use_profile: false
+      profile_ranks: null
+      step_start: -1
+      step_end: -1
+      save_path: null
+    load_weight: true
+  rollout:
+    name: vllm
+    mode: sync
+    temperature: 1.0
+    top_k: -1
+    top_p: 1
+    prompt_length: ${oc.select:data.max_prompt_length,512}
+    response_length: ${oc.select:data.max_response_length,512}
+    dtype: bfloat16
+    gpu_memory_utilization: 0.5
+    ignore_eos: false
+    enforce_eager: true
+    free_cache_engine: true
+    tensor_model_parallel_size: 1
+    max_num_batched_tokens: 8192
+    max_model_len: null
+    max_num_seqs: 1024
+    log_prob_micro_batch_size: null
+    log_prob_micro_batch_size_per_gpu: null
+    log_prob_use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
+    log_prob_max_token_len_per_gpu: ${oc.select:actor_rollout_ref.actor.ppo_max_token_len_per_gpu,16384}
+    disable_log_stats: true
+    do_sample: true
+    'n': 1
+    multi_stage_wake_up: false
+    engine_kwargs:
+      vllm:
+        swap_space: null
+        disable_mm_preprocessor_cache: false
+      sglang:
+        attention_backend: null
+    val_kwargs:
+      top_k: -1
+      top_p: 1.0
+      temperature: 0
+      'n': 1
+      do_sample: false
+    multi_turn:
+      enable: false
+      max_assistant_turns: null
+      tool_config_path: null
+      max_user_turns: null
+      max_parallel_calls: 1
+      max_tool_response_length: 256
+      tool_response_truncate_side: middle
+      interaction_config_path: null
+      completion_callback: null
+      use_inference_chat_template: false
+      tokenization_sanity_check_mode: strict
+      format: hermes
+    calculate_log_probs: false
+    agent:
+      num_workers: 8
+      agent_loop_config_path: null
+      custom_async_server:
+        path: null
+        name: null
+    update_weights_bucket_megabytes: 512
+    trace:
+      backend: null
+      token2text: false
+    enable_chunked_prefill: false
+    load_format: dummy_megatron
+    layer_name_map:
+      qkv_layer_name: qkv
+      gate_proj_layer_name: gate_up
+  hybrid_engine: true
+  nccl_timeout: 600
+  model:
+    path: ~/models/deepseek-llm-7b-chat
+    custom_chat_template: null
+    external_lib: null
+    override_config:
+      model_config: {}
+      moe_config:
+        freeze_moe_router: false
+    enable_gradient_checkpointing: false
+    gradient_checkpointing_kwargs:
+      activations_checkpoint_method: null
+      activations_checkpoint_granularity: null
+      activations_checkpoint_num_layers: null
+    use_fused_kernels: false
+    trust_remote_code: false
+  profiler:
+    _target_: verl.utils.profiler.ProfilerConfig
+    discrete: false
+    all_ranks: false
+    ranks: []
+trainer:
+  npu_profile:
+    options:
+      save_path: ./profiler_data
+      level: level1
+      with_memory: false
+      record_shapes: false
+      with_npu: true
+      with_cpu: true
+      with_module: false
+      with_stack: false
+      analysis: true
+  balance_batch: true
+  total_epochs: 30
+  total_training_steps: null
+  profile_steps: null
+  project_name: verl_examples
+  experiment_name: gsm8k
+  logger:
+  - console
+  - wandb
+  log_val_generations: 0
+  nnodes: 1
+  n_gpus_per_node: 8
+  save_freq: -1
+  esi_redundant_time: 0
+  resume_mode: auto
+  resume_from_path: null
+  del_local_ckpt_after_load: false
+  val_before_train: true
+  test_freq: -1
+  critic_warmup: 0
+  default_hdfs_dir: null
+  default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
+  max_actor_ckpt_to_keep: null
+  max_critic_ckpt_to_keep: null
+  ray_wait_register_center_timeout: 300
+  device: cuda
+  controller_nsight_options:
+    trace: cuda,nvtx,cublas,ucx
+    cuda-memory-usage: 'true'
+    cuda-graph-trace: graph
+  worker_nsight_options:
+    trace: cuda,nvtx,cublas,ucx
+    cuda-memory-usage: 'true'
+    cuda-graph-trace: graph
+    capture-range: cudaProfilerApi
+    capture-range-end: null
+    kill: none
+data:
+  tokenizer: null
+  use_shm: false
+  train_files: ~/data/rlhf/gsm8k/train.parquet
+  val_files: ~/data/rlhf/gsm8k/test.parquet
+  prompt_key: prompt
+  reward_fn_key: data_source
+  max_prompt_length: 512
+  max_response_length: 512
+  train_batch_size: 1024
+  val_batch_size: null
+  return_raw_input_ids: false
+  return_raw_chat: false
+  return_full_prompt: false
+  shuffle: true
+  dataloader_num_workers: 8
+  validation_shuffle: false
+  filter_overlong_prompts: false
+  filter_overlong_prompts_workers: 1
+  truncation: error
+  image_key: images
+  video_key: videos
+  trust_remote_code: false
+  custom_cls:
+    path: null
+    name: null
+  return_multi_modal_inputs: true
+  sampler:
+    class_path: null
+    class_name: null
+  datagen:
+    path: null
+    name: null
+critic:
+  rollout_n: ${actor_rollout_ref.rollout.n}
+  strategy: megatron
+  optim:
+    lr_warmup_steps_ratio: 0.0
+    total_training_steps: -1
+    weight_decay: 0.01
+    optimizer: adam
+    lr: 1.0e-06
+    clip_grad: 1.0
+    lr_warmup_init: 0.0
+    lr_warmup_steps: null
+    lr_decay_steps: null
+    lr_decay_style: linear
+    min_lr: 0.0
+    weight_decay_incr_style: constant
+    lr_wsd_decay_style: exponential
+    lr_wsd_decay_steps: null
+    use_checkpoint_opt_param_scheduler: false
+  model:
+    path: ~/models/deepseek-llm-7b-chat
+    tokenizer_path: ${actor_rollout_ref.model.path}
+    override_config:
+      model_config: {}
+      moe_config:
+        freeze_moe_router: false
+    external_lib: ${actor_rollout_ref.model.external_lib}
+    enable_gradient_checkpointing: false
+    trust_remote_code: ${actor_rollout_ref.model.trust_remote_code}
+    gradient_checkpointing_kwargs:
+      activations_checkpoint_method: null
+      activations_checkpoint_granularity: null
+      activations_checkpoint_num_layers: null
+  ppo_mini_batch_size: ${actor_rollout_ref.actor.ppo_mini_batch_size}
+  ppo_micro_batch_size: null
+  ppo_micro_batch_size_per_gpu: null
+  use_dynamic_bsz: ${actor_rollout_ref.actor.use_dynamic_bsz}
+  ppo_max_token_len_per_gpu: 32768
+  forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
+  ppo_epochs: ${actor_rollout_ref.actor.ppo_epochs}
+  shuffle: ${actor_rollout_ref.actor.shuffle}
+  cliprange_value: 0.5
+  loss_agg_mode: ${actor_rollout_ref.actor.loss_agg_mode}
+  checkpoint:
+    save_contents:
+    - model
+    - optimizer
+    - extra
+    load_contents: ${.save_contents}
+    async_save: false
+  profiler:
+    _target_: verl.utils.profiler.ProfilerConfig
+    discrete: false
+    all_ranks: false
+    ranks: []
+  nccl_timeout: 600
+  megatron:
+    param_offload: false
+    grad_offload: false
+    optimizer_offload: false
+    tensor_model_parallel_size: 1
+    expert_model_parallel_size: 1
+    expert_tensor_parallel_size: null
+    pipeline_model_parallel_size: 1
+    virtual_pipeline_model_parallel_size: null
+    context_parallel_size: 1
+    sequence_parallel: true
+    use_distributed_optimizer: true
+    use_dist_checkpointing: false
+    dist_checkpointing_path: null
+    seed: ${actor_rollout_ref.actor.megatron.seed}
+    override_ddp_config: ${actor_rollout_ref.actor.megatron.override_ddp_config}
+    override_transformer_config: ${actor_rollout_ref.actor.megatron.override_transformer_config}
+    use_mbridge: ${actor_rollout_ref.actor.megatron.use_mbridge}
+  load_weight: true
+  data_loader_seed: ${actor_rollout_ref.actor.data_loader_seed}
+  kl_ctrl:
+    type: fixed
+    kl_coef: 0.001
+reward_model:
+  enable: false
+  strategy: megatron
+  model:
+    input_tokenizer: ${actor_rollout_ref.model.path}
+    path: ~/models/FsfairX-LLaMA3-RM-v0.1
+    external_lib: ${actor_rollout_ref.model.external_lib}
+    trust_remote_code: false
+  micro_batch_size: null
+  micro_batch_size_per_gpu: null
+  max_length: null
+  use_dynamic_bsz: ${critic.use_dynamic_bsz}
+  forward_max_token_len_per_gpu: ${critic.forward_max_token_len_per_gpu}
+  reward_manager: naive
+  launch_reward_fn_async: false
+  sandbox_fusion:
+    url: null
+    max_concurrent: 64
+    memory_limit_mb: 1024
+  profiler:
+    _target_: verl.utils.profiler.ProfilerConfig
+    discrete: false
+    all_ranks: false
+    ranks: []
+  nccl_timeout: 600
+  megatron:
+    param_offload: false
+    tensor_model_parallel_size: 1
+    expert_model_parallel_size: 1
+    expert_tensor_parallel_size: null
+    pipeline_model_parallel_size: 1
+    virtual_pipeline_model_parallel_size: null
+    context_parallel_size: 1
+    sequence_parallel: true
+    use_distributed_optimizer: false
+    use_dist_checkpointing: false
+    dist_checkpointing_path: null
+    seed: ${actor_rollout_ref.actor.megatron.seed}
+    override_transformer_config: {}
+    use_mbridge: ${actor_rollout_ref.actor.megatron.use_mbridge}
+  load_weight: true
+custom_reward_function:
+  path: null
+  name: compute_score
+algorithm:
+  _target_: verl.trainer.config.AlgoConfig
+  gamma: 1.0
+  lam: 1.0
+  adv_estimator: gae
+  norm_adv_by_std_in_grpo: true
+  use_kl_in_reward: false
+  kl_penalty: kl
+  kl_ctrl:
+    _target_: verl.trainer.config.KLControlConfig
+    type: fixed
+    kl_coef: 0.001
+    horizon: 10000
+    target_kl: 0.1
+  use_pf_ppo: false
+  pf_ppo:
+    _target_: verl.trainer.config.PFPPOConfig
+    reweight_method: pow
+    weight_pow: 2.0
+ray_init:
+  num_cpus: null
+  timeline_json_file: null

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -1,5 +1,5 @@
 # This reference configration yaml is automatically generated via 'scripts/generate_trainer_config.sh'
-# in which it invokes 'python3 scripts/print_cfg.py --cfg job --config-name='ppo_megatron_trainer.yaml'' to flatten the 'verl/trainer/config/ppo_megatron_trainer.yaml' config fields into a single file.
+# in which it invokes 'python3 scripts/print_cfg.py --cfg job --config-name=ppo_megatron_trainer.yaml' to flatten the 'verl/trainer/config/ppo_megatron_trainer.yaml' config fields into a single file.
 # Do not modify this file directly.
 # The file is usually only for reference and never used.
 

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -1,5 +1,5 @@
 # This reference configration yaml is automatically generated via 'scripts/generate_trainer_config.sh'
-# in which it invokes 'python3 scripts/print_cfg.py --cfg job' to flatten the 'verl/trainer/config/ppo_trainer.yaml' config fields into a single file.
+# in which it invokes 'python3 scripts/print_cfg.py --cfg job ' to flatten the 'verl/trainer/config/ppo_trainer.yaml' config fields into a single file.
 # Do not modify this file directly.
 # The file is usually only for reference and never used.
 


### PR DESCRIPTION
### What does this PR do?

- Added CONFIG_SPECS array: "config_name:output_file:config_arg" format
- Now generates both _generated_ppo_trainer.yaml and _generated_ppo_megatron_trainer.yaml
- Maintains identical output format and verification behavior

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
