### PR TITLE
[ci] fix: fix fsdp test in transformers 4.54.1

### DIFF
--- a/tests/special_distributed/test_fsdp_ckpt.py
+++ b/tests/special_distributed/test_fsdp_ckpt.py
@@ -26,7 +26,20 @@ from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.utils.distributed import initialize_global_process_group
 from verl.utils.fsdp_utils import MixedPrecisionPolicy, apply_fsdp2
 
-FIX_TRANSFORMERS_4_54_0 = False
+
+def create_random_input_ids(batch_size, seq_len, vocab_size):
+    from verl.utils.model import create_random_mask, compute_position_id_with_mask
+    from flash_attn.bert_padding import unpad_input
+
+    input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
+
+    attention_mask = create_random_mask(input_ids, max_ratio_of_left_padding=0.1, min_ratio_of_valid_token=0.5, max_ratio_of_valid_token=0.7)
+    position_ids = compute_position_id_with_mask(attention_mask)
+
+    input_ids = unpad_input(input_ids.unsqueeze(-1), attention_mask)[0].transpose(0, 1)
+    position_ids = unpad_input(position_ids.unsqueeze(-1), attention_mask)[0].transpose(0, 1)
+    return input_ids, position_ids
+
 
 
 def test_fsdp_ckpt(strategy="fsdp"):
@@ -77,19 +90,17 @@ def test_fsdp_ckpt(strategy="fsdp"):
     )
 
     # Generate sample input
-    batch_size = 2
-    seq_len = 32
-    vocab_size = 32000
+    batch_size = 10
+    seq_len = 1024
+    vocab_size = config.vocab_size
     # First input for initial update
-    input_ids1 = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
-    attention_mask1 = torch.ones_like(input_ids1)
+    input_ids1, position_ids1 = create_random_input_ids(batch_size, seq_len, vocab_size)
 
     # Second input for verification
-    input_ids2 = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
-    attention_mask2 = torch.ones_like(input_ids2)
+    input_ids2, position_ids2 = create_random_input_ids(batch_size, seq_len, vocab_size)
 
     # Step 1: Initial update and save checkpoint
-    outputs1 = model(input_ids=input_ids1, attention_mask=attention_mask1)
+    outputs1 = model(input_ids=input_ids1, position_ids=position_ids1)
     loss1 = outputs1.logits.mean()
     loss1.backward()
     optimizer.step()
@@ -103,7 +114,7 @@ def test_fsdp_ckpt(strategy="fsdp"):
     saved_state_dict = model.state_dict()
 
     # Step 2: Second update and forward pass
-    outputs2 = model(input_ids=input_ids2, attention_mask=attention_mask2)
+    outputs2 = model(input_ids=input_ids2, position_ids=position_ids2)
     loss2 = outputs2.logits.mean()
     loss2.backward()
     optimizer.step()
@@ -112,7 +123,7 @@ def test_fsdp_ckpt(strategy="fsdp"):
 
     # Record logits after second update
     with torch.no_grad():
-        logits_before_load = model(input_ids=input_ids2, attention_mask=attention_mask2).logits
+        logits_before_load = model(input_ids=input_ids2, position_ids=position_ids2).logits
 
     # Step 3: Load checkpoint and repeat second update
     checkpoint_manager.load_checkpoint(checkpoint_path)
@@ -122,22 +133,19 @@ def test_fsdp_ckpt(strategy="fsdp"):
         torch.testing.assert_close(loaded_state_dict[key], saved_state_dict[key], atol=0.0, rtol=0.0)
 
     # Repeat the second update with same input
-    # TODO: Fix the issue with transformers 4.54.0
-    #       where the model outputs change after loading the checkpoint.
-    if FIX_TRANSFORMERS_4_54_0:
-        outputs3 = model(input_ids=input_ids2, attention_mask=attention_mask2)
-        loss3 = outputs3.logits.mean()
-        loss3.backward()
-        optimizer.step()
-        lr_scheduler.step()
-        optimizer.zero_grad()
+    outputs3 = model(input_ids=input_ids2, position_ids=position_ids2)
+    loss3 = outputs3.logits.mean()
+    loss3.backward()
+    optimizer.step()
+    lr_scheduler.step()
+    optimizer.zero_grad()
 
-        # Record logits after loaded checkpoint and update
-        with torch.no_grad():
-            logits_after_load = model(input_ids=input_ids2, attention_mask=attention_mask2).logits
+    # Record logits after loaded checkpoint and update
+    with torch.no_grad():
+        logits_after_load = model(input_ids=input_ids2, position_ids=position_ids2).logits
 
-        # Step 4: Verify outputs match
-        torch.testing.assert_close(logits_before_load, logits_after_load, atol=0.0, rtol=0.0)
+    # Step 4: Verify outputs match
+    torch.testing.assert_close(logits_before_load, logits_after_load, atol=0.0, rtol=0.0)
     print("Checkpoint save/load test passed!")
 
     # Cleanup

--- a/tests/special_distributed/test_fsdp_ckpt.py
+++ b/tests/special_distributed/test_fsdp_ckpt.py
@@ -158,4 +158,5 @@ def test_fsdp_ckpt(strategy="fsdp"):
 
 if __name__ == "__main__":
     strategy = os.environ.get("STRATEGY", "fsdp")
+    os.environ["FLASH_ATTENTION_DETERMINISTIC"] = "1"
     test_fsdp_ckpt(strategy=strategy)

--- a/tests/special_distributed/test_fsdp_ckpt.py
+++ b/tests/special_distributed/test_fsdp_ckpt.py
@@ -28,18 +28,20 @@ from verl.utils.fsdp_utils import MixedPrecisionPolicy, apply_fsdp2
 
 
 def create_random_input_ids(batch_size, seq_len, vocab_size):
-    from verl.utils.model import create_random_mask, compute_position_id_with_mask
     from flash_attn.bert_padding import unpad_input
+
+    from verl.utils.model import compute_position_id_with_mask, create_random_mask
 
     input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")
 
-    attention_mask = create_random_mask(input_ids, max_ratio_of_left_padding=0.1, min_ratio_of_valid_token=0.5, max_ratio_of_valid_token=0.7)
+    attention_mask = create_random_mask(
+        input_ids, max_ratio_of_left_padding=0.1, min_ratio_of_valid_token=0.5, max_ratio_of_valid_token=0.7
+    )
     position_ids = compute_position_id_with_mask(attention_mask)
 
     input_ids = unpad_input(input_ids.unsqueeze(-1), attention_mask)[0].transpose(0, 1)
     position_ids = unpad_input(position_ids.unsqueeze(-1), attention_mask)[0].transpose(0, 1)
     return input_ids, position_ids
-
 
 
 def test_fsdp_ckpt(strategy="fsdp"):


### PR DESCRIPTION
### What does this PR do?

When we upgrade to transformers 4.54.1, the fsdp checkpoint manager test breaks, and here are some observations:
- If we switch the "attn_implementation" to "eager" or "sdpa", everything works fine. So, it suggests that the issue lies within the flash_attention_2 backend of transformers.
- Previously, this test passes in input_ids and attention_mask. However, workers in verl passes in input_ids and position_ids to utilize rmpad. After we switch the input to `input_ids` and `position_ids`, all the tests passed.
- If we do not call loss.backward, everything works fine
- So, FSDP works fine, checkpoint manager works fine. The problem must lie in how transformers handles different type of input combinations in flash_attention_2 backend.
- In this PR, we modify the input to pass the test.

TODO: write a test to replicate the issues when passing in input_ids and attention_mask to transformers library

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
