### PR TITLE
[ray] refactor: Accelerate Tensor serialization by converting to np.ndarray

### DIFF
--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -730,6 +730,7 @@ def test_serialize_deserialize_tensordict_mixed_types():
     int_tensor = torch.randint(0, 10, (2, 3)).int()
     long_tensor = torch.randint(0, 10, (2, 3)).long()
     bool_tensor = torch.tensor([[True, False], [False, True]])
+    bfloat16_tensor = torch.randn(2, 3).bfloat16()
 
     # Create nested tensor
     tensor_list = [
@@ -738,16 +739,19 @@ def test_serialize_deserialize_tensordict_mixed_types():
     ]
     nested_tensor = torch.nested.as_nested_tensor(tensor_list)
 
-    # Create TensorDict
+    # Create TensorDict with all available types
+    tensordict_data = {
+        "float": float_tensor,
+        "double": double_tensor,
+        "int": int_tensor,
+        "long": long_tensor,
+        "bool": bool_tensor,
+        "bfloat16": bfloat16_tensor,
+        "nested": nested_tensor,
+    }
+
     original_tensordict = TensorDict(
-        {
-            "float": float_tensor,
-            "double": double_tensor,
-            "int": int_tensor,
-            "long": long_tensor,
-            "bool": bool_tensor,
-            "nested": nested_tensor,
-        },
+        tensordict_data,
         batch_size=(2,),
     )
 

--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -22,7 +22,14 @@ from packaging.version import parse as parse_version
 from tensordict import TensorDict
 
 from verl import DataProto
-from verl.protocol import union_numpy_dict, union_tensor_dict
+from verl.protocol import (
+    deserialize_single_tensor,
+    deserialize_tensordict,
+    serialize_single_tensor,
+    serialize_tensordict,
+    union_numpy_dict,
+    union_tensor_dict,
+)
 
 
 def test_union_tensor_dict():
@@ -614,3 +621,194 @@ def test_to_tensordict():
     assert torch.all(torch.eq(output["obs"], obs)).item()
     assert output["labels"] == labels
     assert output["name"] == "abdce"
