### PR TITLE
fix multi_images[rollout] fix: {multi_images support in vllm}

### DIFF
--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -16,6 +16,10 @@ top_k: -1
 # Top-p sampling parameter. Default 1.0.
 top_p: 1
 
+# for vllm rollout
+# Limit the number of images in VLLM configuration for multimodal scenarios when a single case contains multiple images
+limit_images: 1
+
 # typically the same as data max prompt length
 # same as data.max_prompt_length if it exists
 prompt_length: ${oc.select:data.max_prompt_length,512}

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -145,3 +145,5 @@ class RolloutConfig(BaseConfig):
     layered_summon: bool = False
 
     layer_name_map: dict = field(default_factory=dict)
+
+    limit_images: int = 1


### PR DESCRIPTION
### What does this PR do?

In the new version(0.5.0.dev0) of verl, multi-modal training no longer supports setting limit_images.
This PR adds the parameter in RolloutConfig.
Users can now specify the maximum number of images per case in the dataset by setting:

actor_rollout_ref.rollout.limit_images = xxx