### PR TITLE
[sglang] fix: Fix No command 'hf' found for dapo multi-turn as alternative baseline 

### DIFF
--- a/examples/sglang_multiturn/run_qwen2_3b_dapo_multiturn.sh
+++ b/examples/sglang_multiturn/run_qwen2_3b_dapo_multiturn.sh
@@ -5,6 +5,8 @@ ulimit -n 65535
 PROJECT_DIR="$(pwd)"
 CONFIG_PATH="$PROJECT_DIR/examples/sglang_multiturn/config"
 
+alias hf="huggingface-cli"
+
 hf download \
     BytedTsinghua-SIA/DAPO-Math-17k \
     --repo-type dataset \

--- a/examples/sglang_multiturn/run_qwen2_3b_dapo_multiturn.sh
+++ b/examples/sglang_multiturn/run_qwen2_3b_dapo_multiturn.sh
@@ -5,8 +5,7 @@ ulimit -n 65535
 PROJECT_DIR="$(pwd)"
 CONFIG_PATH="$PROJECT_DIR/examples/sglang_multiturn/config"
 
-alias hf="huggingface-cli"
-
+pip install --upgrade "huggingface-hub>=0.34.0"
 hf download \
     BytedTsinghua-SIA/DAPO-Math-17k \
     --repo-type dataset \


### PR DESCRIPTION
### What does this PR do?

> Fix No command 'hf' found for dapo multi-turn as alternative baseline 


> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
