### PR TITLE
[rollout,vllm] fix: A major issue in random sampling of vllm engine

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -198,7 +198,7 @@ class vLLMRollout(BaseRollout):
 
         # supporting adding any sampling params from the config file
         for k in config.keys():
-            if hasattr(SamplingParams(), str(k)):
+            if hasattr(SamplingParams(), str(k)) and k != "seed":
                 kwargs[k] = config.get(k)
         kwargs["n"] = 1  # already repeat in ray_trainer
         print(f"kwargs: {kwargs}")


### PR DESCRIPTION
There is a optional config `+actor_rollout_ref.rollout.seed`, which is used in 

[https://github.com/volcengine/verl/blob/fcb1e191b758cadd3f45bb9d3ee815d979f4a1ec/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py#L165-L185](https://github.com/volcengine/verl/blob/fcb1e191b758cadd3f45bb9d3ee815d979f4a1ec/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py#L165-L185)

This config ensures identical initialization of vllm engine in distributed systems.

However in 

[https://github.com/volcengine/verl/blob/fcb1e191b758cadd3f45bb9d3ee815d979f4a1ec/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py#L202](https://github.com/volcengine/verl/blob/fcb1e191b758cadd3f45bb9d3ee815d979f4a1ec/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py#L202)

`class SamplingParam` unexpectedly adopts this `seed` param again when `actor_rollout_ref.rollout.seed` is explicitly set.

In sampling param, this means the reproducibility during vllm inference.

This will cause serious problems, because in recent verl, the `ray_trainer.py` will first flatten the input prompts, e.g.

[https://github.com/volcengine/verl/blob/fcb1e191b758cadd3f45bb9d3ee815d979f4a1ec/verl/trainer/ppo/ray_trainer.py#L1160](https://github.com/volcengine/verl/blob/fcb1e191b758cadd3f45bb9d3ee815d979f4a1ec/verl/trainer/ppo/ray_trainer.py#L1160)

so if `+actor_rollout_ref.rollout.seed` is set, identical prompts will receive identical responses, leading to a completely collapse of GRPO training, as every advantage is zero, for example:

<img width="1104" height="858" alt="Screenshot 2025-07-20 002009" src="https://github.com/user-attachments/assets/32eb1cc3-2ca2-41b9-9a9c-57b5dc557ed1" />




