### PR TITLE
[fsdp, trainer] fix: save config parameters to wandb in SFT

### DIFF
--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -30,7 +30,7 @@ from contextlib import nullcontext
 import hydra
 import torch
 import torch.distributed
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from peft import LoraConfig, TaskType, get_peft_model
 from tensordict import TensorDict
 from torch import nn, optim
@@ -684,8 +684,6 @@ class FSDPSFTTrainer:
 
         # TODO: add a unified tracking
         if rank == 0:
-            from omegaconf import OmegaConf
-            
             tracking = Tracking(
                 project_name=self.config.trainer.project_name,
                 experiment_name=self.config.trainer.experiment_name,

--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -684,10 +684,13 @@ class FSDPSFTTrainer:
 
         # TODO: add a unified tracking
         if rank == 0:
+            from omegaconf import OmegaConf
+            
             tracking = Tracking(
                 project_name=self.config.trainer.project_name,
                 experiment_name=self.config.trainer.experiment_name,
                 default_backend=self.config.trainer.logger,
+                config=OmegaConf.to_container(self.config, resolve=True),
             )
 
         global_step = self.resume_global_step  # Start from resumed step


### PR DESCRIPTION
### What does this PR do?

This PR adds support for logging Config parameters to Weights & Biases (wandb) when running SFT training via fsdp_sft_trainer.py.

Previously, wandb overview panel did not include configuration details, making it harder to trace experiment setups, as shown below:
<img width="927" height="210" alt="image" src="https://github.com/user-attachments/assets/06a9b570-8f3f-451e-b484-0ccf3c307dba" />
This PR ensures that all relevant config parameters are recorded, improving reproducibility and experiment tracking:
<img width="906" height="383" alt="image" src="https://github.com/user-attachments/assets/99f228ce-3596-4e5b-973e-0f8b910edf2b" />

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

torchrun --nnodes=1 --nproc_per_node=8 \
            -m verl.trainer.fsdp_sft_trainer \
            data.train_files=/root/data/gsm8k/train.parquet \
            data.val_files=/root/data/gsm8k/test.parquet \
            data.train_batch_size=1024 \
            data.prompt_key=extra_info \
            data.response_key=extra_info \
            data.prompt_dict_keys=['question'] \
            data.response_dict_keys=['answer'] \
            data.micro_batch_size_per_gpu=4 \
            model.partial_pretrain=Qwen/Qwen2.5-7B-Instruct\
            optim.lr=1e-5 \
            optim.betas='[0.9,0.95]' \
            optim.weight_decay=0.01 \
            optim.warmup_steps_ratio=0.05 \
            optim.clip_grad=1.0 \
            optim.lr_scheduler=cosine \
            trainer.default_local_dir=/workspace/verl/checkpoints/sft/gsm8k/qwen-7b\
            trainer.project_name=gsm8k-sft \
            trainer.experiment_name=gsm8k-sft-qwen-7b \
            trainer.total_epochs=4 \
            trainer.logger='["wandb"]'
<img width="906" height="383" alt="image" src="https://github.com/user-attachments/assets/99f228ce-3596-4e5b-973e-0f8b910edf2b" />

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [N/A] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Logging-only change, no functional impact
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
