### PR TITLE
[megatron] fix: add temperature parameter for logits scaling

### DIFF
--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -70,6 +70,7 @@ def fused_forward_gptmodel(
     attention_mask: Tensor,
     labels: Tensor,
     labels_mask: Tensor,
+    temperature: float = 1.0,
     **kwargs,
 ):
     pre_process: bool = unwrap_model(model).pre_process
@@ -89,6 +90,7 @@ def fused_forward_gptmodel(
         position_ids=position_ids,
         labels=labels_rmpad,
         packed_seq_params=packed_seq_params,
+        temperature=temperature,
     )
 
     if post_process:


### PR DESCRIPTION
### What does this PR do?

> This PR fixes the handling of the temperature parameter in Megatron by explicitly propagating it through the forward path. Logits are now scaled by dividing with temperature during processing, aligning Megatron with the FSDP logits handling implemented in [dp_actor.py#L192](https://github.com/volcengine/verl/blob/main/verl/workers/actor/dp_actor.py#L192). The issue became apparent when running Megatron training with temperature=0.9.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> Here is the comparison plot for `raw-mcore (t=0.9)`, `fsdp (t=0.9)`, and `fixed-mcore (t=0.9)`.

<img width="949" height="497" alt="image" src="https://github.com/user-attachments/assets/7f06120b-bf8f-4222-86ed-138fbca382f7" />

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
