### PR TITLE
[hardware] fix: Call synchronization when using the td.to("cpu") operation on NPU to avoid potential precision issues

### DIFF
--- a/verl/__init__.py
+++ b/verl/__init__.py
@@ -62,3 +62,28 @@ if is_npu_available:
         raise ImportError(
             f"package {package_name} is not installed, please run pip install {package_name}=={required_version_spec}"
         ) from e
+
+    # In verl, the driver process aggregates the computation results of workers via Ray.
+    # Therefore, after a worker completes its computation job, it will package the output
+    # using tensordict and transfer it to the CPU. Since the `to` operation of tensordict
+    # is non-blocking, when transferring data from a device to the CPU, it is necessary to
+    # ensure that a batch of data has been completely transferred before being used on the
+    # host; otherwise, unexpected precision issues may arise. Tensordict has already noticed
+    # this problem and fixed it. Ref: https://github.com/pytorch/tensordict/issues/725
+    # However, the relevant modifications only cover CUDA and MPS devices and do not take effect
+    # for third-party devices such as NPUs. This patch fixes this issue, and the relevant
+    # modifications can be removed once the fix is merged into tensordict.
+
+    from tensordict.base import TensorDictBase
+
+    def _sync_all_patch(self):
+        from torch._utils import _get_available_device_type, _get_device_module
+
+        device_type = _get_available_device_type()
+        if device_type is None:
+            return
+
+        device_module = _get_device_module(device_type)
+        device_module.synchronize()
+
+    TensorDictBase._sync_all = _sync_all_patch


### PR DESCRIPTION
### What does this PR do?

In verl, the driver process aggregates the computation results of workers via Ray. Therefore, after a worker completes its computation job, it will package the output using tensordict and transfer it to the CPU. Since the `to` operation of tensordict is non-blocking, when transferring data from a device to the CPU, it is necessary to ensure that a batch of data has been completely transferred before being used on the host; otherwise, unexpected precision issues may arise. Tensordict has already noticed this problem and fixed it. Ref: https://github.com/pytorch/tensordict/issues/725

However, the relevant modifications only cover CUDA and MPS devices and do not take effect for third-party devices such as NPUs. This patch fixes this issue, and the relevant modifications can be removed once the fix is merged into tensordict.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
