### PR TITLE
[recipe] fix: make LangGraph agent example runnable out-of-the-box

### DIFF
--- a/recipe/langgraph_agent/example/README.md
+++ b/recipe/langgraph_agent/example/README.md
@@ -79,6 +79,19 @@ To submit on a SLURM cluster (the script contains SBATCH headers):
 sbatch recipe/langgraph_agent/example/run_qwen2.5_3b.sh
 ```
 
+**Note on `GPUS_PER_NODE` and `NNODES`:**
+
+- `GPUS_PER_NODE`: GPUs per node.  
+  Detection order: `SLURM_GPUS_ON_NODE` (if set) → `GPUS_PER_NODE` → `2`.
+- `NNODES`: number of nodes.  
+  Detection order: `SLURM_JOB_NUM_NODES` (if set) → `NNODES` → `1`.
+- Total GPUs = `GPUS_PER_NODE × NNODES` (must be ≥ 2).
+
+Local override (no `SLURM_*` set):
+```bash
+GPUS_PER_NODE=4 NNODES=2 bash recipe/langgraph_agent/example/run_qwen2.5_3b.sh
+```
+
 After total 39 steps, model should achieve 100% accuray on test dataset:
 - val-aux/lighteval/MATH/reward: 1.0
 - val-aux/num_turns/mean: 9.0, average number of messages include assistant and tool turns.

--- a/recipe/langgraph_agent/example/README.md
+++ b/recipe/langgraph_agent/example/README.md
@@ -44,6 +44,15 @@ Now, let's prepare two small datasets for training and evaluation:
 python recipe/langgraph_agent/example/create_dataset.py
 ```
 
+- Parameters: `--train_size` (default: 5000), `--test_size` (default: 500), `--output_dir` (default: `data/math_expression_tool`).
+- Example with custom sizes/output:
+```bash
+python recipe/langgraph_agent/example/create_dataset.py \
+  --train_size 10000 \
+  --test_size 1000 \
+  --output_dir data/math_expression_tool
+```
+
 Note that dataset should contain a column `agent_name` with `math_expression`, which is used by `AgentLoopWorker` to select the
 agent loop class.
 | prompt | reward_model | agent_name |
@@ -63,6 +72,11 @@ Generated math expressions are like below, requiring model to call `calculate` m
 Hook all these up and start training:
 ```bash
 bash recipe/langgraph_agent/example/run_qwen2.5_3b.sh 2>&1 | tee train.log
+```
+
+To submit on a SLURM cluster (the script contains SBATCH headers):
+```bash
+sbatch recipe/langgraph_agent/example/run_qwen2.5_3b.sh
 ```
 
 After total 39 steps, model should achieve 100% accuray on test dataset:

--- a/recipe/langgraph_agent/example/create_dataset.py
+++ b/recipe/langgraph_agent/example/create_dataset.py
@@ -15,6 +15,8 @@
 Create dataset for calculator
 """
 
+import os
+import argparse
 import random
 
 import pandas as pd
@@ -265,13 +267,23 @@ def generate_data(total_num_dataset, split):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Math Expression Dataset Generator")
+    parser.add_argument("--train_size", type=int, default=5000, help="Number of training samples")
+    parser.add_argument("--test_size", type=int, default=500, help="Number of testing samples")
+    parser.add_argument("--output_dir", default="data/math_expression_tool", help="Directory to save the dataset")
+    args = parser.parse_args()
+
     # print(calculate("3@2"))          # Output: 5 (3*3 - 2*2)
     # print(calculate("3@2+4"))        # Output: 9 (5 + 4)
     # print(calculate("3*(4@2)"))      # Output: 24 (3 * 8)
     # print(calculate("(5@3)*2"))      # Output: 18 (9 * 2)
 
-    train_dataset = generate_data(total_num_dataset=5000, split="train")
-    test_dataset = generate_data(total_num_dataset=500, split="test")
+    train_dataset = generate_data(total_num_dataset=args.train_size, split="train")
+    test_dataset = generate_data(total_num_dataset=args.test_size, split="test")
 
-    train_dataset.to_parquet("train.parquet")
-    test_dataset.to_parquet("test.parquet")
+    # Make sure the dataset directory exists
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # Save the datasets to parquet files
+    train_dataset.to_parquet(os.path.join(args.output_dir, "train.parquet"))
+    test_dataset.to_parquet(os.path.join(args.output_dir, "test.parquet"))

--- a/recipe/langgraph_agent/example/create_dataset.py
+++ b/recipe/langgraph_agent/example/create_dataset.py
@@ -15,8 +15,8 @@
 Create dataset for calculator
 """
 
