### PR TITLE
[rollout,vllm] fix: max_num_seqs not take effect

### DIFF
--- a/tests/workers/rollout/rollout_vllm/test_vllm_model_rope_scaling.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_model_rope_scaling.py
@@ -44,6 +44,7 @@ def test_vllm_rollout_with_yarn_position_embeddings():
             "free_cache_engine": False,
             "disable_log_stats": True,
             "max_model_len": 35000 + 512,
+            "max_num_seqs": 1024,
             "load_format": "auto",
             "val_kwargs": {
                 "top_k": -1,

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -253,6 +253,7 @@ class AsyncvLLMServer(AsyncServerBase):
             disable_custom_all_reduce=True,
             skip_tokenizer_init=False,
             max_model_len=self.max_model_len,
+            max_num_seqs=config.max_num_seqs,
             load_format="auto",
             disable_log_stats=config.disable_log_stats,
             max_num_batched_tokens=max_num_batched_tokens,

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -174,6 +174,7 @@ class vLLMRollout(BaseRollout):
             disable_custom_all_reduce=True,
             skip_tokenizer_init=False,
             max_model_len=max_model_len,
+            max_num_seqs=config.max_num_seqs,
             load_format=load_format,
             disable_log_stats=config.disable_log_stats,
             max_num_batched_tokens=max_num_batched_tokens,


### PR DESCRIPTION
### What does this PR do?

`max_num_seqs` not take effect, vllm's default value 256 sometimes is too small.
