### PR TITLE
Revert "[fsdp,megatron,sglang] fix: Fix torch reduce to speed up update weights"

### DIFF
--- a/verl/workers/sharding_manager/fsdp_sglang.py
+++ b/verl/workers/sharding_manager/fsdp_sglang.py
@@ -22,11 +22,7 @@ import torch
 import torch.distributed as dist
 from sglang.srt.entrypoints.engine import Engine
 from sglang.srt.model_executor.model_runner import LocalSerializedTensor
-
-try:
-    from sglang.srt.utils import TorchPatchMultiprocessingSerializer as MultiprocessingSerializer
-except ImportError:
-    from sglang.srt.utils import MultiprocessingSerializer
+from sglang.srt.utils import MultiprocessingSerializer
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp.api import FullStateDictConfig, ShardedStateDictConfig, StateDictType
 from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP

--- a/verl/workers/sharding_manager/megatron_sglang.py
+++ b/verl/workers/sharding_manager/megatron_sglang.py
@@ -25,11 +25,7 @@ import torch.distributed as dist
 from omegaconf import DictConfig
 from sglang.srt.entrypoints.engine import Engine
 from sglang.srt.model_executor.model_runner import LocalSerializedTensor
-
-try:
-    from sglang.srt.utils import TorchPatchMultiprocessingSerializer as MultiprocessingSerializer
-except ImportError:
-    from sglang.srt.utils import MultiprocessingSerializer
+from sglang.srt.utils import MultiprocessingSerializer
 from torch import nn
 from torch.distributed.device_mesh import DeviceMesh
 


### PR DESCRIPTION
Reverts volcengine/verl#2692 since https://github.com/sgl-project/sglang/pull/8267 is merged yet, we need to wait for 8267 and sglang release