### PR TITLE
[trainer, hardware] chore: add pin_memory_device when pin_memory is enabled

### DIFF
--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -168,6 +168,9 @@ class FSDPSFTTrainer:
         if self.device_mesh.get_rank() == 0:
             print(f"Using FSDP rank {rank} and size {world_size} for data distribution")
 
+        # Set pin_memory_device when pin_memory is enabled.
+        device_name = get_device_name()
+
         self.train_sampler = DistributedSampler(
             self.train_dataset, shuffle=True, num_replicas=world_size, rank=rank, drop_last=True
         )
@@ -178,6 +181,7 @@ class FSDPSFTTrainer:
             num_workers=8,
             pin_memory=True,
             drop_last=True,
+            pin_memory_device=device_name,
         )
 
         self.val_sampler = DistributedSampler(
@@ -190,6 +194,7 @@ class FSDPSFTTrainer:
             num_workers=8,
             pin_memory=True,
             drop_last=True,
+            pin_memory_device=device_name,
         )
 
     def _build_model_optimizer(self):


### PR DESCRIPTION
### What does this PR do?

To use pin_cemory, we need to set pin_memory_name="npu".

About pin_memory, see: [torchdata/stateful_dataloader/stateful_dataloader.py](https://github.com/pytorch/data/blob/main/torchdata/stateful_dataloader/stateful_dataloader.py)

```
if self._pin_memory:
    self._pin_memory_thread_done_event = threading.Event()

    # Queue is not type-annotated
    self._data_queue = queue.Queue()  # type: ignore[var-annotated]
    if self._pin_memory_device == "xpu":
        current_device = torch.xpu.current_device()  # type: ignore[attr-defined]
    elif self._pin_memory_device == torch._C._get_privateuse1_backend_name():
        custom_device_mod = getattr(torch, torch._C._get_privateuse1_backend_name())
        current_device = custom_device_mod.current_device()
    else:
        current_device = torch.cuda.current_device()  # choose cuda for default
    pin_memory_thread = threading.Thread(
        target=_utils.pin_memory._pin_memory_loop,
        args=(
            self._worker_result_queue,
            self._data_queue,
            current_device,
            self._pin_memory_thread_done_event,
            self._pin_memory_device,
        ),
    )
    pin_memory_thread.daemon = True
    pin_memory_thread.start()
    # Similar to workers (see comment above), we only register
    # pin_memory_thread once it is started.
    self._pin_memory_thread = pin_memory_thread
else:
    self._data_queue = self._worker_result_queue  # type: ignore[assignment]

```

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
