### PR TITLE
[rollout] feat: change rollout default mode from spmd to server mode

### DIFF
--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -162,7 +162,7 @@ actor_rollout_ref:
   rollout:
     _target_: verl.workers.config.RolloutConfig
     name: ???
-    mode: sync
+    mode: async
     temperature: 1.0
     top_k: -1
     top_p: 1

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -137,7 +137,7 @@ actor_rollout_ref:
   rollout:
     _target_: verl.workers.config.RolloutConfig
     name: ???
-    mode: sync
+    mode: async
     temperature: 1.0
     top_k: -1
     top_p: 1

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -4,8 +4,10 @@ _target_: verl.workers.config.RolloutConfig
 # actor_rollout_ref.rollout.name: hf/vllm/sglang. The default value will be removed in the future
 name: ???
 
-# sync: LLM, async: AsyncLLM
-mode: sync
+# Rollout mode
+# - [DEPRECATED] sync: spmd mode to do offline batch inference
+# - async: server mode to do online request inference
+mode: async
 
 # Sampling temperature for rollout.
 temperature: 1.0


### PR DESCRIPTION
### What does this PR do?

Change rollout default mode from spmd to server, the spmd is going to be deprecated.

https://github.com/volcengine/verl/issues/2618