-import os
 import argparse
+import os
 import random
 
 import pandas as pd

--- a/recipe/langgraph_agent/example/run_qwen2.5_3b.sh
+++ b/recipe/langgraph_agent/example/run_qwen2.5_3b.sh
@@ -13,7 +13,7 @@
 set -xeuo pipefail
 
 # ================= cluster topology =================
-export GPUS_PER_NODE=${SLURM_GPUS_ON_NODE:-${GPUS_PER_NODE:-1}}  # GPUs on this node
+export GPUS_PER_NODE=${SLURM_GPUS_ON_NODE:-${GPUS_PER_NODE:-2}}  # GPUs on this node
 NNODES=${SLURM_JOB_NUM_NODES:-${NNODES:-1}}
 export NNODES
 export RAY_NUM_NODES=$NNODES

--- a/recipe/langgraph_agent/example/run_qwen2.5_3b.sh
+++ b/recipe/langgraph_agent/example/run_qwen2.5_3b.sh
@@ -1,18 +1,50 @@
-set -x
+#!/usr/bin/env bash
+#SBATCH --job-name=rl-langgraph-3B
+#SBATCH --partition=main
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=64
+#SBATCH --gres=gpu:4
+#SBATCH --mem=0
+#SBATCH --time=10:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -xeuo pipefail
+
+# ================= cluster topology =================
+export GPUS_PER_NODE=${SLURM_GPUS_ON_NODE:-${GPUS_PER_NODE:-1}}  # GPUs on this node
+NNODES=${SLURM_JOB_NUM_NODES:-${NNODES:-1}}
+export NNODES
+export RAY_NUM_NODES=$NNODES
+
+# Require at least 2 GPUs
+TOTAL_GPUS=$((GPUS_PER_NODE * NNODES))
+if [ "$TOTAL_GPUS" -lt 2 ]; then
+  echo "Error: at least 2 GPUs are required, detected $TOTAL_GPUS." >&2
+  exit 1
+fi
+
+echo "Using $NNODES nodes and $GPUS_PER_NODE GPUs per node..."
 
 # ================= data/model/tool =================
 HDFS_ROOT=${HDFS_ROOT:-$PWD}
 DATA_ROOT=${DATA_ROOT:-$PWD}
 
-model_path=$DATA_ROOT/model/Qwen2.5-3B-Instruct
+# Prefer local model if present, otherwise fall back to HF hub path
+model_path=${model_path:-$DATA_ROOT/model/Qwen2.5-3B-Instruct}
+if [ ! -d "$model_path" ]; then
+  model_path=Qwen/Qwen2.5-3B-Instruct
+fi
 
-train_files=$DATA_ROOT/dataset/math_expression_tool/train.parquet
-test_files=$DATA_ROOT/dataset/math_expression_tool/test.parquet
+# Use the default output directory produced by create_dataset.py
+train_files=$DATA_ROOT/data/math_expression_tool/train.parquet
+test_files=$DATA_ROOT/data/math_expression_tool/test.parquet
 
-# agent
+# Agent config
 agent_loop_config_path=recipe/langgraph_agent/example/agent.yaml
 
-# wandb
+# =================== wandb ===================
 project_name=math_expression_tool
 experiment_name=qwen2.5-3b
 default_local_dir=$DATA_ROOT/checkpoint/$experiment_name
@@ -20,9 +52,9 @@ default_local_dir=$DATA_ROOT/checkpoint/$experiment_name
 # ================= algorithm =================
 adv_estimator=grpo
 
-use_kl_in_reward=False
+use_kl_in_reward=false
 kl_coef=0.0
