### PR TITLE
[megatron,trainer]feat: simplify optim config

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -219,16 +219,18 @@ def convert_config(hf_config: PretrainedConfig, megatron_config) -> TransformerC
 
 
 def init_megatron_optim_config(optim_config: dict) -> OptimizerConfig:
+    # We enable some optimization configurations by default. For all other Megatron configurations,
+    # please check the official Megatron documentation.
+    # https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/optimizer/optimizer_config.py
     config = OptimizerConfig(
-        optimizer=optim_config.get("optimizer", "adam"),
-        lr=optim_config.get("lr"),
-        min_lr=optim_config.get("min_lr", None),
-        clip_grad=optim_config.get("clip_grad", 1.0),
-        weight_decay=optim_config.get("weight_decay", 0.01),
         bf16=True,
         params_dtype=torch.bfloat16,
         use_distributed_optimizer=True,
     )
+    for name, value in optim_config.items():
+        if hasattr(config, name):
+            setattr(config, name, value)
+
     return config
 
 

--- a/verl/workers/config/optimizer.py
+++ b/verl/workers/config/optimizer.py
@@ -66,29 +66,31 @@ class FSDPOptimizerConfig(OptimizerConfig):
 
 @dataclass
 class McoreOptimizerConfig(OptimizerConfig):
-    """Mcore optimizer configuration extending base OptimizerConfig.
+    """Mcore optimizer and Mcore lr-schedular configuration extending base OptimizerConfig.
+
+    Note: optimizer and lr-scheduler share some common arguments, for example: lr/min_lr. We hide all the
+    arguments which are used by optimizer. If users want to know the definition or default value of these
+    arguments, they should check megatron official documents:
+    https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/optimizer/optimizer_config.py
 
     Args:
-        optimizer (str): Optimizer name; default is "adam".
-        lr (float): Learning rate.
-        clip_grad (float): Gradient clipping norm.
         lr_warmup_init (float): Initial learning rate for warmup; defaults to 0.0.
         lr_decay_steps (Optional[int]): Number of decay steps.
         lr_decay_style (str): LR decay style: "constant", "linear", "cosine", or "inverse_square_root".
-        min_lr (float): Minimum learning rate.
         weight_decay_incr_style (str): Weight decay increment style: "constant" or "cosine".
         lr_wsd_decay_style (str): Weight-standard-deviation decay style: "constant", "exponential", or "cosine".
         lr_wsd_decay_steps (Optional[int]): Number of steps for weight-standard-deviation decay.
         use_checkpoint_opt_param_scheduler (bool): Whether to use checkpoint optimizer parameter scheduler.
     """
 
-    optimizer: str = "adam"
-    clip_grad: float = 1.0
     lr_warmup_init: float = 0.0
     lr_decay_steps: Optional[int] = None
     lr_decay_style: str = "linear"
-    min_lr: float = 0.0
     weight_decay_incr_style: str = "constant"
     lr_wsd_decay_style: str = "exponential"
     lr_wsd_decay_steps: Optional[int] = None
     use_checkpoint_opt_param_scheduler: bool = False
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)


### PR DESCRIPTION
### What does this PR do?

We should not add megatron/vllm/sglang's default values in verl config. It will confuse users because they don't know whether it's verl's special optimization or other framework's default value. The config system only supports limited configs to pass in megatron optimizer, which hinders extensibility.

After this PR, users can define megatron optimization config like this

```bash
    # for backward compatibility, these args can be used as before
    actor_rollout_ref.actor.optim.lr=1e-6 \
    actor_rollout_ref.actor.optim.clip_grad=1.0 \
    actor_rollout_ref.actor.optim.lr_warmup_steps=10 \
    actor_rollout_ref.actor.optim.weight_decay=0.1 \
    # all the other arguments can be passed in like this, even non-existent arguments
    +actor_rollout_ref.actor.optim.debugdebug=123 \
    +actor_rollout_ref.actor.optim.overlap_cpu_optimizer_d2h_h2d=True \
    +actor_rollout_ref.actor.optim.use_precision_aware_optimizer=True \
    +actor_rollout_ref.actor.optim.optimizer_cpu_offload=True \
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
