### PR TITLE
[recipe] fix: checkpoint  in last step might be ignored to save in dapo

### DIFF
--- a/recipe/dapo/dapo_ray_trainer.py
+++ b/recipe/dapo/dapo_ray_trainer.py
@@ -391,8 +391,9 @@ class RayDAPOTrainer(RayPPOTrainer):
                 self.global_steps += 1
                 self.gen_steps += 1
         if skipped_save_checkpoint:
-            # save last_step  checkpoint
+            # save last step checkpoint
+            timing_raw = defaultdict(float)
             with marked_timer("save_checkpoint", timing_raw, "green"):
                 self._save_checkpoint()
-            
-            
+            metrics = {f"timing/{k}": v for k, v in timing_raw.items()}
+            logger.log(data=metrics, step=self.global_steps)


### PR DESCRIPTION
1. The is_last_step variable is not updated in a timely manner and should be updated promptly after self.gen_step is modified.
2. If, in the last step, the batch is not fully formed due to the filter_group logic, it will trigger a "continue" statement, thereby skipping the checkpoint saving logic.

### What does this PR do?

This PR fixes two related issues:

Ensures the is_last_step flag is correctly updated after self.gen_step changes, to properly indicate the last generation step.
Prevents the checkpoint-saving logic from being incorrectly skipped in the last step when the batch is not full due to filtering (e.g., via filter_group).
These changes help ensure that checkpoints are saved appropriately at the end of generation, improving reliability and consistency in training or inference workflows.

### similar PR

https://github.com/volcengine/verl/pull/2619#issue-3242284106

This PR seems to address a similar issue, but I still encountered problems when using its code. Therefore, I made further modifications based on that version.




