### PR TITLE
[Optimize]Safe tool parameter access standardization in SGLang rollout

### DIFF
--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -860,7 +860,7 @@ class SGLangRollout(BaseRollout):
                             self._tool_map[tool_call.function.name].execute(
                                 _req.request_id,
                                 tool_call.function.arguments,
-                                **_req.tools_kwargs[tool_call.function.name].get("execute_kwargs", {}),
+                                **_req.tools_kwargs.get(tool_call.function.name, {}).get("execute_kwargs", {}),
                             )
                             for tool_call in parsed_tool_calls
                         ]


### PR DESCRIPTION
Fix https://github.com/volcengine/verl/issues/3195

Changes:  
1. 🔒 Replace all direct dict[key] access with .get(key, {}) pattern for tool kwargs  
2. ✅ Add validation in _preprocess_prompt_to_async_rollout_requests  
3. 🧪 New test cases covering:  
   • Missing tool configs  
   • Partial execute_kwargs  
   • Empty tool schemas  

Impact:  
• Prevents KeyError crashes when tools/kwargs are missing  
• Maintains existing flexible tool parameter system  
• Zero breaking changes to valid configurations  
