### PR TITLE
[fsdp] fix: set _set_allocator_settings to True to avoid fsdp2 oom

### DIFF
--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -86,7 +86,7 @@ def get_nccl_backend() -> str:
         raise RuntimeError(f"No available nccl backend found on device type {get_device_name()}.")
 
 
-def expandable_segments(enable: bool) -> None:
+def set_expandable_segments(enable: bool) -> None:
     """Enable or disable expandable segments for cuda.
     Args:
         enable (bool): Whether to enable expandable segments. Used to avoid OOM.

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -86,10 +86,10 @@ def get_nccl_backend() -> str:
         raise RuntimeError(f"No available nccl backend found on device type {get_device_name()}.")
 
 
-def expandable_segments(enable: bool = True):
+def expandable_segments(enable: bool) -> None:
     """Enable or disable expandable segments for cuda.
     Args:
-        enable (bool): Whether to enable expandable segments. Default: True.
+        enable (bool): Whether to enable expandable segments. Used to avoid OOM.
     """
     if is_cuda_available:
         torch.cuda.memory._set_allocator_settings(f"expandable_segments:{enable}")

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -84,3 +84,12 @@ def get_nccl_backend() -> str:
         return "hccl"
     else:
         raise RuntimeError(f"No available nccl backend found on device type {get_device_name()}.")
+
+
+def expandable_segments(enable: bool = True):
+    """Enable or disable expandable segments for cuda.
+    Args:
+        enable (bool): Whether to enable expandable segments. Default: True.
+    """
+    if is_cuda_available:
+        torch.cuda.memory._set_allocator_settings(f"expandable_segments:{enable}")

--- a/verl/workers/sharding_manager/fsdp_sglang.py
+++ b/verl/workers/sharding_manager/fsdp_sglang.py
@@ -26,7 +26,7 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataP
 
 from verl import DataProto
 from verl.protocol import all_gather_data_proto
-from verl.utils.device import set_expandable_segments, get_device_id, get_torch_device
+from verl.utils.device import get_device_id, get_torch_device, set_expandable_segments
 from verl.utils.fsdp_utils import fsdp_version, load_fsdp_model_to_gpu, offload_fsdp_model_to_cpu
 from verl.utils.model import convert_weight_keys
 from verl.utils.profiler import GPUMemoryLogger, log_gpu_memory_usage, simple_timer

--- a/verl/workers/sharding_manager/fsdp_sglang.py
+++ b/verl/workers/sharding_manager/fsdp_sglang.py
@@ -26,7 +26,7 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataP
 
 from verl import DataProto
 from verl.protocol import all_gather_data_proto
-from verl.utils.device import expandable_segments, get_device_id, get_torch_device
+from verl.utils.device import set_expandable_segments, get_device_id, get_torch_device
 from verl.utils.fsdp_utils import fsdp_version, load_fsdp_model_to_gpu, offload_fsdp_model_to_cpu
 from verl.utils.model import convert_weight_keys
 from verl.utils.profiler import GPUMemoryLogger, log_gpu_memory_usage, simple_timer
@@ -146,7 +146,7 @@ class FSDPSGLangShardingManager(BaseShardingManager):
 
         # sglang need to set _set_allocator_settings to False
         logger.debug("fsdp sglang sharding_manager _set_allocator_settings to False")
-        expandable_segments(False)
+        set_expandable_segments(False)
 
         if self.device_mesh["infer_tp"].get_local_rank() == 0 and self.rollout_config.free_cache_engine:
             if self.multi_stage_wake_up:
@@ -192,7 +192,7 @@ class FSDPSGLangShardingManager(BaseShardingManager):
         # always set _set_allocator_settings to True when using sglang
         # it is required by fsdp2 to avoid oom
         logger.debug("fsdp sglang sharding_manager _set_allocator_settings to True")
-        expandable_segments(True)
+        set_expandable_segments(True)
 
         # restore random states
         if self.device_mesh is not None:

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -34,7 +34,7 @@ from verl import DataProto
 from verl.protocol import all_gather_data_proto
 from verl.third_party.vllm import LLM
 from verl.third_party.vllm import parallel_state as vllm_ps
-from verl.utils.device import set_expandable_segments, get_device_id, get_device_name, get_torch_device
+from verl.utils.device import get_device_id, get_device_name, get_torch_device, set_expandable_segments
 from verl.utils.fsdp_utils import (
     fsdp_version,
     layered_summon_lora_params,

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -18,7 +18,6 @@ import os
 import time
 from collections import OrderedDict
 
-import torch
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp.api import FullStateDictConfig, ShardedStateDictConfig, StateDictType
 from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
@@ -35,7 +34,7 @@ from verl import DataProto
 from verl.protocol import all_gather_data_proto
 from verl.third_party.vllm import LLM
 from verl.third_party.vllm import parallel_state as vllm_ps
-from verl.utils.device import get_device_id, get_device_name, get_torch_device
+from verl.utils.device import expandable_segments, get_device_id, get_device_name, get_torch_device
 from verl.utils.fsdp_utils import (
     fsdp_version,
     layered_summon_lora_params,
@@ -213,7 +212,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
 
             # vllm need to set _set_allocator_settings to False
             logger.debug("fsdp vllm sharding_manager _set_allocator_settings to False")
-            torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+            expandable_segments(False)
 
             if self.rollout_config.free_cache_engine:
                 if "tags" in inspect.signature(self.inference_engine.wake_up).parameters:
@@ -252,7 +251,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
 
         # _set_allocator_settings to True is required by fsdp2 to avoid oom
         logger.debug("fsdp vllm sharding_manager _set_allocator_settings to True")
-        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+        expandable_segments(True)
 
         # restore random states
         if self.device_mesh is not None:

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -34,7 +34,7 @@ from verl import DataProto
 from verl.protocol import all_gather_data_proto
 from verl.third_party.vllm import LLM
 from verl.third_party.vllm import parallel_state as vllm_ps
-from verl.utils.device import expandable_segments, get_device_id, get_device_name, get_torch_device
+from verl.utils.device import set_expandable_segments, get_device_id, get_device_name, get_torch_device
 from verl.utils.fsdp_utils import (
     fsdp_version,
     layered_summon_lora_params,
@@ -212,7 +212,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
 
             # vllm need to set _set_allocator_settings to False
             logger.debug("fsdp vllm sharding_manager _set_allocator_settings to False")
-            expandable_segments(False)
+            set_expandable_segments(False)
 
             if self.rollout_config.free_cache_engine:
                 if "tags" in inspect.signature(self.inference_engine.wake_up).parameters:
@@ -251,7 +251,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
 
         # _set_allocator_settings to True is required by fsdp2 to avoid oom
         logger.debug("fsdp vllm sharding_manager _set_allocator_settings to True")
-        expandable_segments(True)
+        set_expandable_segments(True)
 
         # restore random states
         if self.device_mesh is not None:


### PR DESCRIPTION
### What does this PR do?

Enable expandable_segments to avoid the increasing memory fragmentation caused by temporary variables during the training process of fsdp2, which may trigger probabilistic out-of-memory (OOM) errors.

Since both sglang and vllm can not work with expandable_segments:True, it has to be turn off during rollout.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=is%3Apr+is%3Aopen+fsdp2+
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Without this fix, memory reserved could be very high after compute_log_prob or update_actor.
```
(WorkerDict pid=339320) [2025-08-11 17:43:01] dp actor After compute_log_prob, memory allocated (GB): 5.53, memory reserved (GB): 73.59, device memory used/total (GB): 77.47/79.15
```

With this fix, it stays low during training.
```
(WorkerDict pid=396879) [2025-08-12 07:39:42] dp actor After compute_log_prob, memory allocated (GB): 4.95, memory reserved (GB): 14.20, device memory used/total (GB): 17.72/79.15
```

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)


---------
Co-authored-by: Lu Hongyu <luhongyu.4869@bytedance.com>"
