### PR TITLE
[ray] feat: support directly register dispatch device mesh

### DIFF
--- a/tests/single_controller/test_device_mesh_register.py
+++ b/tests/single_controller/test_device_mesh_register.py
@@ -1,0 +1,96 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from verl import DataProto
+from verl.single_controller.base import Worker
+from verl.single_controller.base.decorator import register, make_nd_compute_dataproto_dispatch_fn
+import ray
+
+import torch
+
+@ray.remote
+class TestActor(Worker):
+    def __init__(self):
+        super().__init__()
+
+        import torch.distributed
+
+        torch.distributed.init_process_group(backend="nccl")
+        self.infer_device_mesh = torch.distributed.device_mesh.init_device_mesh(
+            device_type="cuda", mesh_shape=[2, 4], mesh_dim_names=["dp", "tp"]
+        )
+        self.train_device_mesh = torch.distributed.device_mesh.init_device_mesh(
+            device_type="cuda", mesh_shape=[2, 2, 2], mesh_dim_names=["pp", "dp", "tp"]
+        )
+
+        self._register_dispatch_collect_info('infer', 
+                                             dp_rank=self.infer_device_mesh["dp"].get_local_rank(),
+                                             is_collect=self.infer_device_mesh["tp"].get_local_rank() == 0)
+        self._register_dispatch_collect_info('train', 
+                                             dp_rank=self.train_device_mesh["dp"].get_local_rank(),
+                                             is_collect=self.train_device_mesh["tp"].get_local_rank() == 0 and self.train_device_mesh["pp"].get_local_rank() == 1)
+
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="infer"))
+    def generate_data_proto(self, data: DataProto):
+        tp_rank = self.infer_device_mesh["tp"].get_local_rank()
+        dp_rank = self.infer_device_mesh["dp"].get_local_rank()
+        data.batch["a"] += (tp_rank + 1) * dp_rank
+        return data
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="train"))
+    def train_data_proto(self, data: DataProto):
+        tp_rank = self.train_device_mesh["tp"].get_local_rank()
+        dp_rank = self.train_device_mesh["dp"].get_local_rank()
+        pp_rank = self.train_device_mesh["pp"].get_local_rank()
+        data.batch["a"] += (tp_rank + 1) * (dp_rank + 2) * (pp_rank + 3)
+        # tp rank 0, pp rank 1, dp rank 0, output data added: 8 + 3 = 11
+        # tp rank 0, pp rank 1, dp rank 1, output data added: 12 + 4 = 16
+        return data
+
+
+def test_dist_global_info_wg():
+    # create a worker group with size 8
+    # register a infer dist info with tp=4, dp=2
+    # register a train dist info with tp=2, dp=2, pp=2
+    # test the correctness of data dispatch and computation
+    from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
+
+    ray.init()
+
+    ray_cls = RayClassWithInitArgs(TestActor)
+    resource_pool = RayResourcePool(process_on_nodes=[8])
+    wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls)
+
+    infer_input_data_proto = DataProto.from_single_dict(data={"a": torch.tensor([1, 2])})
+    infer_output_data_proto = wg.generate_data_proto(infer_input_data_proto)
+
+    assert wg._dispatch_info['infer'] == [0, 0, 0, 0, 1, 1, 1, 1]
+
+    assert torch.all(torch.eq(infer_output_data_proto.batch["a"], torch.tensor([1, 3])))
+
+    train_input_data_proto = DataProto.from_single_dict(data={"a": torch.tensor([3, 4])})
+    train_output_data_proto = wg.train_data_proto(train_input_data_proto)
+
+    assert wg._dispatch_info['train'] == [0, 0, 1, 1, 0, 0, 1, 1]
+
+
+    assert torch.all(torch.eq(train_output_data_proto.batch["a"], torch.tensor([11, 16])))
+
+    ray.shutdown()
+
+
+if __name__ == '__main__':
+    test_dist_global_info_wg()

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -405,7 +405,7 @@ def dispatch_nd_compute(dp_rank_mapping: list[int], dp_size, worker_group, *args
     return all_args, all_kwargs
 
 
-def collect_nd_compute(dp_rank_mapping: list[int], worker_group, output):
+def collect_nd_compute(collect_mask: list[bool], worker_group, output):
     from verl.single_controller.base.worker_group import WorkerGroup
 
     assert isinstance(worker_group, WorkerGroup)

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -413,7 +413,7 @@ def collect_nd_compute(collect_mask: list[bool], worker_group, output):
 
     output_in_dp = []
     for global_rank in range(worker_group.world_size):
-        collect_dp_rank = dp_rank_mapping[global_rank]
+        collect_dp_rank = collect_mask[global_rank]
         if collect_dp_rank:
             output_in_dp.append(output[global_rank])
     return output_in_dp
@@ -425,7 +425,7 @@ def dispatch_nd_compute_dataproto(dp_rank_mapping: list[int], dp_size, worker_gr
 
 
 def collect_nd_compute_dataproto(collect_mask: list[bool], worker_group, output):
-    output = collect_nd_compute(dp_rank_mapping, worker_group, output)
+    output = collect_nd_compute(collect_mask, worker_group, output)
     import ray
 
     from verl.protocol import DataProto
@@ -464,9 +464,9 @@ def collect_lazy_compute_data_proto(mesh_name, worker_group, *args, **kwargs):
         assert len(worker_group._collect_info[mesh_name]) == worker_group.world_size
 
     # a boolean of whether the dp_rank is used for collect
-    dp_rank_mapping = worker_group._collect_info[mesh_name]
+    collect_mask = worker_group._collect_info[mesh_name]
     # perform dispatch
-    return collect_nd_compute_dataproto(dp_rank_mapping, worker_group, *args, **kwargs)
+    return collect_nd_compute_dataproto(collect_mask, worker_group, *args, **kwargs)
 
 
 def make_nd_compute_dataproto_dispatch_fn(mesh_name):

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -16,6 +16,8 @@ import inspect
 from functools import wraps
 from types import FunctionType
 
+from functools import partial
+
 from verl.protocol import DataProtoFuture, _padding_size_key
 from verl.utils.py_functional import DynamicEnum
 
@@ -372,6 +374,110 @@ def collect_dp_compute_data_proto(worker_group, output):
 
     output = collect_dp_compute(worker_group, output)
     return _concat_data_proto_or_future(output)
+
+
+
+
+def dispatch_nd_compute(dp_rank_mapping: list[int], dp_size, worker_group, *args, **kwargs):
+    from verl.single_controller.base.worker_group import WorkerGroup
+    import ray
+
+    assert isinstance(worker_group, WorkerGroup)
+
+    args = [[ray.put(dp_arg) for dp_arg in arg] for arg in args]
+    kwargs = {k: [ray.put(dp_v) for dp_v in v] for k, v in kwargs.items()}
+
+    all_args = []
+    for arg in args:
+        assert isinstance(arg, (tuple, list)) and len(arg) == dp_size
+        transformed_args = []
+        for i in range(worker_group.world_size):
+            local_dp_rank = dp_rank_mapping[i]
+            transformed_args.append(arg[local_dp_rank])
+        all_args.append(transformed_args)
+    all_args = tuple(all_args)
+
+    all_kwargs = {}
+    for k, v in kwargs.items():
+        assert isinstance(v, (tuple, list)) and len(v) == dp_size
+        transformed_v = []
+        for i in range(worker_group.world_size):
+            local_dp_rank = dp_rank_mapping[i]
+            transformed_v.append(v[local_dp_rank])
+        all_kwargs[k] = transformed_v
+    return all_args, all_kwargs
+
+
+
+def collect_nd_compute(dp_rank_mapping: list[int], worker_group, output):
+    from verl.single_controller.base.worker_group import WorkerGroup
+    assert isinstance(worker_group, WorkerGroup)
+    assert len(output) == worker_group.world_size
+
+    output_in_dp = []
+    for global_rank in range(worker_group.world_size):
+        collect_dp_rank = dp_rank_mapping[global_rank]
+        if collect_dp_rank:
+            output_in_dp.append(output[global_rank])
+    return output_in_dp
+
+
+
+def dispatch_nd_compute_dataproto(dp_rank_mapping: list[int], dp_size, worker_group, *args, **kwargs):
+    splitted_args, splitted_kwargs = _split_args_kwargs_data_proto(dp_size, *args, **kwargs)
+    return dispatch_nd_compute(dp_rank_mapping, dp_size, worker_group, *splitted_args, **splitted_kwargs)
+
+
+def collect_nd_compute_dataproto(dp_rank_mapping: list[int], worker_group, output):
+    output = collect_nd_compute(dp_rank_mapping, worker_group, output)
+    import ray
+
+    from verl.protocol import DataProto
+    for o in output:
+        assert isinstance(o, (DataProto, ray.ObjectRef)), f"expecting {o} to be DataProto, but got {type(o)}"
+    return _concat_data_proto_or_future(output)
+
+
+def dispatch_lazy_compute_data_proto(mesh_name, worker_group, *args, **kwargs):
+    from verl.single_controller.base.worker_group import WorkerGroup
+
+    assert isinstance(worker_group, WorkerGroup)
+
+    # query dispatch info of the worker group
+    if mesh_name not in worker_group._dispatch_info:
+        worker_group._dispatch_info[mesh_name] = worker_group._query_dispatch_info(mesh_name)
+        assert len(worker_group._dispatch_info[mesh_name]) == worker_group.world_size
+
+    dp_rank_mapping = worker_group._dispatch_info[mesh_name]
+    # perform dispatch
+    dp_size = max(dp_rank_mapping) + 1
+    return dispatch_nd_compute_dataproto(dp_rank_mapping, dp_size, worker_group, *args, **kwargs)
+
+
+def collect_lazy_compute_data_proto(mesh_name, worker_group, *args, **kwargs):
+    from verl.single_controller.base.worker_group import WorkerGroup
+
+    assert isinstance(worker_group, WorkerGroup)
+
+    # the dispatch info is stored in the worker group
+    assert mesh_name in worker_group._dispatch_info
+
+
+    if mesh_name not in worker_group._collect_info:
+        worker_group._collect_info[mesh_name] = worker_group._query_collect_info(mesh_name)
+        assert len(worker_group._collect_info[mesh_name]) == worker_group.world_size
+
+    # a boolean of whether the dp_rank is used for collect
+    dp_rank_mapping = worker_group._collect_info[mesh_name]
+    # perform dispatch
+    return collect_nd_compute_dataproto(dp_rank_mapping, worker_group, *args, **kwargs)
+
+
+def make_nd_compute_dataproto_dispatch_fn(mesh_name):
+    return {
+        "dispatch_fn": partial(dispatch_lazy_compute_data_proto, mesh_name),
+        "collect_fn": partial(collect_lazy_compute_data_proto, mesh_name),
+    }
 
 
 # Global registry for dispatch mode.

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -424,7 +424,7 @@ def dispatch_nd_compute_dataproto(dp_rank_mapping: list[int], dp_size, worker_gr
     return dispatch_nd_compute(dp_rank_mapping, dp_size, worker_group, *splitted_args, **splitted_kwargs)
 
 
-def collect_nd_compute_dataproto(dp_rank_mapping: list[int], worker_group, output):
+def collect_nd_compute_dataproto(collect_mask: list[bool], worker_group, output):
     output = collect_nd_compute(dp_rank_mapping, worker_group, output)
     import ray
 

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -90,7 +90,7 @@ class Worker(WorkerHelper):
             instance._configure_before_init(f"{worker_group_prefix}_register_center", int(rank))
 
         return instance
-    
+
     def _register_dispatch_collect_info(self, mesh_name: str, dp_rank: int, is_collect: bool):
         """Register the dp_rank for a given mesh name. This function is meant to be called by the worker
 
@@ -104,7 +104,7 @@ class Worker(WorkerHelper):
         """
         self.__dispatch_dp_rank[mesh_name] = dp_rank
         self.__collect_dp_rank[mesh_name] = is_collect
-    
+
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def _query_dispatch_info(self, mesh_name: str):
         """Query the dispatch info for a given mesh name.
@@ -135,7 +135,6 @@ class Worker(WorkerHelper):
         """
         assert mesh_name in self.__collect_dp_rank
         return self.__collect_dp_rank[mesh_name]
-    
 
     def _configure_before_init(self, register_center_name: str, rank: int):
         """Configure worker settings before initialization.

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -70,6 +70,8 @@ class Worker(WorkerHelper):
     """
 
     fused_worker_attr_name = "fused_worker_dict"
+    __dispatch_dp_rank = {}
+    __collect_dp_rank = {}
 
     def __new__(cls, *args, **kwargs):
         """Create a new Worker instance with proper initialization based on environment settings."""
@@ -88,6 +90,52 @@ class Worker(WorkerHelper):
             instance._configure_before_init(f"{worker_group_prefix}_register_center", int(rank))
 
         return instance
+    
+    def _register_dispatch_collect_info(self, mesh_name: str, dp_rank: int, is_collect: bool):
+        """Register the dp_rank for a given mesh name. This function is meant to be called by the worker
+
+        Args:
+            mesh_name (str):
+                Name of the mesh to register dp_rank for.
+            dp_rank (int):
+                dp_rank to register for the given mesh name.
+            is_collect (bool):
+                Whether the dp_rank is used for collect.
+        """
+        self.__dispatch_dp_rank[mesh_name] = dp_rank
+        self.__collect_dp_rank[mesh_name] = is_collect
+    
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def _query_dispatch_info(self, mesh_name: str):
+        """Query the dispatch info for a given mesh name.
+
+        Args:
+            mesh_name (str):
+                Name of the mesh to query dispatch info for.
+
+        Returns:
+            dict:
+                A dictionary containing the dispatch info for the given mesh name.
+        """
+        assert mesh_name in self.__dispatch_dp_rank
+        # note that each rank store its own dp_rank
+        return self.__dispatch_dp_rank[mesh_name]
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def _query_collect_info(self, mesh_name: str):
+        """Query the collect info for a given mesh name.
+
+        Args:
+            mesh_name (str):
+                Name of the mesh to query collect info for.
+
+        Returns:
+            bool:
+                Whether the dp_rank is used for collect.
+        """
+        assert mesh_name in self.__collect_dp_rank
+        return self.__collect_dp_rank[mesh_name]
+    
 
     def _configure_before_init(self, register_center_name: str, rank: int):
         """Configure worker settings before initialization.

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -114,8 +114,8 @@ class Worker(WorkerHelper):
                 Name of the mesh to query dispatch info for.
 
         Returns:
-            dict:
-                A dictionary containing the dispatch info for the given mesh name.
+            int:
+                The dp_rank for the given mesh name.
         """
         assert mesh_name in self.__dispatch_dp_rank
         # note that each rank store its own dp_rank

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -142,6 +142,9 @@ class WorkerGroup:
         self._workers = []
         self._worker_names = []
 
+        self._dispatch_info = {}
+        self._collect_info = {}
+
         self._master_addr = None
         self._master_port = None
 


### PR DESCRIPTION
### What does this PR do?

A better solution than https://github.com/volcengine/verl/pull/1260

The current dispatch methods are quite limited:

In hybrid engine, we would like to dispatch infer_tp x infer_dp for generation and train_tp x train_dp x train_pp for training. However, currently implementation can only dispatch train_tp x train_dp x train_pp for training and dp for generation and perform allgather inside the workergroup.
When two megatron models colocate, their device mesh has to be identical.
We have to subclass RayWorkerGroup in order to implement various distributed strategies. This makes create_colocated_worker hacky to implement in the future.

The difference in this implementation:
- We register directly inside the worker of the dp_rank and whether the output of this rank will be collected.
- By doing so, we can 1) completely remote MegatronWorker and the necessity to subclass RayWorkerGroup in the future to implement flexible dispatch methods. 2) remove all other dispatch/collect methods

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
