### PR TITLE
[sglang] fix: Support SGLang>=v0.5.2

### DIFF
--- a/tests/workers/rollout/rollout_sglang/test_http_server_engine.py
+++ b/tests/workers/rollout/rollout_sglang/test_http_server_engine.py
@@ -46,7 +46,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import aiohttp
 import pytest
 import requests
-from sglang.srt.managers.tokenizer_manager import (
+from sglang.srt.managers.io_struct import (
     UpdateWeightsFromTensorReqInput,
 )
 from sglang.srt.utils import MultiprocessingSerializer
@@ -439,7 +439,7 @@ class TestHttpServerEngineAdapter:
     def test_update_weights_from_tensor_strict(self, mock_launch_server_process, basic_adapter_kwargs):
         import base64
 
-        from sglang.srt.managers.tokenizer_manager import UpdateWeightsFromTensorReqInput
+        from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
 
         from verl.workers.rollout.sglang_rollout.http_server_engine import HttpServerAdapter
 
@@ -471,7 +471,7 @@ class TestHttpServerEngineAdapter:
             )
 
     def test_update_weights_from_tensor_empty(self, mock_launch_server_process, basic_adapter_kwargs):
-        from sglang.srt.managers.tokenizer_manager import UpdateWeightsFromTensorReqInput
+        from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
 
         from verl.workers.rollout.sglang_rollout.http_server_engine import HttpServerAdapter
 
@@ -500,7 +500,7 @@ class TestHttpServerEngineAdapter:
             )
 
     def test_update_weights_from_tensor_none(self, mock_launch_server_process, basic_adapter_kwargs):
-        from sglang.srt.managers.tokenizer_manager import UpdateWeightsFromTensorReqInput
+        from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
 
         from verl.workers.rollout.sglang_rollout.http_server_engine import HttpServerAdapter
 

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -30,7 +30,7 @@ from sglang.srt.entrypoints.http_server import (
     set_global_state,
 )
 from sglang.srt.managers.io_struct import GenerateReqInput
-from sglang.srt.managers.tokenizer_manager import ReleaseMemoryOccupationReqInput, ResumeMemoryOccupationReqInput
+from sglang.srt.managers.io_struct import ReleaseMemoryOccupationReqInput, ResumeMemoryOccupationReqInput
 
 from verl.single_controller.ray import RayClassWithInitArgs
 from verl.utils.config import omega_conf_to_dataclass

--- a/verl/workers/rollout/sglang_rollout/http_server_engine.py
+++ b/verl/workers/rollout/sglang_rollout/http_server_engine.py
@@ -56,7 +56,7 @@ import aiohttp
 import requests
 from sglang.srt.entrypoints.EngineBase import EngineBase
 from sglang.srt.entrypoints.http_server import launch_server
-from sglang.srt.managers.tokenizer_manager import (
+from sglang.srt.managers.io_struct import (
     UpdateWeightsFromTensorReqInput,
 )
 from sglang.srt.server_args import ServerArgs

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -29,7 +29,7 @@ import ray
 import sglang.srt.entrypoints.engine
 import torch
 import torch.distributed as dist
-from sglang.srt.managers.tokenizer_manager import (
+from sglang.srt.managers.io_struct import (
     ReleaseMemoryOccupationReqInput,
     ResumeMemoryOccupationReqInput,
     UpdateWeightsFromTensorReqInput,


### PR DESCRIPTION
`sglang.srt.managers.[tokenizer_manager->io_struct]` fixes refactor https://github.com/sgl-project/sglang/pull/10028, should be compatible >=0.4.1.post6 https://github.com/sgl-project/sglang/pull/2630

Can merge https://github.com/volcengine/verl/pull/3484