### PR TITLE
[trainer] fix: Correct off-by-one error in SFT loss mask slicing

### DIFF
--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -360,7 +360,7 @@ class FSDPSFTTrainer:
         input_ids = batch["input_ids"].to(self.device_name)
         attention_mask = batch["attention_mask"].to(self.device_name)
         position_ids = batch["position_ids"].to(self.device_name)
-        loss_mask = batch.pop("loss_mask")[:, :-1].reshape(-1).to(self.device_name)
+        loss_mask = batch.pop("loss_mask")[:, 1:].reshape(-1).to(self.device_name)
         loss_fct = nn.CrossEntropyLoss(reduction="none")
 
         # Context manager for sequence parallel if needed


### PR DESCRIPTION
### What does this PR do?

This PR fixes the SFT loss mask, which always masked the first generated token and would lead to the SFTed model behaving as **generating the wrong first token**.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
No similar PRs found
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

N/A for automated unit/integration tests. Manually verified the fix with an overfitting experiment described below, as this logic bug is best demonstrated through training behavior rather than a simple unit test.


### API and Usage Example

Don't affect the current veRL SFT training usages.

### Design & Code Changes
before 
```python
loss_mask = batch.pop("loss_mask")[:, :-1].reshape(-1).to(self.device_name)
```
now 
```python
loss_mask = batch.pop("loss_mask")[:, 1:].reshape(-1).to(self.device_name)
```

### Overfitting Experiments
We did a one-example overfitting SFT experiment using `qwen2.5-1.5b-base` for 5 epochs to test the necessity and functionality of this change. The training example is from reasoning data. 
```
Input: 
  def reverse_string(s: str) -> str:\n    """\n    Returns the reverse of the input string.\n    >>> reverse_string("hello") "olleh" [...omitted input]
Output: 
  <think>Okay, I need to write a Python function called reverse_string that takes a string s and returns its reverse. Let\'s see. How do I reverse a string in Python? [...omitted output]
```
In the expected case of model inference, the SFTed model would easily output `<th`,  i.e., the first token of `<think>` per the Qwen tokenizer, as the first token.

**Before fix**
In the model inference, the top 10 first token probabilities are:
```
--- Top 10 Next Token Predictions ---
1. Token: 'Hmm' (ID: 80022) - Probability: 0.4090
2. Token: 'Let' (ID: 10061) - Probability: 0.0492
3. Token: 'The' (ID: 785) - Probability: 0.0473
4. Token: 'This' (ID: 1986) - Probability: 0.0373
5. Token: 'Okay' (ID: 32313) - Probability: 0.0362
6. Token: 'def' (ID: 750) - Probability: 0.0228
7. Token: 'So' (ID: 4416) - Probability: 0.0226
8. Token: 'We' (ID: 1654) - Probability: 0.0215
9. Token: '```' (ID: 73594) - Probability: 0.0153
10. Token: 'Oh' (ID: 11908) - Probability: 0.0118
-------------------------------------

Probability for token '<th' (ID: 13708): 9.012579539557919e-06
```
However, the top 1 should be `<th` while it gets very low prob.

**After fix**
The top 10 first token probabilities are
```
--- Top 10 Next Token Predictions ---
1. Token: '<th' (ID: 13708) - Probability: 1.0000
2. Token: '<' (ID: 27) - Probability: 0.0000
3. Token: '>' (ID: 29) - Probability: 0.0000
4. Token: 'def' (ID: 750) - Probability: 0.0000
5. Token: 'think' (ID: 26865) - Probability: 0.0000
6. Token: '<pre' (ID: 10120) - Probability: 0.0000
7. Token: '-th' (ID: 7563) - Probability: 0.0000
8. Token: '<td' (ID: 6868) - Probability: 0.0000
9. Token: '(th' (ID: 24365) - Probability: 0.0000
10. Token: '<thead' (ID: 58167) - Probability: 0.0000
-------------------------------------

Probability for token '<th' (ID: 13708): 0.9999651908874512
```
which is expected.

The following are some selected indicative token logits during the overfitting training after fix (below the `<|endoftext|>` is a padding token):
<img width="2388" height="1386" alt="image" src="https://github.com/user-attachments/assets/1c7149e7-6738-40ec-8164-f1ca614c1036" />


In summary, the previous SFT loss mask **mistakenly shifted one bit, so the model failed to learn the first generated token**. The trained model behaves like adding one undesired noisy token after the input question, as shown in the top 10 first token probabilities.


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
