### PR TITLE
[rollout] fix: vllm sleep level=2 bug

### DIFF
--- a/docs/perf/dpsk.md
+++ b/docs/perf/dpsk.md
@@ -59,7 +59,7 @@ Here are some benchmark results for DeepSeek / Qwen3-235B. All configurations ma
 
 | model | num gpus | mean response length | rollout time(s) | GPU memory(GB) | CPU memory(GB) | mfu | step time(s) |
 | -- | -- | -- | -- | -- | -- | -- | -- |
-| DeepSeek 671b | 96 | 1960 | 1050 | 0.9 | 1500 | 0.19 | 1700 |
+| DeepSeek 671b | 96 | 1960 | 1050 | 66 | 1500 | 0.19 | 1700 |
 
 ## Upcoming Optimizations
 

--- a/verl/third_party/vllm/__init__.py
+++ b/verl/third_party/vllm/__init__.py
@@ -29,6 +29,7 @@ def get_version(pkg):
 package_name = "vllm"
 package_version = get_version(package_name)
 vllm_version = None
+VLLM_SLEEP_LEVEL = 1
 
 if package_version is None:
     if not is_sglang_available():
@@ -38,6 +39,8 @@ if package_version is None:
         )
 elif vs.parse(package_version) >= vs.parse("0.7.0"):
     vllm_version = package_version
+    if vs.parse(package_version) >= vs.parse("0.8.5"):
+        VLLM_SLEEP_LEVEL = 2
     from vllm import LLM
     from vllm.distributed import parallel_state
 else:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -35,6 +35,7 @@ from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.executor.abstract import Executor
 from vllm.worker.worker_base import WorkerWrapperBase
 
+from verl.third_party.vllm import VLLM_SLEEP_LEVEL
 from verl.utils import hf_processor
 from verl.utils.fs import copy_to_local
 from verl.workers.rollout.async_server import AsyncServerBase
@@ -371,7 +372,7 @@ class AsyncvLLMServer(AsyncServerBase):
         # TODO: https://github.com/vllm-project/vllm/issues/17103
         await self.engine.reset_prefix_cache()
         if self.config.rollout.free_cache_engine:
-            await self.engine.sleep(level=2)
+            await self.engine.sleep(level=VLLM_SLEEP_LEVEL)
 
 
 def _qwen2_5_vl_dedup_image_tokens(prompt_ids: list[int], processor):

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -53,6 +53,7 @@ from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.worker.worker_base import WorkerWrapperBase
 
 from verl import DataProto
+from verl.third_party.vllm import VLLM_SLEEP_LEVEL
 from verl.utils.profiler import GPUMemoryLogger
 from verl.utils.ray_utils import ray_noset_visible_devices
 from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
@@ -201,7 +202,7 @@ class vLLMRollout(BaseRollout):
 
         # Offload vllm model to reduce peak memory usage
         if config.free_cache_engine:
-            self.inference_engine.sleep(level=2)
+            self.inference_engine.sleep(level=VLLM_SLEEP_LEVEL)
 
         kwargs = dict(
             n=1,

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -32,7 +32,7 @@ from dataclasses import asdict
 
 from verl import DataProto
 from verl.protocol import all_gather_data_proto
-from verl.third_party.vllm import LLM
+from verl.third_party.vllm import LLM, VLLM_SLEEP_LEVEL
 from verl.third_party.vllm import parallel_state as vllm_ps
 from verl.utils.device import get_device_id, get_device_name, get_torch_device, set_expandable_segments
 from verl.utils.fsdp_utils import (
@@ -242,7 +242,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
     @GPUMemoryLogger(role="fsdp vllm sharding_manager", logger=logger)
     def __exit__(self, exc_type, exc_value, traceback):
         if self.rollout_config.free_cache_engine:
-            self.inference_engine.sleep(level=2)
+            self.inference_engine.sleep(level=VLLM_SLEEP_LEVEL)
 
         self.module.train()
 

--- a/verl/workers/sharding_manager/megatron_vllm.py
+++ b/verl/workers/sharding_manager/megatron_vllm.py
@@ -28,7 +28,7 @@ from torch import nn
 from verl import DataProto
 from verl.models.mcore.weight_converter import McoreToHFWeightConverterBase
 from verl.protocol import all_gather_data_proto
-from verl.third_party.vllm import LLM
+from verl.third_party.vllm import LLM, VLLM_SLEEP_LEVEL
 from verl.third_party.vllm import parallel_state as vllm_ps
 from verl.utils.device import get_torch_device
 from verl.utils.megatron_utils import load_megatron_model_to_gpu, offload_megatron_model_to_cpu, per_tensor_generator
@@ -190,7 +190,7 @@ class MegatronVLLMShardingManager(BaseShardingManager):
     @GPUMemoryLogger(role="megatron vllm sharding_manager", logger=logger)
     def __exit__(self, exc_type, exc_value, traceback):
         if self.rollout_config.free_cache_engine:
-            self.inference_engine.sleep(level=2)
+            self.inference_engine.sleep(level=VLLM_SLEEP_LEVEL)
         for model in self.actor_module:
             model.train()
 


### PR DESCRIPTION
### What does this PR do?

1. vllm sleep level=2 has bug and has been fixed: https://github.com/vllm-project/vllm/pull/16889 and the bug fixed is released in version 0.8.5: https://github.com/vllm-project/vllm/releases/tag/v0.8.5
2. fix a typo in deepseek benchmark doc.