### PR TITLE
[rollout] feat: pass all dataset fields to agent loop run

### DIFF
--- a/docs/advance/agent_loop.rst
+++ b/docs/advance/agent_loop.rst
@@ -43,18 +43,18 @@ could do whatever user wants, such as
 .. code:: python
 
    class AgentLoopBase(ABC):
-        @abstractmethod
-        async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
-            """Run agent loop to interact with LLM server and environment.
+       @abstractmethod
+       async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+           """Run agent loop to interact with LLM server and environment.
 
-            Args:
-                sampling_params (Dict[str, Any]): LLM sampling params.
-                **kwargs: dataset fields from `verl.utils.dataset.RLHFDataset`.
+           Args:
+               sampling_params (Dict[str, Any]): LLM sampling params.
+               **kwargs: dataset fields from `verl.utils.dataset.RLHFDataset`.
 
-            Returns:
-                AgentLoopOutput: Agent loop output.
-            """
-            raise NotImplementedError
+           Returns:
+               AgentLoopOutput: Agent loop output.
+           """
+           raise NotImplementedError
 
 After running user defined loop, run method should return ``AgentLoopOutput``, including prompt token ids,
 response token ids, and response mask.

--- a/docs/advance/agent_loop.rst
+++ b/docs/advance/agent_loop.rst
@@ -43,18 +43,18 @@ could do whatever user wants, such as
 .. code:: python
 
    class AgentLoopBase(ABC):
-       @abstractmethod
-       async def run(self, messages: list[dict[str, Any]], sampling_params: dict[str, Any]) -> AgentLoopOutput:
-           """Run agent loop to interact with LLM server and environment.
+        @abstractmethod
+        async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+            """Run agent loop to interact with LLM server and environment.
 
-           Args:
-               messages (List[Dict[str, Any]]): Input messages.
-               sampling_params (Dict[str, Any]): LLM sampling params.
+            Args:
+                sampling_params (Dict[str, Any]): LLM sampling params.
+                **kwargs: dataset fields from `verl.utils.dataset.RLHFDataset`.
 
-           Returns:
-               AgentLoopOutput: Agent loop output.
-           """
-           raise NotImplementedError
+            Returns:
+                AgentLoopOutput: Agent loop output.
+            """
+            raise NotImplementedError
 
 After running user defined loop, run method should return ``AgentLoopOutput``, including prompt token ids,
 response token ids, and response mask.

--- a/recipe/langgraph_agent/react_agent_loop.py
+++ b/recipe/langgraph_agent/react_agent_loop.py
@@ -99,7 +99,9 @@ class ReactAgentLoop(AgentLoopBase):
         graph = workflow.compile()
         return graph
 
-    async def run(self, messages: list[dict[str, Any]], sampling_params: dict[str, Any]) -> AgentLoopOutput:
+    async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+        messages = list(kwargs["raw_prompt"])
+
         model_path = self.config.actor_rollout_ref.model.path
         model_name = "/".join(model_path.split("/")[-2:])
 

--- a/recipe/langgraph_agent/test_react_agent_loop.py
+++ b/recipe/langgraph_agent/test_react_agent_loop.py
@@ -41,6 +41,7 @@ def init_config() -> DictConfig:
     config.actor_rollout_ref.rollout.n = 4
     config.actor_rollout_ref.rollout.agent.num_workers = 2
 
+    config.actor_rollout_ref.actor.use_dynamic_bsz = True
     # test sleep/wake_up with fsdp offload
     config.actor_rollout_ref.actor.fsdp_config.param_offload = True
     config.actor_rollout_ref.actor.fsdp_config.optimizer_offload = True

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -32,7 +32,9 @@ class SingleTurnAgentLoop(AgentLoopBase):
         self.prompt_length = self.config.actor_rollout_ref.rollout.prompt_length
         self.response_length = self.config.actor_rollout_ref.rollout.response_length
 
-    async def run(self, messages: list[dict[str, Any]], sampling_params: dict[str, Any]) -> AgentLoopOutput:
+    async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+        messages = list(kwargs["raw_prompt"])
+
         metrics = {}
         request_id = uuid4().hex
         prompt_ids = await self.loop.run_in_executor(

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -56,7 +56,8 @@ class ToolAgentLoop(AgentLoopBase):
         cls.system_prompt = tokenizer.apply_chat_template([{}], add_generation_prompt=False, tokenize=True)
 
     @rollout_trace_op
-    async def run(self, messages: list[dict[str, Any]], sampling_params: dict[str, Any]) -> AgentLoopOutput:
+    async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+        messages = list(kwargs["raw_prompt"])
         metrics = {}
         request_id = uuid4().hex
         prompt_ids = await self.loop.run_in_executor(


### PR DESCRIPTION
### What does this PR do?

Pass all dataset fields from `RLHFDataset` to agent loop run, including:
- raw_prompt
- tools_kwargs
- multi_modal_data
- ...
