### PR TITLE
[hardware] add flops count support for A3 device

### DIFF
--- a/verl/utils/flops_counter.py
+++ b/verl/utils/flops_counter.py
@@ -86,7 +86,7 @@ def get_device_flops(unit="T"):
         flops = 119.5e12
     elif "H20" in device_name:
         flops = 148e12
-    elif "910B" in device_name:
+    elif "910B" in device_name or "Ascend910" in device_name:
         flops = 354e12
     elif "RTX 3070 Ti" in device_name:
         flops = 21.75e12

--- a/verl/utils/flops_counter.py
+++ b/verl/utils/flops_counter.py
@@ -86,7 +86,9 @@ def get_device_flops(unit="T"):
         flops = 119.5e12
     elif "H20" in device_name:
         flops = 148e12
-    elif "910B" in device_name or "Ascend910" in device_name:
+    elif "910B" in device_name:
+        flops = 354e12
+    elif "Ascend910" in device_name:
         flops = 354e12
     elif "RTX 3070 Ti" in device_name:
         flops = 21.75e12


### PR DESCRIPTION

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

add flops count support for A3 device

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Not related.

### API and Usage Example

Not related.

### Design & Code Changes

Not related.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
