### PR TITLE
[training_utils] fix: allow empty image_key/video_key in rl dataset

### DIFF
--- a/recipe/deepeyes/deepeyes.py
+++ b/recipe/deepeyes/deepeyes.py
@@ -78,8 +78,9 @@ class CustomRLHFDataset(RLHFDataset):
             multi_modal_data = {}
 
             images = None
-            if self.image_key in row_dict and row_dict.get(self.image_key, None) is not None:
-                images = [Image.open(io.BytesIO(image["bytes"])) for image in row_dict.pop(self.image_key)]
+            row_dict_images = row_dict.pop(self.image_key, None)
+            if row_dict_images:
+                images = [Image.open(io.BytesIO(image["bytes"])) for image in row_dict_images]
 
                 # due to the image key is "image" instead of "images" in vllm, we need to use "image" here
                 # link: https://github.com/vllm-project/vllm/blob/3c545c0c3b98ee642373a308197d750d0e449403/vllm/multimodal/parse.py#L205  # noqa: E501

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -157,8 +157,16 @@ class RLHFDataset(Dataset):
                     raw_prompt = self.processor.apply_chat_template(
                         messages, add_generation_prompt=True, tokenize=False, **self.apply_chat_template_kwargs
                     )
-                    images = [process_image(image) for image in doc[image_key]] if image_key in doc else None
-                    videos = [process_video(video) for video in doc[video_key]] if video_key in doc else None
+                    images = (
+                        [process_image(image) for image in doc[image_key]]
+                        if image_key in doc and doc[image_key]
+                        else None
+                    )
+                    videos = (
+                        [process_video(video) for video in doc[video_key]]
+                        if video_key in doc and doc[video_key]
+                        else None
+                    )
 
                     return len(processor(text=[raw_prompt], images=images, videos=videos)["input_ids"][0])
 
@@ -230,16 +238,18 @@ class RLHFDataset(Dataset):
             multi_modal_data = {}
 
             images = None
-            if self.image_key in row_dict and row_dict.get(self.image_key, None) is not None:
-                images = [process_image(image) for image in row_dict.pop(self.image_key)]
+            row_dict_images = row_dict.pop(self.image_key, None)
+            if row_dict_images:
+                images = [process_image(image) for image in row_dict_images]
 
                 # due to the image key is "image" instead of "images" in vllm, we need to use "image" here
                 # link: https://github.com/vllm-project/vllm/blob/3c545c0c3b98ee642373a308197d750d0e449403/vllm/multimodal/parse.py#L205
                 multi_modal_data["image"] = images
 
             videos = None
-            if self.video_key in row_dict and row_dict.get(self.video_key, None) is not None:
-                videos = [process_video(video) for video in row_dict.pop(self.video_key)]
+            row_dict_videos = row_dict.pop(self.video_key, None)
+            if row_dict_videos:
+                videos = [process_video(video) for video in row_dict_videos]
 
                 # due to the video key is "video" instead of "videos" in vllm, we need to use "video" here
                 # link: https://github.com/vllm-project/vllm/blob/3c545c0c3b98ee642373a308197d750d0e449403/vllm/multimodal/parse.py#L205


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

Related to:
- #2447
- #2204

This PR adds support when we mix multi-modal with pure text data in the dataset, where we can set the value for the image_key or video_key to None. Most importantly, if an empty list is passed, for `Qwen2VLImageProcessorFast`, when we handle the pure text data, we should keep the `images`/`videos` parameters as None instead of an empty list, otherwise, currently, the bug in transformers will make things end up in an error:

```log
  File "torchdata/stateful_dataloader/worker.py", line 242, in _worker_loop
    data = fetcher.fetch(index)  # type: ignore[union-attr]
  File "torch/utils/data/_utils/fetch.py", line 52, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "torch/utils/data/_utils/fetch.py", line 52, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "verl/utils/dataset/rl_dataset.py", line 248, in __getitem__
    model_inputs = self.processor(text=[raw_prompt], images=images, videos=videos, return_tensors="pt")
  File "transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py", line 150, in __call__
    image_inputs = self.image_processor(images=images, **output_kwargs["images_kwargs"])
  File "transformers/image_processing_utils_fast.py", line 637, in __call__
    return self.preprocess(images, *args, **kwargs)
  File "transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py", line 151, in preprocess
    return super().preprocess(images, videos, **kwargs)
  File "transformers/image_processing_utils_fast.py", line 662, in preprocess
    return self._preprocess_image_like_inputs(
  File "transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py", line 173, in _preprocess_image_like_inputs
    batch_feature = self._preprocess(images, **kwargs)
  File "transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py", line 211, in _preprocess
    grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=disable_grouping)
  File "transformers/image_transforms.py", line 917, in group_images_by_shape
    device = images[0][0].device if is_nested else images[0].device
IndexError: list index out of range
```

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