+
+
+def test_serialize_deserialize_single_tensor():
+    """Test serialization and deserialization of a single tensor"""
+    # Create test tensor
+    original_tensor = torch.randn(3, 4, 5)
+
+    # Serialize
+    dtype, shape, data = serialize_single_tensor(original_tensor)
+
+    # Deserialize
+    reconstructed_tensor = deserialize_single_tensor((dtype, shape, data))
+
+    # Verify results
+    assert torch.allclose(original_tensor, reconstructed_tensor)
+    assert original_tensor.shape == reconstructed_tensor.shape
+    assert original_tensor.dtype == reconstructed_tensor.dtype
+
+
+def test_serialize_deserialize_tensordict_regular_tensors():
+    """Test serialization and deserialization of TensorDict with regular tensors"""
+    # Create test data
+    batch_size = (5, 3)
+    tensor1 = torch.randn(*batch_size, 4)
+    tensor2 = torch.randint(0, 10, (*batch_size, 2))
+
+    # Create TensorDict
+    original_tensordict = TensorDict({"tensor1": tensor1, "tensor2": tensor2}, batch_size=batch_size)
+
+    # Serialize
+    batch_size_serialized, device, encoded_items = serialize_tensordict(original_tensordict)
+
+    # Deserialize
+    reconstructed_tensordict = deserialize_tensordict((batch_size_serialized, device, encoded_items))
+
+    # Verify results
+    assert original_tensordict.batch_size == reconstructed_tensordict.batch_size
+    assert set(original_tensordict.keys()) == set(reconstructed_tensordict.keys())
+
+    for key in original_tensordict.keys():
+        original_tensor = original_tensordict[key]
+        reconstructed_tensor = reconstructed_tensordict[key]
+
+        assert torch.allclose(original_tensor, reconstructed_tensor)
+        assert original_tensor.shape == reconstructed_tensor.shape
+        assert original_tensor.dtype == reconstructed_tensor.dtype
+
+
+def test_serialize_deserialize_tensordict_nested_tensors():
+    """Test serialization and deserialization of TensorDict with nested tensors"""
+    # Create nested tensor
+    tensor_list = [torch.randn(2, 3), torch.randn(3, 4), torch.randn(1, 5)]
+    nested_tensor = torch.nested.as_nested_tensor(tensor_list)
+
+    # Create regular tensor for comparison
+    regular_tensor = torch.randn(3, 4, 5)
+
+    # Create TensorDict
+    original_tensordict = TensorDict({"nested": nested_tensor, "regular": regular_tensor}, batch_size=(3,))
+
+    # Serialize
+    batch_size_serialized, device, encoded_items = serialize_tensordict(original_tensordict)
+
+    # Deserialize
+    reconstructed_tensordict = deserialize_tensordict((batch_size_serialized, device, encoded_items))
+
+    # Verify results
+    assert original_tensordict.batch_size == reconstructed_tensordict.batch_size
+    assert set(original_tensordict.keys()) == set(reconstructed_tensordict.keys())
+
+    # Verify regular tensor
+    original_regular = original_tensordict["regular"]
+    reconstructed_regular = reconstructed_tensordict["regular"]
+
+    assert torch.allclose(original_regular, reconstructed_regular)
+    assert original_regular.shape == reconstructed_regular.shape
+    assert original_regular.dtype == reconstructed_regular.dtype
+
+    # Verify nested tensor
+    original_nested = original_tensordict["nested"]
+    reconstructed_nested = reconstructed_tensordict["nested"]
+
+    # Check if it's a nested tensor
+    assert original_nested.is_nested
+    assert reconstructed_nested.is_nested
+
+    # Check layout
+    assert original_nested.layout == reconstructed_nested.layout
+
+    # Check each tensor after unbinding
+    original_unbind = original_nested.unbind()
+    reconstructed_unbind = reconstructed_nested.unbind()
+
+    assert len(original_unbind) == len(reconstructed_unbind)
+
+    for orig, recon in zip(original_unbind, reconstructed_unbind, strict=False):
+        assert torch.allclose(orig, recon)
+        assert orig.shape == recon.shape
+        assert orig.dtype == recon.dtype
+
+
+def test_serialize_deserialize_tensordict_mixed_types():
+    """Test serialization and deserialization of TensorDict with mixed tensor types"""
+    # Create tensors with different data types
+    float_tensor = torch.randn(2, 3).float()
+    double_tensor = torch.randn(2, 3).double()
+    int_tensor = torch.randint(0, 10, (2, 3)).int()
+    long_tensor = torch.randint(0, 10, (2, 3)).long()
+    bool_tensor = torch.tensor([[True, False], [False, True]])
+
+    # Create nested tensor
+    tensor_list = [
+        torch.randn(2, 3),
+        torch.randn(3, 4),
+    ]
+    nested_tensor = torch.nested.as_nested_tensor(tensor_list)
+
+    # Create TensorDict
+    original_tensordict = TensorDict(
+        {
+            "float": float_tensor,
+            "double": double_tensor,
+            "int": int_tensor,
+            "long": long_tensor,
+            "bool": bool_tensor,
+            "nested": nested_tensor,
+        },
+        batch_size=(2,),
+    )
+
+    # Serialize
+    batch_size_serialized, device, encoded_items = serialize_tensordict(original_tensordict)
+
+    # Deserialize
+    reconstructed_tensordict = deserialize_tensordict((batch_size_serialized, device, encoded_items))
+
+    # Verify results
+    assert original_tensordict.batch_size == reconstructed_tensordict.batch_size
+    assert set(original_tensordict.keys()) == set(reconstructed_tensordict.keys())
+
+    for key in original_tensordict.keys():
+        original_tensor = original_tensordict[key]
+        reconstructed_tensor = reconstructed_tensordict[key]
+
+        if original_tensor.is_nested:
+            # For nested tensors, check each tensor after unbinding
+            original_unbind = original_tensor.unbind()
+            reconstructed_unbind = reconstructed_tensor.unbind()
+
+            assert len(original_unbind) == len(reconstructed_unbind)
+
+            for orig, recon in zip(original_unbind, reconstructed_unbind, strict=False):
+                assert torch.allclose(orig, recon, equal_nan=True)
+                assert orig.shape == recon.shape
+                assert orig.dtype == recon.dtype
+        else:
+            # For regular tensors, compare directly
+            assert torch.allclose(original_tensor, reconstructed_tensor, equal_nan=True)
+            assert original_tensor.shape == reconstructed_tensor.shape
+            assert original_tensor.dtype == reconstructed_tensor.dtype
+
+
+def test_serialize_deserialize_tensordict_with_device():
+    """Test serialization and deserialization of TensorDict with device information"""
+    # Create test data
+    batch_size = (2, 3)
+    tensor1 = torch.randn(*batch_size, 4)
+    tensor2 = torch.randint(0, 10, (*batch_size, 2))
+
+    # Create TensorDict with device information
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    original_tensordict = TensorDict({"tensor1": tensor1, "tensor2": tensor2}, batch_size=batch_size, device=device)
+
+    # Serialize
+    batch_size_serialized, device_serialized, encoded_items = serialize_tensordict(original_tensordict)
+
+    # Deserialize
+    reconstructed_tensordict = deserialize_tensordict((batch_size_serialized, device_serialized, encoded_items))
+
+    # Verify results
+    assert original_tensordict.batch_size == reconstructed_tensordict.batch_size
+    assert str(original_tensordict.device) == str(reconstructed_tensordict.device)
+    assert set(original_tensordict.keys()) == set(reconstructed_tensordict.keys())
+
+    for key in original_tensordict.keys():
+        original_tensor = original_tensordict[key]
+        reconstructed_tensor = reconstructed_tensordict[key]
+
+        assert torch.allclose(original_tensor.cpu(), reconstructed_tensor.cpu())
+        assert original_tensor.shape == reconstructed_tensor.shape
+        assert original_tensor.dtype == reconstructed_tensor.dtype

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -343,9 +343,14 @@ class DataProto:
 
     def __setstate__(self, data):
         batch_deserialized_bytes, non_tensor_batch, meta_info = data
