### PR TITLE
[fsdp, megatron, sglang] fix: Fixed a bug in the update_weight process where the GPU ID was being passed incorrectly.

### DIFF
--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -162,16 +162,14 @@ class AsyncEngine(sglang.srt.entrypoints.engine.Engine):
 
     async def update_weights_from_tensor(
         self,
-        named_tensors: List[Tuple[str, torch.Tensor]],  # noqa: UP006
+        named_tensors: List[str],  # noqa: UP006
         load_format: Optional[str] = None,
         flush_cache: bool = True,
     ):
         """Update weights from distributed source. If there are going to be more updates, set `flush_cache` to be false
         to avoid duplicated cache cleaning operation."""
         obj = UpdateWeightsFromTensorReqInput(
-            serialized_named_tensors=[
-                MultiprocessingSerializer.serialize(named_tensors) for _ in range(self.server_args.tp_size)
-            ],
+            serialized_named_tensors=named_tensors,
             load_format=load_format,
             flush_cache=flush_cache,
         )

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -22,7 +22,7 @@ import os
 import time
 from copy import deepcopy
 from json import JSONDecodeError
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional
 from uuid import uuid4
 
 import numpy as np
@@ -38,7 +38,6 @@ from sglang.srt.managers.tokenizer_manager import (
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import (
-    MultiprocessingSerializer,
     assert_pkg_version,
     get_ip,
     get_open_port,

--- a/verl/workers/sharding_manager/megatron_sglang.py
+++ b/verl/workers/sharding_manager/megatron_sglang.py
@@ -24,7 +24,6 @@ import os
 import torch.distributed as dist
 from omegaconf import DictConfig
 from sglang.srt.entrypoints.engine import Engine
-from sglang.srt.patch_torch import monkey_patch_torch_reductions
 from sglang.srt.utils import MultiprocessingSerializer
 from torch import nn
 from torch.distributed.device_mesh import DeviceMesh
@@ -147,7 +146,6 @@ class MegatronSGLangShardingManager(BaseShardingManager):
             await self.inference_engine.resume_memory_occupation()
         named_tensors = params
         load_format = None
-        monkey_patch_torch_reductions()
 
         update_weights_bucket_bytes = int(self.rollout_config.update_weights_bucket_megabytes) << 20
         for batch in get_named_tensor_buckets(named_tensors, update_weights_bucket_bytes):

--- a/verl/workers/sharding_manager/megatron_sglang.py
+++ b/verl/workers/sharding_manager/megatron_sglang.py
@@ -24,7 +24,7 @@ import os
 import torch.distributed as dist
 from omegaconf import DictConfig
 from sglang.srt.entrypoints.engine import Engine
-from sglang.srt.model_executor.model_runner import LocalSerializedTensor
+from sglang.srt.patch_torch import monkey_patch_torch_reductions
 from sglang.srt.utils import MultiprocessingSerializer
 from torch import nn
 from torch.distributed.device_mesh import DeviceMesh
@@ -147,15 +147,16 @@ class MegatronSGLangShardingManager(BaseShardingManager):
             await self.inference_engine.resume_memory_occupation()
         named_tensors = params
         load_format = None
+        monkey_patch_torch_reductions()
 
         update_weights_bucket_bytes = int(self.rollout_config.update_weights_bucket_megabytes) << 20
         for batch in get_named_tensor_buckets(named_tensors, update_weights_bucket_bytes):
             # On each rank, serialize a batch of (name, tensor) tuples.
             # named_tensors_batch will be a list like:
             # [(name0, serialized_tensor0_tp0), (name1, serialized_tensor1_tp0), ...]
-            named_tensors_batch = [
-                (name, MultiprocessingSerializer.serialize(tensor.detach())) for name, tensor in batch
-            ]
+            named_tensors_batch = MultiprocessingSerializer.serialize(
+                [(name, tensor.detach()) for name, tensor in batch], output_str=True
+            )
 
             if self.device_mesh["tp"].get_local_rank() == 0:
                 # On rank 0, prepare a list to hold the gathered batches from all ranks.
@@ -181,20 +182,8 @@ class MegatronSGLangShardingManager(BaseShardingManager):
                 # This groups the serialized parts for each individual tensor across all TP ranks.
                 # Example: from [[(n0, t0_tp0), (n1, t1_tp0)], [(n0, t0_tp1), (n1, t1_tp1)]]
                 # to [ ( (n0, t0_tp0), (n0, t0_tp1) ), ( (n1, t1_tp0), (n1, t1_tp1) ) ]
-                logical_tensors = zip(*gathered_serialized_batches, strict=False)
                 await self.inference_engine.update_weights_from_tensor(
-                    named_tensors=[
-                        # 'tensor_group' represents a single logical tensor's data from all ranks.
-                        (
-                            tensor_group[0][0],  # Get the name from the first rank's data.
-                            LocalSerializedTensor(
-                                # 'rank_part' is the (name, serialized_tensor) tuple from one specific rank.
-                                values=[rank_part[1] for rank_part in tensor_group]
-                            ),
-                        )
-                        for tensor_group in logical_tensors
-                        # each tensor_group is like ( (n0, t0_tp0), (n0, t0_tp1) )
-                    ],
+                    named_tensors=gathered_serialized_batches,
                     load_format=load_format,
                     flush_cache=False,
                 )


### PR DESCRIPTION
### What does this PR do?

When using verl+megatron+sglang, we observed extremely unusual phenomena. We found that some abnormal processes were always running on GPU0, occupying VRAM. 

<img width="414" height="355" alt="image" src="https://github.com/user-attachments/assets/d7cfa350-4c69-44c8-8cf2-7713af484f49" />

When Ray launches each process, it sets `CUDA_VISIBLE_DEVICES` for each process. For example, rank 1 is set to GPU 1, and rank 2 is set to GPU 2. However, the problem is that from the perspective of process rank 2, it treats GPU 2 as its own GPU 0 (index=0). This leads to rank 2 actually sending a GPU ID of 0 when transferring Tensors across processes. Consequently, every Worker in SGlang receives a Tensor with an incorrect GPU ID, causing abnormal memory usage on GPU 0,at the same time, this also causes unnecessary memory copies, slowing down the update_weights process.

[PR](https://github.com/pytorch/pytorch/pull/149248) addresses the issue of transferring Tensors across processes. This requires a patch to be applied both during serialization in the sending process and deserialization in the receiving process. Verl hasn't implemented this. Referencing [PR](https://github.com/pytorch/pytorch/pull/149248) and the implementation in [slime](https://github.THUDM/slime.git), we resolved this problem.
We also modified  the [Sglang](https://github.com/sgl-project/sglang/pull/8150).
### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
