### PR TITLE
[cfg] fix: fix failing rollout config test on main

### DIFF
--- a/.github/workflows/cpu_unit_tests.yml
+++ b/.github/workflows/cpu_unit_tests.yml
@@ -59,17 +59,20 @@ permissions:
 
 jobs:
   cpu_unit_tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10 # Increase this timeout value as needed
-    strategy:
-      matrix:
-        python-version: ["3.10"]
+    runs-on: [L20x8]
+    timeout-minutes: 20 # Increase this timeout value as needed
+    env:
+      HTTP_PROXY: ${{ secrets.PROXY_HTTP }}
+      HTTPS_PROXY: ${{ secrets.PROXY_HTTPS }}
+      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com"
+      HF_ENDPOINT: "https://hf-mirror.com"
+      HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
+    container:
+      image: verlai/verl:app-verl0.5-vllm0.9.1-mcore0.12.2-te2.2
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: ${{ matrix.python-version }}
+          fetch-depth: 0
       - name: Install the current repository
         run: |
           pip install -e .[test,prime,geo]

--- a/.github/workflows/model.yml
+++ b/.github/workflows/model.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install the current repository and upgrade to latest transformers/flash_attn
         run: |
           pip3 install --no-deps -e .[test]
-          pip3 install --upgrade transformers
+          pip3 install --upgrade transformers==4.53.3
       - name: Running rmpad model tests on 8 L20 GPUs + flash_attn 2.5.8
         run: |
           pytest -s tests/models/test_transformer.py
@@ -138,7 +138,7 @@ jobs:
       - name: Install the current repository and upgrade to latest transformers/flash_attn
         run: |
           pip3 install --no-deps -e .[test]
-          pip3 install --upgrade transformers
+          pip3 install --upgrade transformers==4.53.3
       - name: Running FSDP2 rmpad model tests on 8 L20 GPUs + latest flash_attn
         run: |
           STRATEGY=fsdp2 torchrun --nproc_per_node=8 tests/special_distributed/test_fsdp_ckpt.py

--- a/tests/trainer/config/test_legacy_config_on_cpu.py
+++ b/tests/trainer/config/test_legacy_config_on_cpu.py
@@ -24,6 +24,7 @@ _BREAKING_CHANGES = [
     "critic.optim.lr",  # mcore critic lr init value 1e-6 -> 1e-5
     "actor_rollout_ref.actor.optim.lr_warmup_steps",  # None -> -1
     "critic.optim.lr_warmup_steps",  # None -> -1
+    "actor_rollout_ref.rollout.name",  # vllm -> ???
 ]
 
 

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -419,7 +419,9 @@ class DataParallelPPOActor(BasePPOActor):
                     )
 
                     loss_mode = self.config.policy_loss.get("loss_mode", "vanilla")
-
+                    # vanilla -> verl.trainer.ppo.core_algos.compute_policy_loss_vanilla
+                    # gpg -> verl.trainer.ppo.core_algos.compute_policy_loss_gpg
+                    # clip_cov -> verl.trainer.ppo.core_algos.compute_policy_loss_clip_cov
                     policy_loss_fn = get_policy_loss_fn(loss_mode)
                     pg_loss, pg_clipfrac, ppo_kl, pg_clipfrac_lower = policy_loss_fn(
                         old_log_prob=old_log_prob,


### PR DESCRIPTION
### What does this PR do?

The cpu unit test is broken when https://github.com/volcengine/verl/pull/2757/files is merged.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`
