### PR TITLE
Update hf_rollout.py

### DIFF
--- a/verl/workers/rollout/hf_rollout.py
+++ b/verl/workers/rollout/hf_rollout.py
@@ -85,7 +85,10 @@ class HFRollout(BaseRollout):
                 "top_p": top_p,
                 "top_k": top_k,
                 "temperature": temperature,
-                "num_return_sequences": self.config.n,
+                
+                # already repeat in ray_trainer
+                # https://github.com/volcengine/verl/blob/2fdfbdcba6f2e076f64bc47922d8fe6cf7dc7da5/verl/trainer/ppo/ray_trainer.py#L1117
+                "num_return_sequences": 1, 
             }
 
         # make config according to generate mode


### PR DESCRIPTION
For GRPO the number of generation has already been specified at https://github.com/volcengine/verl/blob/2fdfbdcba6f2e076f64bc47922d8fe6cf7dc7da5/verl/trainer/ppo/ray_trainer.py#L1117,
 so the original code in huggingface rollout will generate $n^2$ responses for each prompt.