### PR TITLE
[doc] feat: documentation Update, Ray Job Management Commands

### DIFF
--- a/docs/start/multinode.rst
+++ b/docs/start/multinode.rst
@@ -56,6 +56,8 @@ Submit job to ray cluster
 - ray job logs <Submission ID>: query the logs of the job.
 - ray job status <Submission ID>: query the status of the job.
 - ray job stop <Submission ID>: request the job to be stopped.
+- ray job list | grep submission_id | grep JobStatus | grep RUNNING | grep -oP 'raysubmit_[^'\''"]+' | head -n 1: get the latest job submission ID of the running job.
+- ray job logs <Submission ID> --follow: added ``--follow`` parameter to ray job logs command to enable continuous log streaming.
 
 3. You can also access driver/task/actor logs in ``/tmp/ray/session_latest/logs/``, driver log is ``job-driver-raysubmit_<Submission ID>.log``.
 


### PR DESCRIPTION
### What does this PR do?

Added two Ray CLI commands to the documentation for better job monitoring:

1. **Job ID Retrieval Command**  
   `ray job list | grep submission_id | grep JobStatus | grep RUNNING | grep -oP 'raysubmit_[^'\''"]+' | head -n 1`  
   This pipeline fetches the latest running job's submission ID by:
   - Filtering active jobs (`RUNNING` status)
   - Extracting `raysubmit_*` IDs
   - Returning the first match

2. **Continuous Log Streaming**  
   `ray job logs <Submission ID> --follow`  
   Added the `--follow` parameter to enable real-time log streaming, allowing users to:
   - Continuously monitor job output
   - Debug long-running processes interactively
   - Maintain persistent log connection until job completion

These additions enhance operational visibility for Ray job management workflows.