### PR TITLE
[rollout] feat: support blockwise fp8 rollout in vllm

### DIFF
--- a/docs/advance/fp8.md
+++ b/docs/advance/fp8.md
@@ -10,11 +10,14 @@ We monkey patches several vLLM functions to enable FP8 rollout for reinforcement
 2. **process weights after loading**: Replace `vllm.model_executor.layers.quantization.fp8.Fp8LinearMethod.process_weights_after_loading`
 funtion to handle model weights loading after quantization.
 
-**Note**: Currently, we only support VLLM rollout with Megatron training. Sglang rollout with Megatron training is on the roadmap.
+**Notes**: 
+- Currently, we only support VLLM rollout with Megatron training. Sglang rollout with Megatron training is on the roadmap.
+- Only support Batch generate sequences.
+- We also support FP8 per tensor quantization, but after preliminary testing, there were issues with the accuracy and it is not recommended to use it.
 
 ## Usage
 
-It can be enabled in the config file `verl/trainer/config/ppo_megatron_trainer.yaml`:
+FP8 can be enabled in the config file `verl/trainer/config/ppo_megatron_trainer.yaml`:
 
 ```
   rollout:

--- a/docs/advance/fp8.md
+++ b/docs/advance/fp8.md
@@ -1,0 +1,35 @@
+# FP8 for verl
+
+Last updated: 09/18/2025.
+
+This module is still in developement. Currently we support FP8 rollout, using FP8 blockwise scaling (used in Deepseek,
+which is 1x128 quantization for activations and 128x128 quantization for model weights).
+
+We monkey patches several vLLM functions to enable FP8 rollout for reinforcement learning.
+1. **load_weights**: A custom `load_weights` function to quantize the on-the-fly model weights from a higher-precision format to FP8.
+2. **process weights after loading**: Replace `vllm.model_executor.layers.quantization.fp8.Fp8LinearMethod.process_weights_after_loading`
+funtion to handle model weights loading after quantization.
+
+**Note**: Currently, we only support VLLM rollout with Megatron training. Sglang rollout with Megatron training is on the roadmap.
+
+## Usage
+
+It can be enabled in the config file `verl/trainer/config/ppo_megatron_trainer.yaml`:
+
+```
+  rollout:
+    quantization: True
+
+    use_block_quant_rollout: True
+```
+
+Or it can be enabled by command line:
+- `actor_rollout_ref.rollout.quantization=True`
+- `actor_rollout_ref.rollout.use_block_quant_rollout=True`
+
+## Plans
+
+- add performance of FP8 rollout
+- add accuracy curves of FP8 rollout
+- support sglang rollout with FP8 quantization
+- enable FP8 training in megatron

--- a/docs/advance/fp8.md
+++ b/docs/advance/fp8.md
@@ -2,16 +2,16 @@
 
 Last updated: 09/18/2025.
 
-This module is still in developement. Currently we support FP8 rollout, using FP8 blockwise scaling (used in Deepseek,
+This module is still in development. Currently we support FP8 rollout, using FP8 blockwise scaling (used in Deepseek,
 which is 1x128 quantization for activations and 128x128 quantization for model weights).
 
 We monkey patches several vLLM functions to enable FP8 rollout for reinforcement learning.
 1. **load_weights**: A custom `load_weights` function to quantize the on-the-fly model weights from a higher-precision format to FP8.
 2. **process weights after loading**: Replace `vllm.model_executor.layers.quantization.fp8.Fp8LinearMethod.process_weights_after_loading`
-funtion to handle model weights loading after quantization.
+function to handle model weights loading after quantization.
 
 **Notes**: 
-- Currently, we only support VLLM rollout with Megatron training. Sglang rollout with Megatron training is on the roadmap.
+- Currently, we only support VLLM rollout with Megatron training. SGLang rollout with Megatron training is on the roadmap.
 - Only support Batch generate sequences.
 - We also support FP8 per tensor quantization, but after preliminary testing, there were issues with the accuracy and it is not recommended to use it.
 
@@ -34,5 +34,5 @@ Or it can be enabled by command line:
 
 - add performance of FP8 rollout
 - add accuracy curves of FP8 rollout
-- support sglang rollout with FP8 quantization
+- support SGLang rollout with FP8 quantization
 - enable FP8 training in megatron

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,6 +121,7 @@ verl is fast with:
    advance/rollout_skip.rst
    advance/one_step_off
    advance/agent_loop
+   advance/fp8.md
 
 .. toctree::
    :maxdepth: 1

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -250,6 +250,8 @@ actor_rollout_ref:
       ranks: ${oc.select:actor_rollout_ref.actor.profiler.ranks,[]}
       save_path: ${oc.select:global_profiler.save_path,null}
       tool_config: ${oc.select:actor_rollout_ref.actor.profiler.tool_config,null}
+    quantization: false
+    use_block_quant_rollout: true
     layer_name_map:
       qkv_layer_name: qkv
       gate_proj_layer_name: gate_up

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -44,6 +44,10 @@ actor_rollout_ref:
     use_remove_padding: false
 
   rollout:
+    quantization: False
+
+    use_block_quant_rollout: True
+
     layer_name_map:
       qkv_layer_name: qkv
       gate_proj_layer_name: gate_up

--- a/verl/utils/fp8_utils.py
+++ b/verl/utils/fp8_utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import logging
 from dataclasses import dataclass, field
 from typing import Optional
 from unittest.mock import patch
@@ -134,9 +134,8 @@ def scaled_fp8_blockwise(
 
     # Calculate max absolute value per block
     max_abs = torch.amax(torch.abs(data_hp), dim=-1, keepdim=True)
-    # Calculate descale factor
-    descale = max_abs / max_dtype
 
+    # Use FP32 scale
     scale_fp = max_dtype / max_abs
     scale_fp = torch.where(max_abs == 0, 1.0, scale_fp)
     # preserve the behavior for 0 amax case
@@ -162,8 +161,6 @@ def scaled_fp8_blockwise(
 
 def quant_weights(weights, model, quant_config):
     weights_quantized = []
-    qkv_weights = []
-    gate_up_weights = []
     for k, v in weights:
         if not is_fp8_weight(k, model):
             weights_quantized.append((k, v))

--- a/verl/utils/fp8_utils.py
+++ b/verl/utils/fp8_utils.py
@@ -1,0 +1,370 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from dataclasses import dataclass, field
+from typing import Optional
+from unittest.mock import patch
+
+import torch
+from transformers import AutoConfig, AutoModel
+
+try:
+    from vllm.model_executor.layers.linear import LinearBase
+    from vllm._custom_ops import scaled_fp8_quant
+except ImportError as e:
+    raise ImportError("FP8 quantization not available") from e
+
+logger = logging.getLogger(__name__)
+
+FP8_BLOCK_QUANT_KWARGS = {
+    "activation_scheme": "dynamic",
+    "fmt": "e4m3",
+    "quant_method": "fp8",
+    "weight_block_size": [128, 128],
+}
+
+
+# Ref: https://github.com/NVIDIA-NeMo/RL/commit/bc24887c72a6e1b2699a228bc87c588546dfe6b7
+@dataclass()
+class FP8State:
+    # A cache of fp8 parameter names, we can check this cache to see if a
+    # param name corresponds to a fp8 weight
+    seen_params: set = field(default_factory=lambda: set())
+    fp8_param_names: set = field(default_factory=lambda: set())
+    vllm_patches: list = field(default_factory=lambda: [])
+
+fp8_state: FP8State = FP8State()
+
+
+def is_fp8_model(vllm_config):
+    from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+
+    if hasattr(vllm_config, "quant_config") and isinstance(
+        vllm_config.quant_config, Fp8Config
+    ):
+        return True
+
+    return False
+
+
+def get_module_from_param_name(model, name: str):
+    # Split the name into parts (e.g., 'layers', '0', 'self_attn', 'q_proj', 'weight')
+    # The module path is all but the last part (the parameter's own name)
+    path_parts = name.split(".")
+    module_path = path_parts[:-1]
+    # Replace with the fused model name
+    packed_modules_mapping = model.packed_modules_mapping
+    reversed_mapping = {
+        original_name: fused_name
+        for fused_name, original_names_list in packed_modules_mapping.items()
+        for original_name in original_names_list
+    }
+    if module_path[-1] in reversed_mapping.keys():
+        module_path[-1] = reversed_mapping[module_path[-1]]
+
+    current_module = model
+    try:
+        # Traverse the model hierarchy
+        for part in module_path:
+            if isinstance(current_module, torch.nn.ModuleList):
+                current_module = current_module[int(part)]
+            else:
+                current_module = getattr(current_module, part)
+    except (AttributeError, IndexError, ValueError) as e:
+        print(f"Warning: Could not find module for parameter '{name}'. Error: {e}")
+    return current_module
+
+
+def is_fp8_weight(name, model):
+    if name not in fp8_state.seen_params:
+        fp8_state.seen_params.add(name)
+        # Filter out bias params
+        if name.endswith("weight"):
+            module = get_module_from_param_name(model, name)
+            # We currently only quantize linear layers
+            if (
+                isinstance(module, LinearBase)
+                and module.weight.dtype == torch.float8_e4m3fn
+            ):
+                fp8_state.fp8_param_names.add(name)
+    return name in fp8_state.fp8_param_names
+
+
+def scaled_fp8_blockwise(
+    data_hp,
+    weight_block_size,
+):
+    assert len(data_hp.shape) == 2, "Only 2d input tensor is supported"
+
+    block_size1 = weight_block_size[1]
+    block_size0 = weight_block_size[0]
+    assert data_hp.shape[1] % block_size1 == 0, (
+        f"data_hp.shape[1] {data_hp.shape[1]}  must be a multiple of block_size1: {block_size1}."
+    )
+    assert data_hp.shape[0] % block_size0 == 0, (
+        f"data_hp.shape[0] {data_hp.shape[0]} must be a multiple of block_size0: {block_size0}."
+    )
+
+    # FP8
+    max_dtype = torch.finfo(torch.float8_e4m3fn).max
+
+    original_shape = data_hp.shape
+    blk_m, blk_n = data_hp.shape[0] // block_size0, data_hp.shape[1] // block_size1
+
+    assert block_size1 == block_size0
+    data_hp = data_hp.reshape(blk_m, block_size0, blk_n, block_size1)
+
+    # Permute to (BLK_M, BLK_N, BLOCK_SIZE_M, BLOCK_SIZE_N)
+    data_hp = data_hp.permute(0, 2, 1, 3)
+    # Flatten to (BLK_M, BLK_N, BLOCK_SIZE_M * BLOCK_SIZE_N)
+    data_hp = data_hp.to(torch.float32).contiguous().flatten(start_dim=2)
+
+    # Calculate max absolute value per block
+    max_abs = torch.amax(torch.abs(data_hp), dim=-1, keepdim=True)
+    # Calculate descale factor
+    descale = max_abs / max_dtype
+
+    scale_fp = max_dtype / max_abs
+    scale_fp = torch.where(max_abs == 0, 1.0, scale_fp)
+    # preserve the behavior for 0 amax case
+    scale_fp = torch.where(max_abs == torch.inf, 1.0, scale_fp)
+
+    descale_fp = torch.reciprocal(scale_fp)
+
+    # Scale and saturate cast the data elements to max of target dtype
+    data_lp = torch.clamp(data_hp * scale_fp, min=-1 * max_dtype, max=max_dtype)
+
+    fp_data = data_lp.to(torch.float8_e4m3fn)
+
+    # (BLK_M, BLK_N, BLOCK_SIZE_M * BLOCK_SIZE_N) to (M, N)
+    fp_data = (
+        fp_data.reshape(blk_m, blk_n, block_size0, block_size1)
+        .permute(0, 2, 1, 3)
+        .reshape(original_shape)
+    )
+
+    # Convert to target format, but still in original precision container
+    return fp_data, descale_fp
+
+
+def quant_weights(weights, model, quant_config):
+    weights_quantized = []
+    qkv_weights = []
+    gate_up_weights = []
+    for k, v in weights:
+        if not is_fp8_weight(k, model):
+            weights_quantized.append((k, v))
+            continue
+        # Cast the weight into fp8 and its scale factor
+        if quant_config.weight_block_size is not None:
+            logger.info("Using blockwise quantization")
+            param_lp, param_scale = scaled_fp8_blockwise(
+                v.to(torch.float),
+                weight_block_size=quant_config.weight_block_size,
+            )
+            param_scale = param_scale.squeeze(-1)
+            weights_quantized.append([k, param_lp])
+            weights_quantized.append([k + "_scale_inv", param_scale])
+
+        else:
+            logger.info("Using Per tensor quantization")
+            original_shape = v.shape
+            # Use per tensor quantization
+            quantized_tensor, scale = scaled_fp8_quant(v)
+            # Reshape back to original shape
+            quantized_tensor = quantized_tensor.view(original_shape)
+
+            scale_k = k.replace(".weight", ".weight_scale")
+            scale = scale.view(1)
+            weights_quantized.extend([(k, quantized_tensor), (scale_k, scale)])
+
+    return weights_quantized
+
+
+def load_quanted_weights(weights, model_runner):
+    #weights_quantized = []
+    model = model_runner.model
+    quant_config = model_runner.vllm_config.quant_config
+
+    weights_quantized = quant_weights(weights, model, quant_config)
+
+    # Monkey patch the param class to their subclass, as certain models
+    # will check the param type to call the proper weightloader
+    for name, param in model.named_parameters():
+        if hasattr(param, "subclass_type"):
+            param.orig_type = param.__class__
+            param.__class__ = param.subclass_type
+    # Finally load the weights into vllm
+    loaded_params = model.load_weights(weights_quantized)
+    # Undo the type change above to the original type
+    for name, param in model.named_parameters():
+        if hasattr(param, "subclass_type"):
+            param.__class__ = param.orig_type
+    return loaded_params
+
+
+def process_weights_after_loading(self, layer) -> None:
+    try:
+        from vllm.model_executor.parameter import (
+            BlockQuantScaleParameter,
+            ModelWeightParameter,
+            PerTensorScaleParameter
+        )
+        from vllm.model_executor.layers.quantization.utils.w8a8_utils import requantize_with_max_scale
+    except Exception:
+        try:
+            from sglang.srt.layers.parameter import (
+                BlockQuantScaleParameter,
+                ModelWeightParameter,
+                PerTensorScaleParameter
+            )
+            from sglang.srt.layers.quantization.utils import requantize_with_max_scale
+        except Exception:
+            print("error")
+    from torch.nn import Parameter
+
+    def _create_param_from_subclass_attributes(custom_param):
+        param = Parameter(custom_param.data, requires_grad=False)
+        base_param_dir = dir(torch.nn.Parameter)
+        custom_param_dir = dir(custom_param)
+        # Find the attributes that are unique to the custom parameter
+        custom_attributes = [
+            attr
+            for attr in custom_param_dir
+            if attr not in base_param_dir and not attr.startswith("__")
+        ]
+        # Set the custom attributes into the base parameter object
+        for attr in custom_attributes:
+            setattr(param, attr, getattr(custom_param, attr))
+
+        param.subclass_type = type(custom_param)
+        return param
+
+    if self.block_quant:
+        assert self.block_quant and self.quant_config.is_checkpoint_fp8_serialized
+        assert self.quant_config.activation_scheme == "dynamic"
+        weight = layer.weight.data
+        weight_scale_inv = layer.weight_scale_inv.data
+        weight = self._maybe_pad_weight(weight)
+
+        layer.weight = _create_param_from_subclass_attributes(
+            ModelWeightParameter(
+                data=weight,
+                output_dim=0,
+                input_dim=1,
+                weight_loader=layer.weight.weight_loader,
+            )
+        )
+        layer.weight_scale_inv = _create_param_from_subclass_attributes(
+            BlockQuantScaleParameter(
+                data=weight_scale_inv,
+                output_dim=0,
+                input_dim=1,
+                weight_loader=layer.weight_scale_inv.weight_loader,
+            )
+        )
+
+    else:
+        weight = layer.weight.data
+        weight_scale = layer.weight_scale.data
+
+        # # If using w8a8, torch._scaled_mm needs per tensor, so
+        # # requantize the logical shards as a single weight.
+        if not self.use_marlin:
+            # Dequant -> Quant with max scale so we can run per tensor.
+
+            weight_scale, weight = requantize_with_max_scale(
+                weight=weight,
+                weight_scale=weight_scale,
+                logical_widths=layer.logical_widths,
+            )
+
+        weight = self._maybe_pad_weight(weight)
+        # Update layer with new values.
+        # layer.weight = Parameter(weight.t(), requires_grad=False)
+        # layer.weight_scale = Parameter(weight_scale, requires_grad=False)
+
+        layer.weight = _create_param_from_subclass_attributes(
+            ModelWeightParameter(
+                data=weight,
+                output_dim=0,
+                input_dim=1,
+                weight_loader=layer.weight.weight_loader,
+            )
+        )
+        layer.weight_scale = _create_param_from_subclass_attributes(
+            PerTensorScaleParameter(
+                data=weight_scale.repeat(len(layer.logical_widths)),
+                weight_loader=layer.weight_scale.weight_loader,
+            )
+        )
+
+
+def apply(self,
+            layer: torch.nn.Module,
+            x: torch.Tensor,
+            bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+    from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import apply_fp8_marlin_linear
+    from vllm.model_executor.layers.quantization.utils.w8a8_utils import requantize_with_max_scale
+
+    if self.use_marlin:
+        return apply_fp8_marlin_linear(
+            input=x,
+            weight=layer.weight,
+            weight_scale=layer.weight_scale,
+            workspace=layer.workspace,
+            size_n=layer.output_size_per_partition,
+            size_k=layer.input_size_per_partition,
+            bias=bias)
+
+    if self.block_quant:
+        assert self.quant_config.weight_block_size is not None
+        return torch.ops.vllm.apply_w8a8_block_fp8_linear(
+            input=x,
+            weight=layer.weight,
+            block_size=self.quant_config.weight_block_size,
+            weight_scale=layer.weight_scale_inv,
+            input_scale=layer.input_scale,
+            bias=bias,
+            cutlass_block_fp8_supported=self.cutlass_block_fp8_supported,
+            use_aiter_and_is_supported=self.use_aiter_and_is_supported,
+        )
+
+    weight_scale, weight = requantize_with_max_scale(
+            weight=layer.weight,
+            weight_scale=layer.weight_scale,
+            logical_widths=layer.logical_widths,
+    )
+    return self.fp8_linear.apply(input=x,
+                                    weight=weight.t(),
+                                    weight_scale=weight_scale,
+                                    out_dtype=self.out_dtype,
+                                    input_scale=layer.input_scale,
+                                    bias=bias)
+
+def apply_vllm_fp8_patches(block_quant=True):
+    if block_quant:
+        func_path = "vllm.model_executor.layers.quantization.fp8.Fp8LinearMethod.process_weights_after_loading"
+        patcher = patch(func_path, process_weights_after_loading)
+        patcher.start()
+    else:
+        func1_path = "vllm.model_executor.layers.quantization.fp8.Fp8LinearMethod.process_weights_after_loading"
+        patcher1 = patch(func1_path, process_weights_after_loading)
+        patcher1.start()
+        func2_path = "vllm.model_executor.layers.quantization.fp8.Fp8LinearMethod.apply"
+        patcher2 = patch(func2_path, apply)
+        patcher2.start()

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -174,3 +174,7 @@ class RolloutConfig(BaseConfig):
     limit_images: Optional[int] = None
 
     skip_tokenizer_init: bool = False
+
+    quantization: bool = False
+
+    use_block_quant_rollout: bool = False

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -609,10 +609,10 @@ class vLLMAsyncRollout(BaseRollout):
 
         # Add the FP8 related logic here as sharding manager has been deprecated.
         # Check if FP8 quantization is enabled and apply appropriate weight loading
-        if fp8_quant.is_fp8_model(model_runner.vllm_config):
+        if is_fp8_model(model_runner.vllm_config):
             logger.info(f"FP8 model detected (async): {model_runner.vllm_config.quant_config}")
             # Convert bf16 weights to fp8 format before loading
-            loaded_params = fp8_quant.load_quanted_weights(weights, model_runner)
+            loaded_params = load_quanted_weights(weights, model_runner)
             logger.info(f"FP8 weights loaded (async), loaded_params: {len(loaded_params)}")
         else:
             logger.debug("Loading standard weights (non-FP8, async)")

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -58,7 +58,7 @@ from vllm.worker.worker_base import WorkerWrapperBase
 from verl import DataProto
 from verl.third_party.vllm import VLLM_SLEEP_LEVEL
 from verl.utils.device import is_npu_available
-from verl.utils.fp8_utils import apply_vllm_fp8_patches, load_quanted_weights, is_fp8_model 
+from verl.utils.fp8_utils import apply_vllm_fp8_patches, is_fp8_model, load_quanted_weights
 from verl.utils.profiler import GPUMemoryLogger
 from verl.utils.ray_utils import ray_noset_visible_devices
 from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
@@ -462,6 +462,7 @@ class vLLMRollout(BaseRollout):
             logger.info(f"vLLM load weights, loaded_params: {len(weights)}")
         else:
             from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
+
             model_runner = self.inference_engine.llm_engine.model_executor.driver_worker.worker.model_runner
             model = model_runner.model
             patch_vllm_moe_model_weight_loader(model)
@@ -476,6 +477,7 @@ class vLLMRollout(BaseRollout):
             else:
                 logger.debug("Loading standard weights (non-FP8)")
                 model.load_weights(weights)
+
 
 # https://github.com/vllm-project/vllm/issues/13175
 def _monkey_patch_compute_logits(model, vocab_size: int):
@@ -603,6 +605,7 @@ class vLLMAsyncRollout(BaseRollout):
             weights: A generator that yields the name of the weight tensor and the tensor itself.
         """
         from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
+
         model_runner = self.inference_engine.worker.model_runner
         model = model_runner.model
         patch_vllm_moe_model_weight_loader(model)

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -58,7 +58,7 @@ from vllm.worker.worker_base import WorkerWrapperBase
 from verl import DataProto
 from verl.third_party.vllm import VLLM_SLEEP_LEVEL
 from verl.utils.device import is_npu_available
-from verl.utils.fp8_utils import apply_vllm_fp8_patches 
+from verl.utils.fp8_utils import apply_vllm_fp8_patches, load_quanted_weights, is_fp8_model 
 from verl.utils.profiler import GPUMemoryLogger
 from verl.utils.ray_utils import ray_noset_visible_devices
 from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
@@ -462,11 +462,20 @@ class vLLMRollout(BaseRollout):
             logger.info(f"vLLM load weights, loaded_params: {len(weights)}")
         else:
             from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
-
-            model = self.inference_engine.llm_engine.model_executor.driver_worker.worker.model_runner.model
+            model_runner = self.inference_engine.llm_engine.model_executor.driver_worker.worker.model_runner
+            model = model_runner.model
             patch_vllm_moe_model_weight_loader(model)
-            model.load_weights(weights)
 
+            # Add the FP8 related logic here as sharding manager has been deprecated.
+            # Check if FP8 quantization is enabled and apply appropriate weight loading
+            if is_fp8_model(model_runner.vllm_config):
+                logger.info(f"FP8 model detected: {model_runner.vllm_config.quant_config}")
+                # Convert bf16 weights to fp8 format before loading
+                loaded_params = load_quanted_weights(weights, model_runner)
+                logger.info(f"FP8 weights loaded, loaded_params: {len(loaded_params)}")
+            else:
+                logger.debug("Loading standard weights (non-FP8)")
+                model.load_weights(weights)
 
 # https://github.com/vllm-project/vllm/issues/13175
 def _monkey_patch_compute_logits(model, vocab_size: int):
@@ -594,10 +603,20 @@ class vLLMAsyncRollout(BaseRollout):
             weights: A generator that yields the name of the weight tensor and the tensor itself.
         """
         from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
-
-        model = self.inference_engine.worker.model_runner.model
+        model_runner = self.inference_engine.worker.model_runner
+        model = model_runner.model
         patch_vllm_moe_model_weight_loader(model)
-        model.load_weights(weights)
+
+        # Add the FP8 related logic here as sharding manager has been deprecated.
+        # Check if FP8 quantization is enabled and apply appropriate weight loading
+        if fp8_quant.is_fp8_model(model_runner.vllm_config):
+            logger.info(f"FP8 model detected (async): {model_runner.vllm_config.quant_config}")
+            # Convert bf16 weights to fp8 format before loading
+            loaded_params = fp8_quant.load_quanted_weights(weights, model_runner)
+            logger.info(f"FP8 weights loaded (async), loaded_params: {len(loaded_params)}")
+        else:
+            logger.debug("Loading standard weights (non-FP8, async)")
+            model.load_weights(weights)
 
     def generate_sequences(self, prompts: DataProto) -> DataProto:
         """Batch generate sequences in sync mode."""

--- a/verl/workers/sharding_manager/megatron_vllm.py
+++ b/verl/workers/sharding_manager/megatron_vllm.py
@@ -31,7 +31,7 @@ from verl.protocol import all_gather_data_proto
 from verl.third_party.vllm import LLM, VLLM_SLEEP_LEVEL
 from verl.third_party.vllm import parallel_state as vllm_ps
 from verl.utils.device import get_torch_device, set_expandable_segments
-from verl.utils.fp8_utils import load_quanted_weights, is_fp8_model
+from verl.utils.fp8_utils import is_fp8_model, load_quanted_weights
 from verl.utils.import_utils import deprecated
 from verl.utils.megatron_utils import load_megatron_model_to_gpu, offload_megatron_model_to_cpu, per_tensor_generator
 from verl.utils.memory_utils import aggressive_empty_cache


### PR DESCRIPTION
### What does this PR do?

This module is still in development. Currently we support FP8 rollout, using FP8 blockwise scaling (used in Deepseek,
which is 1x128 quantization for activations and 128x128 quantization for model weights).

We monkey patches several vLLM functions to enable FP8 rollout for reinforcement learning.
1. **load_weights**: A custom `load_weights` function to quantize the on-the-fly model weights from a higher-precision format to FP8.
2. **process weights after loading**: Replace `vllm.model_executor.layers.quantization.fp8.Fp8LinearMethod.process_weights_after_loading`
function to handle model weights loading after quantization.

**Notes**: 
- Currently, we only support VLLM rollout with Megatron training. SGLang rollout with Megatron training is on the roadmap.
- Only support Batch generate sequences.
- We also support FP8 per tensor quantization, but after preliminary testing, there were issues with the accuracy and it is not recommended to use it.

**Plans**:
- Optimize performance of FP8 rollout (Now we only see ~7% speedup of `timing_per_token_ms/gen` for Qwen3-8B model)
- Add accuracy curves of FP8 rollout
- Support SGLang rollout with FP8 quantization
- Enable FP8 training in megatron

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [WIP: FP8 train](https://github.com/volcengine/verl/pull/1490)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI) 
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

FP8 can be enabled in the config file `verl/trainer/config/ppo_megatron_trainer.yaml`:

```
  rollout:
    quantization: True

    use_block_quant_rollout: True
```

Or it can be enabled by command line:
- `actor_rollout_ref.rollout.quantization=True`
- `actor_rollout_ref.rollout.use_block_quant_rollout=True`

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
