### PR TITLE
[megatron] feat: use flash as default attention_backend

### DIFF
--- a/verl/models/mcore/config_converter.py
+++ b/verl/models/mcore/config_converter.py
@@ -389,10 +389,8 @@ def hf_to_mcore_config_llama4(
 
 
 def mapping_string_to_attn_backend(args: dict) -> dict:
-    if "attention_backend" in args:
-        if isinstance(args["attention_backend"], str):
-            from megatron.core.transformer.enums import AttnBackend
+    if "attention_backend" in args and isinstance(args["attention_backend"], str):
+        from megatron.core.transformer.enums import AttnBackend
 
-            if isinstance(args["attention_backend"], str):
-                args["attention_backend"] = AttnBackend[args["attention_backend"]]
+        args["attention_backend"] = AttnBackend[args["attention_backend"]]
     return args

--- a/verl/models/mcore/config_converter.py
+++ b/verl/models/mcore/config_converter.py
@@ -156,6 +156,7 @@ def check_and_construct_configs(original_config: dict, cls: type[T]) -> T:
         for key in removed_keys:
             original_config.pop(key)
 
+    original_config = mapping_string_to_attn_backend(original_config)
     if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
         print(f"Overridden {cls.__name__} init config: {original_config}")
     return cls(**original_config)
@@ -376,6 +377,7 @@ def hf_to_mcore_config_qwen2_5_vl(
     )
     # override_transformer_config_kwargs as kwargs shall never be none
     args.update(override_transformer_config_kwargs)
+    args = mapping_string_to_attn_backend(args)
     return TransformerConfig(**args)
 
 
@@ -384,3 +386,13 @@ def hf_to_mcore_config_llama4(
 ) -> TransformerConfig:
     # Llama4ForConditionalGeneration
     raise NotImplementedError("Llama4ForConditionalGeneration is not supported yet")
+
+
+def mapping_string_to_attn_backend(args: dict) -> dict:
+    if "attention_backend" in args:
+        if isinstance(args["attention_backend"], str):
+            from megatron.core.transformer.enums import AttnBackend
+
+            if isinstance(args["attention_backend"], str):
+                args["attention_backend"] = AttnBackend[args["attention_backend"]]
+    return args

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -49,6 +49,7 @@ actor_rollout_ref:
         - core_attn
         recompute_method: null
         recompute_num_layers: null
+        attention_backend: flash
       override_mcore_model_config: {}
       use_mbridge: false
       forward_only: false
@@ -345,6 +346,7 @@ critic:
       - core_attn
       recompute_method: null
       recompute_num_layers: null
+      attention_backend: flash
     override_mcore_model_config: {}
     use_mbridge: false
     forward_only: false

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -66,6 +66,9 @@ override_transformer_config:
   # 'full' will checkpoint the entire transformer layer and 'selective' only checkpoints memory intensive part of attention
   recompute_num_layers: null
 
+  # Attention backend to use (flash,fused,unfused,local,auto). Defaults to auto in mcore, flash in verl
+  attention_backend: flash
+
 override_mcore_model_config: {}
 
 # oc.select: default val for ref.megatron.use_mbridge

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -150,6 +150,11 @@ class MegatronWorker(Worker):
         if self.rank == 0:
             print(f"Model config after override: {hf_config}")
 
+        from verl.models.mcore.config_converter import mapping_string_to_attn_backend
+
+        # todo: remove this line after mcore adopt mbridge 0.15, now for compatibility
+        override_transformer_config = mapping_string_to_attn_backend(override_transformer_config)
+
         if use_mbridge:
             from verl.models.mcore.mbridge import AutoBridge
 


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

1. add mapping from string to megatron's enum for attention_backend choice.
2. use flash attention as default attention_backend, for consistency to FSDP

