### PR TITLE
fix: Handle flash_attn_supports_top_left_mask import for older transformers

### DIFF
--- a/verl/models/transformers/kimi_vl.py
+++ b/verl/models/transformers/kimi_vl.py
@@ -17,7 +17,17 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 from transformers.cache_utils import Cache
-from transformers.modeling_flash_attention_utils import _flash_attention_forward, flash_attn_supports_top_left_mask
+from transformers.modeling_flash_attention_utils import _flash_attention_forward
+
+# Handle version compatibility for flash_attn_supports_top_left_mask
+# This function was added in newer versions of transformers
+try:
+    from transformers.modeling_flash_attention_utils import flash_attn_supports_top_left_mask
+except ImportError:
+    # For older versions of transformers that don't have this function
+    # Default to False as a safe fallback for older versions
+    def flash_attn_supports_top_left_mask():
+        return False
 
 from verl.models.transformers.monkey_patch import is_transformers_version_in_range
 from verl.utils.ulysses import (

--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -23,7 +23,17 @@ else:
     pass
 
 from transformers.cache_utils import Cache
-from transformers.modeling_flash_attention_utils import _flash_attention_forward, flash_attn_supports_top_left_mask
+from transformers.modeling_flash_attention_utils import _flash_attention_forward
+
+# Handle version compatibility for flash_attn_supports_top_left_mask
+# This function was added in newer versions of transformers
+try:
+    from transformers.modeling_flash_attention_utils import flash_attn_supports_top_left_mask
+except ImportError:
+    # For older versions of transformers that don't have this function
+    # Default to False as a safe fallback for older versions
+    def flash_attn_supports_top_left_mask():
+        return False
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 from transformers.utils import logging
 

--- a/verl/models/transformers/qwen2.py
+++ b/verl/models/transformers/qwen2.py
@@ -16,7 +16,17 @@ from typing import Callable, Optional
 
 import torch
 from transformers.cache_utils import Cache
-from transformers.modeling_flash_attention_utils import _flash_attention_forward, flash_attn_supports_top_left_mask
+from transformers.modeling_flash_attention_utils import _flash_attention_forward
+
+# Handle version compatibility for flash_attn_supports_top_left_mask
+# This function was added in newer versions of transformers
+try:
+    from transformers.modeling_flash_attention_utils import flash_attn_supports_top_left_mask
+except ImportError:
+    # For older versions of transformers that don't have this function
+    # Default to False as a safe fallback for older versions
+    def flash_attn_supports_top_left_mask():
+        return False
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb, repeat_kv
 from transformers.utils import logging
 

--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -18,7 +18,17 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
-from transformers.modeling_flash_attention_utils import _flash_attention_forward, flash_attn_supports_top_left_mask
+from transformers.modeling_flash_attention_utils import _flash_attention_forward
+
+# Handle version compatibility for flash_attn_supports_top_left_mask
+# This function was added in newer versions of transformers
+try:
+    from transformers.modeling_flash_attention_utils import flash_attn_supports_top_left_mask
+except ImportError:
+    # For older versions of transformers that don't have this function
+    # Default to False as a safe fallback for older versions
+    def flash_attn_supports_top_left_mask():
+        return False
 from transformers.models.qwen2_vl.modeling_qwen2_vl import (
     Qwen2VLCausalLMOutputWithPast,
     Qwen2VLForConditionalGeneration,


### PR DESCRIPTION
## Summary
Fix ImportError when using older transformers versions that don't have `flash_attn_supports_top_left_mask` function.

## Root Cause
The `flash_attn_supports_top_left_mask` function was added in newer versions of transformers. Users with older versions encounter ImportError.

## Solution  
- Add try/except blocks to handle the import gracefully
- Provide a safe fallback (return False) for older versions
- Applied to all affected model files

## Changes
- `verl/models/transformers/qwen2_vl.py`
- `verl/models/transformers/qwen2.py`
- `verl/models/transformers/llama.py`
- `verl/models/transformers/kimi_vl.py`

## Testing
- ✅ Tested import compatibility
- ✅ Verified Python syntax
- ✅ Code follows existing patterns in the codebase

Fixes #2968