### PR TITLE
[rollout,trainer] feat: offload param before wake up inference engine

### DIFF
--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -205,6 +205,9 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             else:
                 params = self.module.state_dict()
             params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
+
+            if self.offload_param:
+                offload_fsdp_model_to_cpu(self.module)
             log_gpu_memory_usage("After state_dict() in sharding manager memory", logger=logger)
 
             if self.rollout_config.free_cache_engine:
@@ -217,8 +220,6 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             self.update_params(params, peft_config=peft_config)
             log_gpu_memory_usage("After sync model weights in sharding manager", logger=logger)
             del params
-            if self.offload_param:
-                offload_fsdp_model_to_cpu(self.module)
             get_torch_device().empty_cache()
 
             if (


### PR DESCRIPTION
### What does this PR do?

Move the parameter offloading step before waking up the inference engine to reduce GPU memory cap.

Changed vllm and sglang with fsdp. 
Leaving megatron unchanged because it may result illegal access with similar change.

<img width="3198" height="1530" alt="whiteboard_exported_image (4)" src="https://github.com/user-attachments/assets/ec77c41f-2027-43f1-8540-3d4d7182d592" />


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

With this change, the max GPU memory is reduced from logs.

sglang 

Now:
(WorkerDict pid=12436) [2025-08-08 07:16:19] Before state_dict() in sharding manager memory, memory allocated (GB): 0.02, memory reserved (GB): 0.87, device memory used/total (GB): 5.50/79.15
(WorkerDict pid=12436) [2025-08-08 07:16:19] After state_dict() in sharding manager memory, memory allocated (GB): 1.57, memory reserved (GB): 3.44, device memory used/total (GB): 8.07/79.15
(WorkerDict pid=12436) [2025-08-08 07:16:19] After offload_param in sharding manager memory, memory allocated (GB): 0.85, memory reserved (GB): 2.52, device memory used/total (GB): **7.14/79.15** <---
(WorkerDict pid=12436) [2025-08-08 07:16:19] Before resume SGLang weights + kv_cache in sharding manager, memory allocated (GB): 0.85, memory reserved (GB): 2.52, device memory used/total (GB): **53.72/79.15**. <--


Before
(WorkerDict pid=31787) [2025-08-08 07:31:42] Before state_dict() in sharding manager memory, memory allocated (GB): 0.02, memory reserved (GB): 0.87, device memory used/total (GB): 52.06/79.15
(WorkerDict pid=31787) [2025-08-08 07:31:42] After state_dict() in sharding manager memory, memory allocated (GB): 1.57, memory reserved (GB): 3.44, device memory used/total (GB): **54.63/79.15**. <---
(WorkerDict pid=31787) [2025-08-08 07:31:43] After sync model weights in sharding manager, memory allocated (GB): 2.44, memory reserved (GB): 3.44, device memory used/total (GB): 54.61/79.15


vllm

Now

(WorkerDict pid=87197) DEBUG:2025-08-07 11:37:15,191:Before state_dict() in sharding manager memory, memory allocated (GB): 45.21, memory reserved (GB): 45.33, device memory used/total (GB): 2.74/79.15
(WorkerDict pid=87197) DEBUG:2025-08-07 11:37:15,472:After state_dict() in sharding manager memory, memory allocated (GB): 46.06, memory reserved (GB): 47.72, device memory used/total (GB): 5.14/79.15
(WorkerDict pid=87197) DEBUG:2025-08-07 11:37:15,637:After sync model weights in sharding manager, memory allocated (GB): 46.06, memory reserved (GB): 47.72, device memory used/total (GB): **5.92/79.15** <--
(WorkerDict pid=87197) DEBUG:2025-08-07 11:37:15,791:After del state_dict and empty_cache in sharding manager, memory allocated (GB): 45.21, memory reserved (GB): 45.33, device memory used/total (GB): 47.94/79.15


Before
(WorkerDict pid=104544) DEBUG:2025-08-07 11:41:46,431:Before state_dict() in sharding manager memory, memory allocated (GB): 45.21, memory reserved (GB): 45.33, device memory used/total (GB): 2.74/79.15
(WorkerDict pid=104544) DEBUG:2025-08-07 11:41:46,628:After state_dict() in sharding manager memory, memory allocated (GB): 46.78, memory reserved (GB): 48.76, device memory used/total (GB): **6.17/79.15** <--
(WorkerDict pid=104544) DEBUG:2025-08-07 11:41:46,790:After sync model weights in sharding manager, memory allocated (GB): 46.78, memory reserved (GB): 48.76, device memory used/total (GB): 6.96/79.15
(WorkerDict pid=104544) DEBUG:2025-08-07 11:41:47,073:After del state_dict and empty_cache in sharding manager, memory allocated (GB): 45.21, memory reserved (GB): 45.33, device memory used/total (GB): 47.94/79.15


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
