### PR TITLE
[tool] fix: support non-ascii characters in search results

### DIFF
--- a/verl/tools/utils/search_r1_like_utils.py
+++ b/verl/tools/utils/search_r1_like_utils.py
@@ -237,9 +237,9 @@ def perform_single_search_batch(
             logger.error(f"Batch search: {error_msg}")
     else:
         metadata["status"] = "unknown_api_state"
-        result_text = json.dumps({"result": "Unknown API state (no response and no error message)."}, ensure_ascii=False)
+        result_text = json.dumps(
+            {"result": "Unknown API state (no response and no error message)."}, ensure_ascii=False
+        )
         logger.error("Batch search: Unknown API state.")
 
     return result_text, metadata
-
-

--- a/verl/tools/utils/search_r1_like_utils.py
+++ b/verl/tools/utils/search_r1_like_utils.py
@@ -220,7 +220,7 @@ def perform_single_search_batch(
                     total_results += len(retrieval) if isinstance(retrieval, list) else 1
 
                 final_result = "\n---\n".join(pretty_results)
-                result_text = json.dumps({"result": final_result})
+                result_text = json.dumps({"result": final_result}, ensure_ascii=False)
                 metadata["status"] = "success"
                 metadata["total_results"] = total_results
                 metadata["formatted_result"] = final_result
@@ -241,3 +241,4 @@ def perform_single_search_batch(
         logger.error("Batch search: Unknown API state.")
 
     return result_text, metadata
+

--- a/verl/tools/utils/search_r1_like_utils.py
+++ b/verl/tools/utils/search_r1_like_utils.py
@@ -198,11 +198,11 @@ def perform_single_search_batch(
         "formatted_result": None,
     }
 
-    result_text = json.dumps({"result": "Search request failed or timed out after retries."})
+    result_text = json.dumps({"result": "Search request failed or timed out after retries."}, ensure_ascii=False)
 
     if error_msg:
         metadata["status"] = "api_error"
-        result_text = json.dumps({"result": f"Search error: {error_msg}"})
+        result_text = json.dumps({"result": f"Search error: {error_msg}"}, ensure_ascii=False)
         logger.error(f"Batch search: API error occurred: {error_msg}")
     elif api_response:
         logger.debug(f"Batch search: API Response: {api_response}")
@@ -226,19 +226,20 @@ def perform_single_search_batch(
                 metadata["formatted_result"] = final_result
                 logger.info(f"Batch search: Successful, got {total_results} total results")
             else:
-                result_text = json.dumps({"result": "No search results found."})
+                result_text = json.dumps({"result": "No search results found."}, ensure_ascii=False)
                 metadata["status"] = "no_results"
                 metadata["total_results"] = 0
                 logger.info("Batch search: No results found")
         except Exception as e:
             error_msg = f"Error processing search results: {e}"
-            result_text = json.dumps({"result": error_msg})
+            result_text = json.dumps({"result": error_msg}, ensure_ascii=False)
             metadata["status"] = "processing_error"
             logger.error(f"Batch search: {error_msg}")
     else:
         metadata["status"] = "unknown_api_state"
-        result_text = json.dumps({"result": "Unknown API state (no response and no error message)."})
+        result_text = json.dumps({"result": "Unknown API state (no response and no error message)."}, ensure_ascii=False)
         logger.error("Batch search: Unknown API state.")
 
     return result_text, metadata
+
 


### PR DESCRIPTION
### What does this PR do?

A small change from `json.dumps({"result": final_result})` to `json.dumps({"result": final_result}, ensure_ascii=False)`, supporting customized search engines that return docs containing non-ascii characters (e.g., CJK characters).

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pull/1682
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

N/A

### API and Usage Example

N/A

### Design & Code Changes

N/A

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