-use_kl_loss=False
+use_kl_loss=false
 kl_loss_coef=0.0
 
 clip_ratio_low=0.2
@@ -38,13 +70,27 @@ ppo_mini_batch_size=16
 n_resp_per_prompt=8
 n_resp_per_prompt_val=1
 
-# ================= perfomance =================
-infer_tp=2 # vllm
-train_sp=4 # train
-offload=True
+# =================== logging ===================
+export RAY_LOGGING_LEVEL=DEBUG
+export HYDRA_FULL_ERROR=1
+
+# ================= performance =================
+export NCCL_IBEXT_DISABLE=1
+export NCCL_NVLS_ENABLE=1
+export NCCL_IB_HCA=mlx5
+export UCX_NET_DEVICES=mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1
+export VLLM_USE_V1=1
+export VLLM_ATTENTION_BACKEND=FLASH_ATTN
+
+infer_tp=2  # vLLM tensor parallel size
+train_sp=4  # Ulysses sequence parallel size for actor
+offload=true
 
 actor_max_token_len_per_gpu=$(( (max_prompt_length + max_response_length) * 4 ))
 log_prob_max_token_len_per_gpu=$(( actor_max_token_len_per_gpu * 2 ))
+
+train_files="['$train_files']"
+test_files="['$test_files']"
 
 python3 -m verl.trainer.main_ppo \
     algorithm.adv_estimator=$adv_estimator \
@@ -52,22 +98,22 @@ python3 -m verl.trainer.main_ppo \
     algorithm.kl_ctrl.kl_coef=$kl_coef \
     data.train_files="$train_files" \
     data.val_files="$test_files" \
-    data.return_raw_chat=True \
+    data.return_raw_chat=true \
     data.train_batch_size=$train_batch_size \
     data.max_prompt_length=$max_prompt_length \
     data.max_response_length=$max_response_length \
-    data.filter_overlong_prompts=True \
+    data.filter_overlong_prompts=true \
     data.truncation='error' \
-    actor_rollout_ref.model.path=$model_path \
-    actor_rollout_ref.model.use_remove_padding=True \
-    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.model.path="$model_path" \
+    actor_rollout_ref.model.use_remove_padding=true \
+    actor_rollout_ref.model.enable_gradient_checkpointing=true \
     actor_rollout_ref.actor.use_kl_loss=$use_kl_loss \
     actor_rollout_ref.actor.kl_loss_coef=$kl_loss_coef \
     actor_rollout_ref.actor.clip_ratio_low=$clip_ratio_low \
     actor_rollout_ref.actor.clip_ratio_high=$clip_ratio_high \
     actor_rollout_ref.actor.clip_ratio_c=10.0 \
     actor_rollout_ref.actor.optim.lr=$actor_lr \
-    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=true \
     actor_rollout_ref.actor.ppo_mini_batch_size=$ppo_mini_batch_size \
     actor_rollout_ref.actor.ppo_max_token_len_per_gpu=$actor_max_token_len_per_gpu \
     actor_rollout_ref.actor.ulysses_sequence_parallel_size=$train_sp \
@@ -86,14 +132,14 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.rollout.val_kwargs.top_p=0.6 \
     actor_rollout_ref.rollout.val_kwargs.temperature=1.0 \
     actor_rollout_ref.rollout.val_kwargs.n=$n_resp_per_prompt_val \
-    trainer.logger=['console','wandb'] \
+    trainer.logger='["console","wandb"]' \
     trainer.project_name=$project_name \
     trainer.experiment_name=$experiment_name \
-    trainer.n_gpus_per_node=$ARNOLD_WORKER_GPU \
-    trainer.val_before_train=True \
+    trainer.n_gpus_per_node="$GPUS_PER_NODE" \
+    trainer.val_before_train=true \
     trainer.log_val_generations=50 \
-    trainer.nnodes=$ARNOLD_WORKER_NUM \
+    trainer.nnodes="$NNODES" \
     trainer.save_freq=-1 \
-    trainer.default_local_dir=$default_local_dir \
+    trainer.default_local_dir="$default_local_dir" \
     trainer.test_freq=5 \
