### PR TITLE
新增 rollout_skip功能

### DIFF
--- a/recipe/dapo/dapo_ray_trainer.py
+++ b/recipe/dapo/dapo_ray_trainer.py
@@ -41,6 +41,7 @@ from verl.trainer.ppo.ray_trainer import (
     compute_response_mask,
 )
 from verl.utils.profiler import marked_timer
+from verl.workers.rollout.rollout_skip import RolloutSkip
 
 
 class RayDAPOTrainer(RayPPOTrainer):
@@ -92,6 +93,10 @@ class RayDAPOTrainer(RayPPOTrainer):
         batch = None
         num_prompt_in_batch = 0
         num_gen_batches = 0
+
+        if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
+            rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
+
         for epoch in range(self.config.trainer.total_epochs):
             for batch_dict in self.train_dataloader:
                 metrics = {}

--- a/verl/workers/rollout/rollout_skip.py
+++ b/verl/workers/rollout/rollout_skip.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import torch
+import tensordict
+from verl.protocol import DataProto
+
+
+class RolloutSkip:
+
+    def __init__(self, config, rollout_wg):
+        self.dump_step = 0
+
+        self.rollout_config = config.actor_rollout_ref.rollout
+
+        self.n = int(self.rollout_config.get("n", 0))
+        self.gen_gbs = int(config.data.get("gen_batch_size", 0))
+
+        self.skip_use_default_dir = Path(self.rollout_config.get("skip_use_default_dir", "tmp/rollout_dump"))
+        self.skip_use_default_dir = self.skip_use_default_dir.joinpath(f"InferGBS{self.gen_gbs}__N{self.n}")
+        self.skip_use_default_dir.mkdir(exist_ok=True, parents=True)
+
+        # * check is in ray tmp path
+        if self.skip_use_default_dir.absolute().__str__().startswith("/tmp/ray/session"):
+            print(
+                f"\033[33m[RolloutSkip()] Warning: \nit is not recommanded to use dump path ",
+                f"\033[0m'{self.skip_use_default_dir.absolute()}'\033[33m which is relative to /tmp/ray/session*",
+            )
+
+        # todo add dump with step num
+        self.skip_rollout_dumpsteps = int(self.rollout_config.get("skip_rollout_dumpsteps", 1))
+        print(f"\033[33mUsing rollout skip dump path: \n{self.skip_use_default_dir.absolute()}\033[0m", flush=True)
+
+        rollout_wg.generate_sequences = wrap_generate_sequences(self, rollout_wg)
+
+    @property
+    def curr_path_dump(self):
+        return self.skip_use_default_dir.joinpath(f"dump_step_{self.dump_step}")
+
+    def try_load(self):
+        if not self.curr_path_dump.exists():
+            return None
+        try:
+            # * Load
+            # ret_batch = tensordict.TensorDict.load_memmap(self.curr_path_dump)
+            ret_batch = DataProto.load_from_disk(self.curr_path_dump)
+            # todo check if `n` matched current config，otherwise copy part of dumped data.
+            print(f"\033[32mSuccessed to load dumped data from {self.curr_path_dump.absolute()}\033[0m", flush=True)
+            return ret_batch
+        except:
+            print(f"\033[31mFailed to load dumped data from {self.curr_path_dump.absolute()}\033[0m", flush=True)
+
+        return None
+
+    def dump(self, outputs):
+        outputs.save_to_disk(self.curr_path_dump)
+        print(f"\033[32mSuccessed to dump data in {self.curr_path_dump.absolute()}\033[0m", flush=True)
+        # self.dump_step += 1
+
+
+def wrap_generate_sequences(rolloutskip: RolloutSkip, rollout_wg):
+    generate_sequences = rollout_wg.generate_sequences
+
+    def warp_fn(batch, **kwargs):
+        gen_batch_output = rolloutskip.try_load()
+
+        if gen_batch_output is None:
+            # * 1. Generation
+            gen_batch_output = generate_sequences(batch, **kwargs)
+            # * 2. Dump
+            rolloutskip.dump(gen_batch_output)
+        return gen_batch_output
+
+    print(f"SkipRollout patched `actor_rollout_wg.generate_sequences()` successfully.", flush=True)
+    return warp_fn


### PR DESCRIPTION
需要设置两个参数

    +actor_rollout_ref.rollout.skip_rollout=True 
    +actor_rollout_ref.rollout.skip_use_default_dir="/tmp/rollout_dump" 

skip_use_default_dir 设置了 dump 的路径，第一次运行会在这个路径上生成 dump 下来的打桩数据（rollout 推理出来的结果），之后的运行都会检查这个路径下的结果，并自动读取。




<img width="899" height="681" alt="image" src="https://github.com/user-attachments/assets/f6253e36-14b8-47ab-9817-ce6c42b3168d" />
