### PR TITLE
Fix: Initialize _flash_attn_uses_top_left_mask for transformers >= v4.53.0

### DIFF
--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -284,6 +284,10 @@ def ulysses_flash_attn_forward(
     else:
         sliding_window = None
 
+    from transformers.modeling_flash_attention_utils import flash_attn_supports_top_left_mask
+
+    self._flash_attn_uses_top_left_mask = flash_attn_supports_top_left_mask()
+
     attn_output = flash_attention_forward(
         query_states,
         key_states,


### PR DESCRIPTION


### 📝 Pull Request Description


## 🐛 Fix: Initialize `_flash_attn_uses_top_left_mask` for `transformers >= 4.53.0` Compatibility

This PR fixes a runtime `AttributeError` that occurs when using `transformers >= 4.53.0`, where the internal attribute `_flash_attn_uses_top_left_mask` is no longer automatically set in `Qwen2_5_VLAttention`.


### 🧾 Problem

In `transformers` versions prior to `v4.53.0` (e.g., `v4.52.4`), the `Qwen2_5_VLAttention` class automatically initialized the attribute `self._flash_attn_uses_top_left_mask`. However, starting from `v4.53.0`, this attribute is no longer set by default in `Qwen2_5_VLAttention` class, and users are expected to determine mask behavior via the utility function:

```python
from transformers.modeling_flash_attention_utils import flash_attn_supports_top_left_mask
self._flash_attn_uses_top_left_mask = flash_attn_supports_top_left_mask()

```

The original code in `verl` assumed this attribute existed, leading to the following error:

```
AttributeError: 'Qwen2_5_VLAttention' object has no attribute '_flash_attn_uses_top_left_mask'
```

This breaks Flash Attention functionality when using newer versions of `transformers`.

### ✅ Solution

We now explicitly initialize the flag using the provided utility:

```python
from transformers.modeling_flash_attention_utils import flash_attn_supports_top_left_mask
self._flash_attn_uses_top_left_mask = flash_attn_supports_top_left_mask()
```

This ensures compatibility across `transformers` versions, both older and newer.

### 🔍 Affected File

- `verl/models/transformers/qwen2_vl.py` 

### 🧪 Testing

- Verified locally with:
  - `transformers==4.52.4` ✅
  - `transformers==4.53.0` ✅
  - `transformers==4.53.1` ✅
  - `transformers==4.53.2` ✅
  - `transformers==4.53.3` ✅
  - `transformers==4.54.0` ✅
- No functional change in behavior — only restores correctness under newer `transformers` versions.

### 📚 Reference

- Hugging Face Transformers Changelog: https://github.com/huggingface/transformers/releases
- Flash Attention Utility: https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_flash_attention_utils.py

### 🎯 Impact

Enables `verl` to work seamlessly with modern versions of `transformers`, improving maintainability and reducing version lock-in.

---
> ✅ **Note**: This is a minimal, non-breaking fix that aligns with upstream changes in `transformers`. Ready for review!
