### PR TITLE
[misc] fix: fix DataProto __getstate__ bug

### DIFF
--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -332,11 +332,10 @@ class DataProto:
 
         buffer = io.BytesIO()
         if version.parse(tensordict.__version__) >= version.parse("0.5.0") and self.batch is not None:
-            batch = self.batch.contiguous()
-            batch_consolidated = batch.consolidate()
+            batch_to_save = self.batch.contiguous().consolidate()
         else:
-            batch_consolidated = self.batch
-        torch.save(batch_consolidated, buffer)
+            batch_to_save = self.batch
+        torch.save(batch_to_save, buffer)
         buffer_bytes = buffer.getvalue()
         return buffer_bytes, self.non_tensor_batch, self.meta_info
 

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -333,8 +333,8 @@ class DataProto:
         buffer = io.BytesIO()
         if version.parse(tensordict.__version__) >= version.parse("0.5.0") and self.batch is not None:
             self.batch = self.batch.contiguous()
-            self.batch = self.batch.consolidate()
-        torch.save(self.batch, buffer)
+            batch_consolidated = self.batch.consolidate()
+        torch.save(batch_consolidated, buffer)
         buffer_bytes = buffer.getvalue()
         return buffer_bytes, self.non_tensor_batch, self.meta_info
 

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -335,7 +335,7 @@ class DataProto:
             batch = self.batch.contiguous()
             batch_consolidated = batch.consolidate()
         else:
-            batch_consolidated = None
+            batch_consolidated = self.batch
         torch.save(batch_consolidated, buffer)
         buffer_bytes = buffer.getvalue()
         return buffer_bytes, self.non_tensor_batch, self.meta_info

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -332,8 +332,10 @@ class DataProto:
 
         buffer = io.BytesIO()
         if version.parse(tensordict.__version__) >= version.parse("0.5.0") and self.batch is not None:
-            self.batch = self.batch.contiguous()
-            batch_consolidated = self.batch.consolidate()
+            batch = self.batch.contiguous()
+            batch_consolidated = batch.consolidate()
+        else:
+            batch_consolidated = None
         torch.save(batch_consolidated, buffer)
         buffer_bytes = buffer.getvalue()
         return buffer_bytes, self.non_tensor_batch, self.meta_info


### PR DESCRIPTION
### What does this PR do?

- Fix a severe bug in DataProto that cause modification to be incorrect
- We should not use consolidated tensordict to perform any operation other than save and data transfer

```python
import torch
from tensordict import TensorDict

a = TensorDict({"a": torch.zeros(1, 1)}, device='cuda', batch_size=[1])
a_consolidate = a.consolidate()
a['b'] = torch.ones(1, 1)
a = a.to('cpu')

a_consolidate['b'] = torch.ones(1, 1)
a_consolidate = a_consolidate.to('cpu')

print(a['a'], a['b'])  # 0, 1
print(a_consolidate['a'], a_consolidate['b'])  # 0, 0
```

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