-        batch_deserialized_bytes = pickle.loads(batch_deserialized_bytes)
-        
-        self.batch = numpy_dict_to_tensor_dict(batch_deserialized_bytes)
+        batch_deserialized = pickle.loads(batch_deserialized_bytes)
+
+        tensor_dict = torch.utils._pytree.tree_map(
+            lambda x: torch.from_numpy(x) if isinstance(x, np.ndarray) else x,
+            batch_deserialized
+        )
+
+        self.batch = TensorDict.from_dict(tensor_dict)
         self.non_tensor_batch = non_tensor_batch
         self.meta_info = meta_info
 

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -335,15 +335,14 @@ class DataProto:
             batch_to_save = self.batch.contiguous().consolidate()
         else:
             batch_to_save = self.batch
-        return pickle.dumps(self.batch.numpy()), self.batch.batch_size, self.non_tensor_batch, self.meta_info
+        return pickle.dumps(batch_to_save.numpy()), batch_to_save.batch_size, self.non_tensor_batch, self.meta_info
 
     def __setstate__(self, data):
         batch_deserialized_bytes, batch_size, non_tensor_batch, meta_info = data
         batch_deserialized = pickle.loads(batch_deserialized_bytes)
-        
+
         self.batch = TensorDict(
-            {k, torch.from_numpy(v) if isinstance(v, np.ndarray) else v
-             for k, v in batch_deserialized.items()},
+            {k: torch.from_numpy(v) if isinstance(v, np.ndarray) else v for k, v in batch_deserialized.items()},
             batch_size=batch_size,
         )
         self.non_tensor_batch = non_tensor_batch

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -335,9 +335,10 @@ class DataProto:
             batch = self.batch.contiguous().consolidate()
         else:
             batch = self.batch
-        dtypes = {}
-        batch_to_serialize = {}
+
         if batch is not None:
+            dtypes = {}
+            batch_to_serialize = {}
             for k, v in batch.items():
                 dtypes[k] = str(v.dtype).removeprefix("torch.")
                 if v.dtype == torch.bfloat16:
@@ -346,6 +347,8 @@ class DataProto:
                     batch_to_serialize[k] = v.numpy()
             batch_size = batch.batch_size
         else:
+            dtypes = None
+            batch_to_serialize = None
             batch_size = None
 
         return (
@@ -367,8 +370,8 @@ class DataProto:
         numpy_dict = batch_deserialized["data"]
         batch_size = batch_deserialized["batch_size"]
         dtypes = batch_deserialized["dtypes"]
-        tensor_dict = {}
         if numpy_dict is not None:
+            tensor_dict = {}
             for k, v in numpy_dict.items():
                 dtype = dtypes[k]
                 if dtype == "bfloat16":

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -35,7 +35,7 @@ from packaging.version import parse as parse_version
 from tensordict import TensorDict
 from torch.utils.data import DataLoader
 
-from verl.utils.device import get_device_id, get_torch_device
+from verl.utils.device import get_device_id
 from verl.utils.py_functional import union_two_dict
 from verl.utils.torch_functional import allgather_dict_tensors
 

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -364,7 +364,7 @@ class DataProto:
         batch_size = batch_deserialized["batch_size"]
         dtypes = batch_deserialized["dtypes"]
         tensor_dict = {}
-        for k, v in numpy_dict:
+        for k, v in numpy_dict.items():
             dtype = dtypes[k]
             if dtype == "bfloat16":
                 tensor_dict[k] = torch.from_numpy(v).view(getattr(torch, dtype))

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -335,7 +335,7 @@ class DataProto:
             batch = self.batch.contiguous().consolidate()
         else:
             batch = self.batch
-        
+
         if os.getenv("VERL_DATAPROTO_SERIALIZATION_METHOD") == "numpy":
             if batch is not None:
                 dtypes = {}
@@ -404,7 +404,7 @@ class DataProto:
                 map_location="cpu" if not get_torch_device().is_available() else None,
             )
             self.batch = batch