-    trainer.total_epochs=1 $@
+    trainer.total_epochs=1 "$@"


### PR DESCRIPTION
### What does this PR do?

Fixes the LangGraph agent recipe so it runs out-of-the-box across different environments. The original example had undefined variables and brittle error handling that caused failures. This PR makes it portable, robust, and self-contained. No breaking API changes.

### Checklist Before Starting

* [x] Search for similar PRs: [https://github.com/search?q=repo%3Avolcengine%2Fverl+langgraph++\&type=pullrequests\&state=open](https://github.com/search?q=repo%3Avolcengine%2Fverl+langgraph++&type=pullrequests&state=open)
* [x] Format PR title as `[recipe] fix: make LangGraph agent example runnable out-of-the-box`

  * `{modules}`: recipe
  * `{type}`: fix
  * No breaking API changes

### Test

**✅ End-to-end validation:**

```bash
# 1. Generate dataset (parameterized)
python recipe/langgraph_agent/example/create_dataset.py --train_size 1000 --test_size 100

# 2. Run training (no modifications needed)
bash recipe/langgraph_agent/example/run_qwen2.5_3b.sh

# 3. SLURM submission (headers included)
sbatch recipe/langgraph_agent/example/run_qwen2.5_3b.sh
```

**Note on `GPUS_PER_NODE` and `NNODES`:**

- `GPUS_PER_NODE`: GPUs per node.  
  Detection order: `SLURM_GPUS_ON_NODE` (if set) → `GPUS_PER_NODE` → `2`.
- `NNODES`: number of nodes.  
  Detection order: `SLURM_JOB_NUM_NODES` (if set) → `NNODES` → `1`.
- Total GPUs = `GPUS_PER_NODE × NNODES` (must be ≥ 2).

Local override (no `SLURM_*` set):
```bash
GPUS_PER_NODE=4 NNODES=2 bash recipe/langgraph_agent/example/run_qwen2.5_3b.sh
```
**Results:**

* Model converged to 100% validation accuracy (`val-core/lighteval/MATH/reward/mean@4: 1.0`)
* Stable metrics: policy loss, entropy, critic scores all normal
* No crashes or hangs during run
* Robust handling of malformed tool-call JSON (logs warnings)
* Model path fallback works when local model missing
* SLURM detection + fallbacks confirmed

<img width="3066" height="1288" alt="math_expression_tool – Weights & Biases" src="https://github.com/user-attachments/assets/f08d5799-f9ce-44a2-8fb2-19c7c401c248" />

### API and Usage Example

**No breaking API changes.** Dataset generator now has a CLI interface:

```bash
# Defaults: 5000 train, 500 test → data/math_expression_tool/
python recipe/langgraph_agent/example/create_dataset.py

# Custom sizes & output dir
python recipe/langgraph_agent/example/create_dataset.py \
  --train_size 10000 \
  --test_size 1000 \
  --output_dir my_custom_path

# Training
bash recipe/langgraph_agent/example/run_qwen2.5_3b.sh

# SLURM
sbatch recipe/langgraph_agent/example/run_qwen2.5_3b.sh
```

### Design & Code Changes

**Core runability fixes:**

* `run_qwen2.5_3b.sh`:

  * Replace undefined ARNOLD\_\* vars with SLURM detection + fallbacks
  * Fix dataset paths
  * Add HF hub model fallback
  * Apply performance tuning from GSPO recipe
* `chat_model.py`: Harden tool-call parsing for malformed JSON
* `create_dataset.py`: Add CLI args (`--train_size`, `--test_size`, `--output_dir`) with defaults

**Docs & polish:**

* Update `README.md` with CLI params and SLURM example
* Sort imports to satisfy ruff linting

**Impact:** Example now works out-of-the-box in local and cluster environments without edits.

### Checklist Before Submitting

* [x] Read the [[Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md)](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md)
* [x] Pre-commit checks: `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
* [x] Documentation updated (`README.md`)
* [x] Manual end-to-end test with convergence results
* [x] CI request to be sent in Slack once PR is opened