-        
+
         self.non_tensor_batch = non_tensor_batch
         self.meta_info = meta_info
 


### PR DESCRIPTION
### What does this PR do?

For a data size of 6400x20480, the average serialization duration was reduced from 3.32s to 1.32s following this optimization, resulting in a ~151% improvement.

```
# tensor
average  serialize：2.58s  deserialize：0.74s  total：3.32s

TaskRunner pid=1904793) baymax debug serialize time=2.5947s
(TaskRunner pid=1904793) baymax debug serialize time=2.593357s
(TaskRunner pid=1904793) baymax debug serialize time=2.580081s
(TaskRunner pid=1904793) baymax debug serialize time=2.582321s
(WorkerDict pid=1905183) baymax debug deserialize time=0.475745s
(WorkerDict pid=1905184) baymax debug deserialize time=0.538223s
(WorkerDict pid=1905181) baymax debug deserialize time=0.609146s
(WorkerDict pid=1905182) baymax debug deserialize time=0.61064s
(WorkerDict pid=1905189) baymax debug deserialize time=0.597746s
(WorkerDict pid=1905185) baymax debug deserialize time=0.530353s
(WorkerDict pid=1905180) baymax debug deserialize time=0.811555s
(WorkerDict pid=1905194) baymax debug deserialize time=0.513646s
(WorkerDict pid=1905193) baymax debug deserialize time=0.962868s
(WorkerDict pid=1905179) baymax debug deserialize time=0.929226s
(WorkerDict pid=1905186) baymax debug deserialize time=0.701976s
(WorkerDict pid=1905191) baymax debug deserialize time=0.867236s
(WorkerDict pid=1905192) baymax debug deserialize time=0.858472s
(WorkerDict pid=1905187) baymax debug deserialize time=1.045251s
(WorkerDict pid=1905188) baymax debug deserialize time=0.960867s
(WorkerDict pid=1905190) baymax debug deserialize time=1.010673s

# numpy
average  serialize：0.000617s  deserialize：1.32s  total：1.32s

[36m(TaskRunner pid=1729638)[0m baymax debug serialize time=0.00016s
[36m(TaskRunner pid=1729638)[0m baymax debug serialize time=0.000117s
[36m(TaskRunner pid=1729638)[0m baymax debug serialize time=0.000158s
[36m(TaskRunner pid=1729638)[0m baymax debug serialize time=0.000182s
[36m(WorkerDict pid=1730035)[0m baymax debug deserialize time=0.867232s
[36m(WorkerDict pid=1730036)[0m baymax debug deserialize time=0.97372s
[36m(WorkerDict pid=1730028)[0m baymax debug deserialize time=1.08627s
[36m(WorkerDict pid=1730034)[0m baymax debug deserialize time=1.187599s
[36m(WorkerDict pid=1730037)[0m baymax debug deserialize time=1.165926s
[36m(WorkerDict pid=1730025)[0m baymax debug deserialize time=1.281101s
[36m(WorkerDict pid=1730029)[0m baymax debug deserialize time=1.359834s
[36m(WorkerDict pid=1730027)[0m baymax debug deserialize time=1.281978s
[36m(WorkerDict pid=1730030)[0m baymax debug deserialize time=1.329298s
[36m(WorkerDict pid=1730026)[0m baymax debug deserialize time=1.475415s
[36m(WorkerDict pid=1730031)[0m baymax debug deserialize time=1.422345s
[36m(WorkerDict pid=1730033)[0m baymax debug deserialize time=1.378894s
[36m(WorkerDict pid=1730039)[0m baymax debug deserialize time=1.368721s
[36m(WorkerDict pid=1730040)[0m baymax debug deserialize time=1.601587s
[36m(WorkerDict pid=1730042)[0m baymax debug deserialize time=1.768378s
[36m(WorkerDict pid=1730038)[0m baymax debug deserialize time=1.765994s
```

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
